### PR TITLE
Support open amount and line item refunds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@
 - Added `invoice_number_prefix` and `invoice_number_with_prefix()` on
 `Invoice` for use with the Country Invoice Sequencing feature
 - Added support for update_notes path on Subscription
+- Added `refund_amount` (open amount refunds) to `Invoice`
+- Added `refund` (line item refunds) to `Invoice`
 
 ## Version 2.2.7 December 8, 2014
 

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -650,10 +650,10 @@ class Resource(object):
         logging.getLogger('recurly.http.response').debug(response_xml)
         self.update_from_element(ElementTree.fromstring(response_xml))
 
-    def post(self, url):
+    def post(self, url, body=None):
         """Sends this `Resource` instance to the service with a
-        ``POST`` request to the given URL."""
-        response = self.http_request(url, 'POST', self, {'Content-Type': 'application/xml; charset=utf-8'})
+        ``POST`` request to the given URL. Takes an optional body"""
+        response = self.http_request(url, 'POST', body or self, {'Content-Type': 'application/xml; charset=utf-8'})
         if response.status not in (200, 201, 204):
             self.raise_http_error(response)
 

--- a/tests/fixtures/invoice/invoiced-line-items.xml
+++ b/tests/fixtures/invoice/invoiced-line-items.xml
@@ -1,0 +1,47 @@
+POST https://api.recurly.com/v2/accounts/invoicemock/invoices HTTP/1.1
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: recurly-python/{version}
+Content-Length: 0
+
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice href="https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8">
+  <uuid>4ba1531325014b4f969cd13676f514d8</uuid>
+  <account_code>invoicemock</account_code>
+  <invoice_number type="integer">1001</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
+  <start_date type="datetime">2009-11-03T23:27:46-08:00</start_date>
+  <end_date type="datetime"></end_date>
+  <description>test charge</description>
+  <created_at type="datetime">2009-11-03T23:27:46-08:00</created_at>
+  <line_items type="array">
+      <adjustment href="https://your-subdomain.recurly.com/v2/adjustments/2bc3cf4cb513049c6aec1b419c97b508" type="charge">
+          <account href="https://your-subdomain.recurly.com/v2/accounts/1"/>
+          <invoice href="https://your-subdomain.recurly.com/v2/invoices/1010"/>
+          <uuid>2bc3cf4cb513049c6aec1b419c97b508</uuid>
+          <state>invoiced</state>
+          <description>Refund for Setup fee: IP Addresses</description>
+          <accounting_code nil="nil"/>
+          <product_code>ipaddresses</product_code>
+          <origin>setup_fee</origin>
+          <unit_amount_in_cents type="integer">900</unit_amount_in_cents>
+          <quantity type="integer">-1</quantity>
+          <quantity_remaining type="integer">0</quantity_remaining>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">-900</total_in_cents>
+          <currency>GBP</currency>
+          <taxable type="boolean">false</taxable>
+          <tax_exempt type="boolean">false</tax_exempt>
+          <tax_code nil="nil"/>
+          <start_date type="datetime">2014-12-16T18:49:41Z</start_date>
+          <end_date nil="nil"/>
+          <created_at type="datetime">2014-12-16T21:32:16Z</created_at>
+      </adjustment>
+  </line_items>
+</invoice>

--- a/tests/fixtures/invoice/line-item-refunded.xml
+++ b/tests/fixtures/invoice/line-item-refunded.xml
@@ -1,0 +1,35 @@
+POST https://api.recurly.com/v2/invoices/1001/refund HTTP/1.1
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: recurly-python/{version}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice>
+    <line_items>
+        <adjustment>
+            <uuid>2bc3cf4cb513049c6aec1b419c97b508</uuid>
+            <quantity type="integer">1</quantity>
+            <prorate type="boolean">false</prorate>
+        </adjustment>
+    </line_items>
+</invoice>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice href="https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8">
+  <uuid>4ba1531325014b4f969cd13676f514d8</uuid>
+  <account_code>invoicemock</account_code>
+  <invoice_number type="integer">1001</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
+  <subtotal_in_cents type="integer">-1000</subtotal_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">-1000</total_in_cents>
+  <start_date type="datetime">2009-11-03T23:27:46-08:00</start_date>
+  <end_date type="datetime"></end_date>
+  <description>test charge</description>
+  <created_at type="datetime">2009-11-03T23:27:46-08:00</created_at>
+</invoice>

--- a/tests/fixtures/invoice/refunded.xml
+++ b/tests/fixtures/invoice/refunded.xml
@@ -1,0 +1,29 @@
+POST https://api.recurly.com/v2/invoices/1001/refund HTTP/1.1
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: recurly-python/{version}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice>
+    <amount_in_cents type="integer">1000</amount_in_cents>
+</invoice>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice href="https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8">
+  <uuid>4ba1531325014b4f969cd13676f514d8</uuid>
+  <account_code>invoicemock</account_code>
+  <invoice_number type="integer">1001</invoice_number>
+  <invoice_number_prefix></invoice_number_prefix>
+  <subtotal_in_cents type="integer">-1000</subtotal_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">-1000</total_in_cents>
+  <start_date type="datetime">2009-11-03T23:27:46-08:00</start_date>
+  <end_date type="datetime"></end_date>
+  <description>test charge</description>
+  <created_at type="datetime">2009-11-03T23:27:46-08:00</created_at>
+</invoice>


### PR DESCRIPTION
Adds support for open amount refunds and line item refunds.

Approvers: @cbarton 

### Testing

Line Item Refunds:

```python
# must have line items
invoice = recurly.Invoice.get('1569')

adjust = {
        'adjustment': invoice.line_items[0],
        'quantity': 1,
        'prorate': False
        }

refund_invoice = invoice.refund([adjust])

print refund_invoice
print refund_invoice.subtotal_in_cents
```

Open Amount Refund:

```python
invoice = recurly.Invoice.get('1567')

# refund $10
refund_invoice = invoice.refund_amount(1000)

print refund_invoice.uuid
print refund_invoice.subtotal_in_cents
```
