### PR TITLE
The Transaction class was missing a 'description' attribute

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -461,6 +461,7 @@ class Transaction(Resource):
         'reference',
         'test',
         'voidable',
+        'description',
         'refundable',
         'cvv_result',
         'avs_result',


### PR DESCRIPTION
This attribute is available in the other non-python recurly libraries. After speaking with support, it seems like this was accidentally left out of the list of attributes in **init**.py around line 463.

We've been creating transactions via the python library, but the descriptions were not being received.
