### PR TITLE
Support unicode characters in resource elements.

### DIFF
--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -397,7 +397,7 @@ class Resource(object):
         elif isinstance(value, Money):
             value.add_to_element(el)
         else:
-            el.text = str(value)
+            el.text = unicode(value)
 
         return el
 

--- a/tests/fixtures/account/update-bad-email.xml
+++ b/tests/fixtures/account/update-bad-email.xml
@@ -8,7 +8,7 @@ Content-Type: application/xml; charset=utf-8
 <account>
   <username>shmohawk58</username>
   <email>larry.david</email>
-  <first_name>Larry</first_name>
+  <first_name>Lärry</first_name>
   <last_name>David</last_name>
   <company_name>Home Box Office</company_name>
   <accept_language>en-US</accept_language>

--- a/tests/fixtures/account/updated.xml
+++ b/tests/fixtures/account/updated.xml
@@ -8,7 +8,7 @@ Content-Type: application/xml; charset=utf-8
 <account>
   <username>shmohawk58</username>
   <email>larry.david@example.com</email>
-  <first_name>Larry</first_name>
+  <first_name>Lärry</first_name>
   <last_name>David</last_name>
   <company_name>Home Box Office</company_name>
   <accept_language>en-US</accept_language>
@@ -28,7 +28,7 @@ Location: https://api.recurly.com/v2/accounts/testmock
   <account_code>testmock</account_code>
   <username>shmohawk58</username>
   <email>larry.david@example.com</email>
-  <first_name>Larry</first_name>
+  <first_name>Lärry</first_name>
   <last_name>David</last_name>
   <company_name>Home Box Office</company_name>
   <accept_language>en-US</accept_language>

--- a/tests/fixtures/billing-info/account-embed-created.xml
+++ b/tests/fixtures/billing-info/account-embed-created.xml
@@ -15,7 +15,7 @@ Content-Type: application/xml; charset=utf-8
     <year>2015</year>
     <month>12</month>
     <address1>123 Main St</address1>
-    <city>San Francisco</city>
+    <city>San José</city>
     <state>CA</state>
     <zip>94105</zip>
     <country>US</country>

--- a/tests/fixtures/billing-info/created.xml
+++ b/tests/fixtures/billing-info/created.xml
@@ -13,7 +13,7 @@ Content-Type: application/xml; charset=utf-8
   <year>2015</year>
   <month>12</month>
   <address1>123 Main St</address1>
-  <city>San Francisco</city>
+  <city>San José</city>
   <state>CA</state>
   <zip>94105</zip>
   <country>US</country>
@@ -28,7 +28,7 @@ Location: https://api.recurly.com/v2/accounts/binfomock/billing_info
   <first_name>Verena</first_name>
   <last_name>Example</last_name>
   <address1>123 Main St</address1>
-  <city>San Francisco</city>
+  <city>San José</city>
   <state>CA</state>
   <zip>94105</zip>
   <country>US</country>

--- a/tests/fixtures/billing-info/embedded-exists.xml
+++ b/tests/fixtures/billing-info/embedded-exists.xml
@@ -12,7 +12,7 @@ Content-Type: application/xml; charset=utf-8
   <first_name>Verena</first_name>
   <last_name>Example</last_name>
   <address1>123 Main St</address1>
-  <city>San Francisco</city>
+  <city>San José</city>
   <state>CA</state>
   <zip>94105</zip>
   <country>US</country>

--- a/tests/fixtures/billing-info/exists.xml
+++ b/tests/fixtures/billing-info/exists.xml
@@ -12,7 +12,7 @@ Content-Type: application/xml; charset=utf-8
   <first_name>Verena</first_name>
   <last_name>Example</last_name>
   <address1>123 Main St</address1>
-  <city>San Francisco</city>
+  <city>San José</city>
   <state>CA</state>
   <zip>94105</zip>
   <country>US</country>

--- a/tests/fixtures/subscription/subscribe-embedded-account.xml
+++ b/tests/fixtures/subscription/subscribe-embedded-account.xml
@@ -18,7 +18,7 @@ Content-Type: application/xml; charset=utf-8
       <year>2015</year>
       <month>12</month>
       <address1>123 Main St</address1>
