### PR TITLE
Require six version 1.4.0 or higher.  Older versions of six do not impli...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
     ],
     packages=['recurly'],
-    install_requires=['iso8601', 'backports.ssl_match_hostname', 'six'] + more_install_requires,
+    install_requires=['iso8601', 'backports.ssl_match_hostname', 'six>=1.4.0'] + more_install_requires,
     tests_require=['mock',
                    'six'],
     test_suite='unittest2.collector',


### PR DESCRIPTION
...ment six.moves.urllib.parse