### PR TITLE
Add entity_use_code to account

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Added account entity use code: `account.entity_use_code`
+
 ## Version 2.2.3 August 5, 2014
 
 - Added subscription change preview

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -81,6 +81,7 @@ class Account(Resource):
         'company_name',
         'vat_number',
         'tax_exempt',
+        'entity_use_code',
         'accept_language',
         'created_at',
     )

--- a/tests/fixtures/account/exists.xml
+++ b/tests/fixtures/account/exists.xml
@@ -20,5 +20,6 @@ Content-Type: application/xml; charset=utf-8
   <first_name nil="nil"></first_name>
   <last_name nil="nil"></last_name>
   <company_name nil="nil"></company_name>
+  <entity_use_code>I</entity_use_code>
   <accept_language nil="nil"></accept_language>
 </account>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -54,6 +54,7 @@ class TestResources(RecurlyTest):
         self.assertTrue(same_account is not account)
         self.assertEqual(same_account.account_code, account_code)
         self.assertTrue(same_account.first_name is None)
+        self.assertTrue(same_account.entity_use_code == 'I')
         self.assertEqual(same_account._url, urljoin(recurly.base_uri(), 'accounts/%s' % account_code))
 
         account.username = 'shmohawk58'


### PR DESCRIPTION
From our recent integration with Avalara, we now give merchants the ability to set their account tax use code.

cc/ @chrissrogers 
