### PR TITLE
Bank accounts (ACH feature)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 ## Unreleased
 
 - Add `tax_type`, `tax_rate`, `tax_region` to `Adjustment`
+- Added `bank_account` type and attributes to `BillingInfo`, these include:
+	- `name_on_account`
+	- `account_type` (`checking` or `savings`)
+	- `last_four`
+	- `routing_number`
 
 ## Version 2.2.9 February 6, 2015
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -256,6 +256,7 @@ class BillingInfo(Resource):
 
     attributes = (
         'type',
+        'name_on_account',
         'first_name',
         'last_name',
         'number',
@@ -282,8 +283,11 @@ class BillingInfo(Resource):
         'paypal_billing_agreement_id',
         'amazon_billing_agreement_id',
         'token_id',
+        'account_type',
+        'routing_number',
+        'account_number',
     )
-    sensitive_attributes = ('number', 'verification_value')
+    sensitive_attributes = ('number', 'verification_value', 'account_number')
     xml_attribute_attributes = ('type',)
 
 class Coupon(Resource):


### PR DESCRIPTION
Adds ACH support for Billing Infos

cc/ @bhelx 

tests:

```python
account = recurly.Account.get('<account-code>')
billing_info = recurly.BillingInfo(
  name_on_account = 'John Doe',
  routing_number = '125200057',
  account_number = '0123456789',
  account_type = 'checking',
  address1 = '123 Fake St',
  city = 'San Francisco',
  state ='CA',
  country = 'US',
  zip = '94107'
  )

account.update_billing_info(billing_info)
```
  - check the billing info to see that it reflects that info
  