### PR TITLE
Fix for recurly.js.fetch where it was not using the base_uri function that includes the subdomain

### DIFF
--- a/recurly/js.py
+++ b/recurly/js.py
@@ -39,7 +39,7 @@ def sign(*records):
 
 
 def fetch(token):
-    url = urljoin(recurly.BASE_URI, 'recurly_js/result/%s' % token)
+    url = urljoin(recurly.base_uri(), 'recurly_js/result/%s' % token)
     resp, elem = recurly.Resource.element_for_url(url)
     cls = recurly.Resource.value_for_element(elem)
     return cls.from_element(elem)


### PR DESCRIPTION
recurly.js.fetch was using recurly.BASE_URI instead of recurly.base_uri() and therefore was failing because it did not have the full url that included the subdomain.
