### PR TITLE
converted to pep8 style

### DIFF
--- a/recurly/link_header.py
+++ b/recurly/link_header.py
@@ -38,53 +38,57 @@ LINK = r'<[^>]*>\s*(?:;\s*%(PARAMETER)s?\s*)*' % locals()
 COMMA = r'(?:\s*(?:,\s*)+)'
 LINK_SPLIT = r'%s(?=%s|\s*$)' % (LINK, COMMA)
 
+
 def _unquotestring(instr):
     if instr[0] == instr[-1] == '"':
         instr = instr[1:-1]
         instr = re.sub(r'\\(.)', r'\1', instr)
     return instr
+
+
 def _splitstring(instr, item, split):
     if not instr: 
         return []
-    return [ h.strip() for h in re.findall(r'%s(?=%s|\s*$)' % (item, split), instr)]
+    return [h.strip() for h in re.findall(r'%s(?=%s|\s*$)' % (item, split), instr)]
 
 link_splitter = re.compile(LINK_SPLIT)
 
+
 def parse_link_value(instr):
-	"""
-	Given a link-value (i.e., after separating the header-value on commas), 
-	return a dictionary whose keys are link URLs and values are dictionaries
-	of the parameters for their associated links.
-	
-	Note that internationalised parameters (e.g., title*) are 
-	NOT percent-decoded.
-	
-	Also, only the last instance of a given parameter will be included.
-	
-	For example, 
-	
-	>>> parse_link_value('</foo>; rel="self"; title*=utf-8\'de\'letztes%20Kapitel')
-	{'/foo': {'title*': "utf-8'de'letztes%20Kapitel", 'rel': 'self'}}
-	
-	"""
-	out = {}
-	if not instr: 
-		return out
-	for link in [h.strip() for h in link_splitter.findall(instr)]:
-		url, params = link.split(">", 1)
-		url = url[1:]
-		param_dict = {}
-		for param in _splitstring(params, PARAMETER, "\s*;\s*"):
-			try:
-				a, v = param.split("=", 1)
-				param_dict[a.lower()] = _unquotestring(v)
-			except ValueError:
-				param_dict[param.lower()] = None
-		out[url] = param_dict
-	return out
-	
-	
+    """
+    Given a link-value (i.e., after separating the header-value on commas), 
+    return a dictionary whose keys are link URLs and values are dictionaries
+    of the parameters for their associated links.
+    
+    Note that internationalised parameters (e.g., title*) are 
+    NOT percent-decoded.
+    
+    Also, only the last instance of a given parameter will be included.
+    
+    For example, 
+    
+    >>> parse_link_value('</foo>; rel="self"; title*=utf-8\'de\'letztes%20Kapitel')
+    {'/foo': {'title*': "utf-8'de'letztes%20Kapitel", 'rel': 'self'}}
+    
+    """
+    out = {}
+    if not instr: 
+        return out
+    for link in [h.strip() for h in link_splitter.findall(instr)]:
+        url, params = link.split(">", 1)
+        url = url[1:]
+        param_dict = {}
+        for param in _splitstring(params, PARAMETER, "\s*;\s*"):
+            try:
+                a, v = param.split("=", 1)
+                param_dict[a.lower()] = _unquotestring(v)
+            except ValueError:
+                param_dict[param.lower()] = None
+        out[url] = param_dict
+    return out
+
+
 if __name__ == '__main__':
-	import sys
-	if len(sys.argv) > 1:
-		print parse_link_value(sys.argv[1])
+    import sys
+    if len(sys.argv) > 1:
+        print parse_link_value(sys.argv[1])


### PR DESCRIPTION
Hi!
I found link_header.py contains tab indents.
This PR is based on PEP8 like:
- replacing to tab to 4 characters
- separating 2 lines for each functions
- removing a space within brackets

Thanks!
