### PR TITLE
Extra DELETE parameters dropped

### DIFF
--- a/recurly/recurly.py
+++ b/recurly/recurly.py
@@ -120,7 +120,7 @@ class Recurly(object):
 
         # Build argument list if necessary
         args = ''
-        if method == 'GET' and kwargs:
+        if kwargs:
             args = "?%s" % (urllib.urlencode(kwargs.items()))
         
         # Build url from the pieces


### PR DESCRIPTION
Disclaimer: I created this commit purely for convenience for you good folks. There may be a better way to do this or a reason the request method was being checked against that I'm unaware of. I look forward to finding out.

Explanation: 
For instance, if you're trying to make this call: 
DELETE https://subdomain.recurly.com/accounts/[id]/subscription?refund=none

The actual call ends up being:
DELETE https://subdomain.recurly.com/accounts/[id]/subscription?refund=none

This is due to line 123:
http://github.com/recurly/recurly-client-python/blob/master/recurly/recurly.py#L123

The variable args is only redefined from an empty string if it's a GET request.
