### PR TITLE
Add original_adjustment() to Adjustment

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Added `original_adjustment()` to `Adjustment` for retrieving the linked
+adjustment where the other came from for better accounting purposes
+
 ## Version 2.2.8 January 27, 2015
 
 - Added address attribute into preview calls and update invoice notes path

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -418,6 +418,18 @@ class Adjustment(Resource):
     xml_attribute_attributes = ('type',)
     _classes_for_nodename = {'tax_detail': TaxDetail,}
 
+    # This can be removed when the `original_adjustment_uuid` is moved to a link
+    def __getattr__(self, name):
+        if name == 'original_adjustment':
+            try:
+                uuid = super(Adjustment, self).__getattr__('original_adjustment_uuid')
+            except (AttributeError):
+                return super(Adjustment, self).__getattr__(name)
+
+            return lambda: Adjustment.get(uuid)
+        else:
+            return super(Adjustment, self).__getattr__(name)
+
 
 class Invoice(Resource):
 

--- a/tests/fixtures/adjustment/original-adjustment-lookup.xml
+++ b/tests/fixtures/adjustment/original-adjustment-lookup.xml
@@ -1,0 +1,33 @@
+GET https://api.recurly.com/v2/adjustments/2bd3381e9ffb7fddc18128454d835e83 HTTP/1.1
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: recurly-python/{version}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+X-Records: 1
+
+<?xml version="1.0" encoding="UTF-8"?>
+<adjustment href="http://api.recurly.com/v2/adjustments/2bd3381e9ffb7fddc18128454d835e83" type="charge">
+  <account href="https://api.recurly.com/v2/accounts/chargemock"/>
+  <invoice href="https://api.recurly.com/v2/invoices/1074"/>
+  <uuid>2bd3381e9ffb7fddc18128454d835e83</uuid>
+  <state>invoiced</state>
+  <description>test charge</description>
+  <accounting_code></accounting_code>
+  <product_code></product_code>
+  <origin>add_on</origin>
+  <unit_amount_in_cents type="integer">3387</unit_amount_in_cents>
+  <quantity type="integer">1</quantity>
+  <quantity_remaining type="integer">0</quantity_remaining>
+  <discount_in_cents type="integer">0</discount_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">3387</total_in_cents>
+  <currency>USD</currency>
+  <taxable type="boolean">false</taxable>
+  <tax_exempt type="boolean">false</tax_exempt>
+  <start_date type="datetime">2014-12-29T21:22:47Z</start_date>
+  <end_date type="datetime">2015-01-19T21:21:04Z</end_date>
+  <created_at type="datetime">2014-12-29T21:22:47Z</created_at>
+</adjustment>

--- a/tests/fixtures/adjustment/original-adjustment-uuid.xml
+++ b/tests/fixtures/adjustment/original-adjustment-uuid.xml
@@ -1,0 +1,34 @@
+GET https://api.recurly.com/v2/adjustments/2c06b94abe047189b225d94dd0adb71f HTTP/1.1
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: recurly-python/{version}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+X-Records: 1
+
+<?xml version="1.0" encoding="UTF-8"?>
+<adjustment href="http://api.recurly.com/v2/adjustments/2c06b94abe047189b225d94dd0adb71f" type="charge">
+  <account href="https://api.recurly.com/v2/accounts/chargemock"/>
+  <invoice href="https://api.recurly.com/v2/invoices/1075"/>
+  <uuid>2c06b94abe047189b225d94dd0adb71f</uuid>
+  <state>invoiced</state>
+  <description>test charge</description>
+  <accounting_code></accounting_code>
+  <product_code></product_code>
+  <origin>add_on</origin>
+  <unit_amount_in_cents type="integer">3387</unit_amount_in_cents>
+  <quantity type="integer">-1</quantity>
+  <quantity_remaining type="integer">0</quantity_remaining>
+  <original_adjustment_uuid>2bd3381e9ffb7fddc18128454d835e83</original_adjustment_uuid>
+  <discount_in_cents type="integer">0</discount_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">-3387</total_in_cents>
+  <currency>USD</currency>
+  <taxable type="boolean">false</taxable>
+  <tax_exempt type="boolean">false</tax_exempt>
+  <start_date type="datetime">2014-12-29T21:22:47Z</start_date>
+  <end_date type="datetime">2015-01-19T21:21:04Z</end_date>
+  <created_at type="datetime">2014-12-29T21:22:47Z</created_at>
+</adjustment>