-      <city>San Francisco</city>
+      <city>San José</city>
       <state>CA</state>
       <zip>94105</zip>
       <country>US</country>

--- a/tests/fixtures/subscription/subscribed-billing-info.xml
+++ b/tests/fixtures/subscription/subscribed-billing-info.xml
@@ -18,7 +18,7 @@ Content-Type: application/xml; charset=utf-8
       <year>2015</year>
       <month>12</month>
       <address1>123 Main St</address1>
-      <city>San Francisco</city>
+      <city>San José</city>
       <state>CA</state>
       <zip>94105</zip>
       <country>US</country>

--- a/tests/fixtures/subscription/update-billing-info.xml
+++ b/tests/fixtures/subscription/update-billing-info.xml
@@ -13,7 +13,7 @@ Content-Type: application/xml; charset=utf-8
   <year>2015</year>
   <month>12</month>
   <address1>123 Main St</address1>
-  <city>San Francisco</city>
+  <city>San José</city>
   <state>CA</state>
   <zip>94105</zip>
   <country>US</country>
@@ -28,7 +28,7 @@ Location: https://api.recurly.com/v2/accounts/subscribemock/billing_info
   <first_name>Verena</first_name>
   <last_name>Example</last_name>
   <address1>123 Main St</address1>
-  <city>San Francisco</city>
+  <city>San José</city>
   <state>CA</state>
   <zip>94105</zip>
   <country>US</country>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -52,7 +52,7 @@ class TestResources(RecurlyTest):
 
         account.username = 'shmohawk58'
         account.email = 'larry.david'
-        account.first_name = 'Larry'
+        account.first_name = u'L\xe4rry'
         account.last_name = 'David'
         account.company_name = 'Home Box Office'
         account.accept_language = 'en-US'
@@ -188,7 +188,7 @@ class TestResources(RecurlyTest):
                 first_name='Verena',
                 last_name='Example',
                 address1='123 Main St',
-                city='San Francisco',
+                city=u'San Jos\xe9',
                 state='CA',
                 zip='94105',
                 country='US',
@@ -213,6 +213,7 @@ class TestResources(RecurlyTest):
             with self.mock_request('billing-info/exists.xml'):
                 same_binfo = same_account.billing_info
             self.assertEqual(same_binfo.first_name, 'Verena')
+            self.assertEqual(same_binfo.city, u'San Jos\xe9')
 
             with self.mock_request('billing-info/deleted.xml'):
                 binfo.delete()
@@ -229,7 +230,7 @@ class TestResources(RecurlyTest):
             first_name='Verena',
             last_name='Example',
             address1='123 Main St',
-            city='San Francisco',
+            city=u'San Jos\xe9',
             state='CA',
             zip='94105',
             country='US',
@@ -549,7 +550,7 @@ class TestResources(RecurlyTest):
                     first_name='Verena',
                     last_name='Example',
                     address1='123 Main St',
-                    city='San Francisco',
+                    city=u'San Jos\xe9',
                     state='CA',
                     zip='94105',
                     country='US',
@@ -607,7 +608,7 @@ class TestResources(RecurlyTest):
                             first_name='Verena',
                             last_name='Example',
                             address1='123 Main St',
-                            city='San Francisco',
+                            city=u'San Jos\xe9',
                             state='CA',
                             zip='94105',
                             country='US',
@@ -644,7 +645,7 @@ class TestResources(RecurlyTest):
                         first_name='Verena',
                         last_name='Example',
                         address1='123 Main St',
-                        city='San Francisco',
+                        city=u'San Jos\xe9',
                         state='CA',
                         zip='94105',
                         country='US',


### PR DESCRIPTION
The current policy is to cast values to str when serializing them to XML elements. If a unicode string is received (which is likely to happen in people names) a unicode encode error will be raised.

The current commit ensures the value is casted to unicode, which is safe for ascii strings as well. The tests fixtures haven been updated to consider unicode characters in values.
