### PR TITLE
Add invoice previews

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -190,6 +190,21 @@ class Account(Resource):
         invoice._url = response.getheader('Location')
         return invoice
 
+    def build_invoice(self):
+        """Preview an invoice for any outstanding adjustments this account has."""
+        url = urljoin(self._url, '%s/invoices/preview' % self.account_code)
+
+        response = self.http_request(url, 'POST')
+        if response.status != 200:
+            self.raise_http_error(response)
+
+        response_xml = response.read()
+        logging.getLogger('recurly.http.response').debug(response_xml)
+        elem = ElementTree.fromstring(response_xml)
+
+        invoice = Invoice.from_element(elem)
+        return invoice
+
     def notes(self):
         """Fetch Notes for this account."""
         url = urljoin(self._url, '%s/notes' % self.account_code)

--- a/tests/fixtures/invoice/preview-error-no-charges.xml
+++ b/tests/fixtures/invoice/preview-error-no-charges.xml
@@ -1,0 +1,15 @@
+POST https://api.recurly.com/v2/accounts/invoicemock/invoices/preview HTTP/1.1
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: recurly-python/{version}
+Content-Length: 0
+
+
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<error>
+  <symbol>will_not_invoice</symbol>
+  <description>No charges to invoice</description>
+</error>

--- a/tests/fixtures/invoice/preview-invoice.xml
+++ b/tests/fixtures/invoice/preview-invoice.xml
@@ -1,0 +1,22 @@
+POST https://api.recurly.com/v2/accounts/invoicemock/invoices/preview HTTP/1.1
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: recurly-python/{version}
+Content-Length: 0
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice href="">
+  <uuid>4ba1531325014b4f969cd13676f514d8</uuid>
+  <account_code>invoicemock</account_code>
+  <amount_in_cents>
+    <USD type="integer">1000</USD>
+  </amount_in_cents>
+  <start_date type="datetime">2009-11-03T23:27:46-08:00</start_date>
+  <end_date type="datetime"></end_date>
+  <description>test charge</description>
+  <created_at type="datetime">2009-11-03T23:27:46-08:00</created_at>
+</invoice>


### PR DESCRIPTION
cc/ @bhelx 

tests:
- create an uninvoiced charge on an account
- `i = Account.get('<account_code>'). build_invoice()`
- verify `i` has the correct invoice attributes and the charge is still uninvoiced