--- a/tests/fixtures/adjustment/original-adjustment.xml
+++ b/tests/fixtures/adjustment/original-adjustment.xml
@@ -1,0 +1,34 @@
+GET https://api.recurly.com/v2/adjustments/2c06b94abe047189b225d94dd0adb71f HTTP/1.1
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: recurly-python/{version}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+X-Records: 1
+
+<?xml version="1.0" encoding="UTF-8"?>
+<adjustment href="http://api.recurly.com/v2/adjustments/2c06b94abe047189b225d94dd0adb71f" type="charge">
+  <account href="https://api.recurly.com/v2/accounts/chargemock"/>
+  <invoice href="https://api.recurly.com/v2/invoices/1075"/>
+  <uuid>2c06b94abe047189b225d94dd0adb71f</uuid>
+  <state>invoiced</state>
+  <description>test charge</description>
+  <accounting_code></accounting_code>
+  <product_code></product_code>
+  <origin>add_on</origin>
+  <unit_amount_in_cents type="integer">3387</unit_amount_in_cents>
+  <quantity type="integer">-1</quantity>
+  <quantity_remaining type="integer">0</quantity_remaining>
+  <original_adjustment href="https://api.recurly.com/v2/adjustments/2bd3381e9ffb7fddc18128454d835e83"/>
+  <discount_in_cents type="integer">0</discount_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">-3387</total_in_cents>
+  <currency>USD</currency>
+  <taxable type="boolean">false</taxable>
+  <tax_exempt type="boolean">false</tax_exempt>
+  <start_date type="datetime">2014-12-29T21:22:47Z</start_date>
+  <end_date type="datetime">2015-01-19T21:21:04Z</end_date>
+  <created_at type="datetime">2014-12-29T21:22:47Z</created_at>
+</adjustment>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -363,6 +363,24 @@ class TestResources(RecurlyTest):
             charge = account.adjustments()[0]
             self.assertFalse(charge.tax_exempt)
 
+        """Test original adjustment"""
+        with self.mock_request('adjustment/original-adjustment.xml'):
+            charge = Adjustment.get('2c06b94abe047189b225d94dd0adb71f')
+
+            with self.mock_request('adjustment/original-adjustment-lookup.xml'):
+                original_charge = charge.original_adjustment()
+
+            self.assertEqual(original_charge.total_in_cents, -charge.total_in_cents)
+
+        """Test original adjustment lookup by UUID"""
+        with self.mock_request('adjustment/original-adjustment-uuid.xml'):
+            charge = Adjustment.get('2c06b94abe047189b225d94dd0adb71f')
+
+            with self.mock_request('adjustment/original-adjustment-lookup.xml'):
+                original_charge = charge.original_adjustment()
+
+            self.assertEqual(original_charge.total_in_cents, -charge.total_in_cents)
+
     def test_coupon(self):
         # Check that a coupon may not exist.
         coupon_code = 'coupon%s' % self.test_id


### PR DESCRIPTION
`original_adjustment()` returns the linked adjustment for either:

  - the original refunded adjustment
  - the original credit that the account credit came from (the carryforward credit)

As a note to this PR, the element `original_adjustment_uuid` will be deprecated and removed in favor of the more useful `original_adjustment` link. This breaks our other clients and with that we will be having a soft upgrade.

cc/ @bhelx 

tests:

- Given a refund adjustment `abc`
```
adjustment = Adjustment.get('abc')
print adjustment.total_in_cents # -xxx
print adjustment.original_adjustment().total_in_cents # xxx
```