### PR TITLE
Support account codes with colons.

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from urllib import urlencode
+from urllib import quote
 from urlparse import urljoin
 from xml.etree import ElementTree
 
@@ -140,12 +140,12 @@ class Account(Resource):
 
     def charge(self, charge):
         """Charge (or credit) this account with the given `Adjustment`."""
-        url = urljoin(self._url, '%s/adjustments' % self.account_code)
+        url = urljoin(self._url, '%s/adjustments' % quote(self.account_code))
         return charge.post(url)
 
     def invoice(self):
         """Create an invoice for any outstanding adjustments this account has."""
-        url = urljoin(self._url, '%s/invoices' % self.account_code)
+        url = urljoin(self._url, '%s/invoices' % quote(self.account_code))
 
         response = self.http_request(url, 'POST')
         if response.status != 201:
@@ -161,12 +161,12 @@ class Account(Resource):
 
     def notes(self):
         """Fetch Notes for this account."""
-        url = urljoin(self._url, '%s/notes' % self.account_code)
+        url = urljoin(self._url, '%s/notes' % quote(self.account_code))
         return Note.paginated(url)
 
     def reopen(self):
         """Reopen a closed account."""
-        url = urljoin(self._url, '%s/reopen' % self.account_code)
+        url = urljoin(self._url, '%s/reopen' % quote(self.account_code))
         response = self.http_request(url, 'PUT')
         if response.status != 200:
             self.raise_http_error(response)
@@ -177,12 +177,12 @@ class Account(Resource):
 
     def subscribe(self, subscription):
         """Create the given `Subscription` for this existing account."""
-        url = urljoin(self._url, '%s/subscriptions' % self.account_code)
+        url = urljoin(self._url, '%s/subscriptions' % quote(self.account_code))
         return subscription.post(url)
 
     def update_billing_info(self, billing_info):
         """Change this account's billing information to the given `BillingInfo`."""
-        url = urljoin(self._url, '%s/billing_info' % self.account_code)
+        url = urljoin(self._url, '%s/billing_info' % quote(self.account_code))
         response = billing_info.http_request(url, 'PUT', billing_info,
             {'Content-Type': 'application/xml; charset=utf-8'})
         if response.status == 200:

--- a/tests/fixtures/account/created_with_colon.xml
+++ b/tests/fixtures/account/created_with_colon.xml
@@ -1,0 +1,30 @@
+POST https://api.recurly.com/v2/accounts HTTP/1.1
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: recurly-python/{version}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account>
+  <account_code>account:123</account_code>
+</account>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/account:123
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/account:123">
+  <adjustments href="https://api.recurly.com/v2/accounts/account:123/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/account:123/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/account:123/invoices"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/account:123/subscriptions"/>
+  <transactions href="https://api.recurly.com/v2/accounts/account:123/transactions"/>
+  <account_code>account:123</account_code>
+  <username nil="nil"></username>
+  <email nil="nil"></email>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
+  <company_name nil="nil"></company_name>
+  <accept_language nil="nil"></accept_language>
+</account>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -4,6 +4,7 @@ import logging
 import time
 from urlparse import urljoin
 from xml.etree import ElementTree
+from mock import Mock
 
 import recurly
 from recurly import Account, AddOn, Adjustment, BillingInfo, Coupon, Plan, Redemption, Subscription, SubscriptionAddOn, Transaction
@@ -110,6 +111,17 @@ class TestResources(RecurlyTest):
         finally:
             with self.mock_request('account/numeric-deleted.xml'):
                 account.delete()
+
+    def test_account__colon_in_name(self):
+        account_code = "account:123"
+        account = Account(account_code=account_code)
+        with self.mock_request('account/created_with_colon.xml'):
+            account.save()
+        mockCharge = Mock()
+
+        account.charge(mockCharge)
+
+        mockCharge.post.assert_called_with('https://api.recurly.com/v2/accounts/account%3A123/adjustments')
 
     def test_add_on(self):
         plan_code = 'plan%s' % self.test_id


### PR DESCRIPTION
Our account codes were in the format of `account:123` which causes issues with python's `urljoin`. This properly escapes the account code before `urljoin`ing them.

We ultimately decided to switch our delimiter to `_`, but I had the patch already written.