### PR TITLE
Allow downloading invoices as PDF

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -435,6 +435,21 @@ class Invoice(Resource):
         """
         return cls.all(state='past_due', **kwargs)
 
+    @classmethod
+    def pdf(cls, uuid):
+        """Return a PDF of the invoice identified by the UUID
+
+        This is a raw string, which can be written to a file with:
+        `
+            with open('invoice.pdf', 'w') as invoice_file:
+                invoice_file.write(recurly.Invoice.pdf(uuid))
+        `
+
+        """
+        url = urljoin(base_uri(), cls.member_path % (uuid,))
+        pdf_response = cls.http_request(url, headers={'Accept': 'application/pdf'})
+        return pdf_response.read()
+
 
 class Subscription(Resource):
 

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -262,8 +262,8 @@ class Resource(object):
             connection = _ValidatedHTTPSConnection(urlparts.netloc)
 
         headers = {} if headers is None else dict(headers)
+        headers.setdefault('Accept', 'application/xml')
         headers.update({
-            'Accept': 'application/xml',
             'User-Agent': 'recurly-python/%s' % recurly.__version__,
         })
         if recurly.API_KEY is None:


### PR DESCRIPTION
Fixes #46 

Approver: @cbarton 

Tests:
- Download an invoice
  
  ```
  with open('invoice.pdf', 'w') as invoice_file:
      invoice_file.write(recurly.Invoice.pdf(uuid))
  ```
