### PR TITLE
Add Invoice#invoice_number_prefix and Invoice#invoice_number_with_prefix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
 ## Unreleased
 
-- Add address attribute into preview calls and update invoice notes path
+- Added address attribute into preview calls and update invoice notes path
 - Added tests for new read-only attribute `vat_location_valid` on `Account`
+- Added `invoice_number_prefix` and `invoice_number_with_prefix()` on
+`Invoice` for use with the Country Invoice Sequencing feature
 
 ## Version 2.2.7 December 8, 2014
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -433,6 +433,7 @@ class Invoice(Resource):
         'uuid',
         'state',
         'invoice_number',
+        'invoice_number_prefix',
         'po_number',
         'vat_number',
         'subtotal_in_cents',
@@ -452,6 +453,9 @@ class Invoice(Resource):
     blacklist_attributes = (
         'currency',
     )
+
+    def invoice_number_with_prefix(self):
+        return '%s%s' % (self.invoice_number_prefix, self.invoice_number)
 
     def serializable_attributes(self):
         return [attr for attr in self.attributes if attr not in

--- a/tests/fixtures/invoice/invoiced-with-optionals.xml
+++ b/tests/fixtures/invoice/invoiced-with-optionals.xml
@@ -18,6 +18,8 @@ Location: https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8
 <invoice href="https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8">
   <uuid>4ba1531325014b4f969cd13676f514d8</uuid>
   <account_code>invoicemock</account_code>
+  <invoice_number type="integer">1001</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <amount_in_cents>
     <USD type="integer">1000</USD>
   </amount_in_cents>

--- a/tests/fixtures/invoice/invoiced.xml
+++ b/tests/fixtures/invoice/invoiced.xml
@@ -13,6 +13,8 @@ Location: https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8
 <invoice href="https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8">
   <uuid>4ba1531325014b4f969cd13676f514d8</uuid>
   <account_code>invoicemock</account_code>
+  <invoice_number type="integer">1001</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
   <amount_in_cents>
     <USD type="integer">1000</USD>
   </amount_in_cents>

--- a/tests/fixtures/invoice/show-taxed.xml
+++ b/tests/fixtures/invoice/show-taxed.xml
@@ -13,6 +13,8 @@ Content-Type: application/xml; charset=utf-8
   <invoice href="https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8">
     <uuid>4ba1531325014b4f969cd13676f514d8</uuid>
     <account_code>invoicemock</account_code>
+    <invoice_number type="integer">1001</invoice_number>
+    <invoice_number_prefix></invoice_number_prefix>
     <amount_in_cents>
       <USD type="integer">1000</USD>
     </amount_in_cents>

--- a/tests/fixtures/invoice/show-with-prefix.xml
+++ b/tests/fixtures/invoice/show-with-prefix.xml
@@ -14,7 +14,7 @@ Content-Type: application/xml; charset=utf-8
     <uuid>4ba1531325014b4f969cd13676f514d8</uuid>
     <account_code>invoicemock</account_code>
     <invoice_number type="integer">1001</invoice_number>
-    <invoice_number_prefix></invoice_number_prefix>
+    <invoice_number_prefix>GB</invoice_number_prefix>
     <amount_in_cents>
       <USD type="integer">1000</USD>
     </amount_in_cents>
@@ -22,5 +22,6 @@ Content-Type: application/xml; charset=utf-8
     <end_date type="datetime"></end_date>
     <description>test charge</description>
     <created_at type="datetime">2009-11-03T23:27:46-08:00</created_at>
+    <tax_type>usst</tax_type>
   </invoice>
 </invoices>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -542,6 +542,13 @@ class TestResources(RecurlyTest):
             invoice = account.invoices()[0]
             self.assertEqual(invoice.tax_type, 'usst')
 
+        """Test invoice with prefix"""
+        with self.mock_request('invoice/show-with-prefix.xml'):
+            invoice = account.invoices()[0]
+            self.assertEqual(invoice.invoice_number, 1001)
+            self.assertEqual(invoice.invoice_number_prefix, 'GB')
+            self.assertEqual(invoice.invoice_number_with_prefix(), 'GB1001')
+
     def test_invoice_with_optionals(self):
         account = Account(account_code='invoice%s' % self.test_id)
         with self.mock_request('invoice/account-created.xml'):


### PR DESCRIPTION
cc/ @bhelx  

tests:

  - Turn on the Country Invoice Sequencing feature with VAT taxes
  - Create a VAT taxed invoice 
  - `recurly.Invoice.get('<invoice_number_with_prefix>').invoice_number_with_prefix()` should find the correct invoice and return its full invoice number.