### PR TITLE
Adding vat_location_valid field to Account

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add address attribute into preview calls and update invoice notes path
+- Added tests for new read-only attribute `vat_location_valid` on `Account`
 
 ## Version 2.2.7 December 8, 2014
 

--- a/tests/fixtures/account/created.xml
+++ b/tests/fixtures/account/created.xml
@@ -38,4 +38,5 @@ Location: https://api.recurly.com/v2/accounts/testmock
     <phone>8015559876</phone>
   </address>
   <accept_language nil="nil"></accept_language>
+  <vat_location_enabled type="boolean">true</vat_location_enabled>
 </account>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -42,6 +42,7 @@ class TestResources(RecurlyTest):
             account.save()
         self.assertEqual(account._url, urljoin(recurly.base_uri(), 'accounts/%s' % account_code))
         self.assertEqual(account.vat_number, '444444-UK')
+        self.assertEqual(account.vat_location_enabled, True)
 
         with self.mock_request('account/list-active.xml'):
             active = Account.all_active()


### PR DESCRIPTION
This field will show up when the account is elligible and has been
location verified according to the VAT rules. It will be true when
passed and false when failed.

There weren't any needed changes for the library code here as it's a
read-only attribute. I just wanted to update the fixture and the test.