### PR TITLE
Fix multiple line items and payments in invoices

### DIFF
--- a/recurly.py
+++ b/recurly.py
@@ -45,6 +45,8 @@ MULTIPLE = [
         'charge',
         'credit',
         'invoice',
+        'line_item',
+        'payment',
         'plan',
         'transaction',
     ]


### PR DESCRIPTION
Multiple line items and payments weren't appearing in the invoice
response, they were erroneously collapsed into one.
