### PR TITLE
Adding ip_address to Transaction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add `ip_address` to `Transaction`
+
 ## Version 2.2.11 May 6, 2015
 
 - Add `bank_account_authorized_at` to `Subscription`

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -720,6 +720,7 @@ class Transaction(Resource):
         'details',
         'transaction_error',
         'type',
+        'ip_address',
     )
     xml_attribute_attributes = ('type',)
     sensitive_attributes = ('number', 'verification_value',)

--- a/tests/fixtures/transaction/created-again.xml
+++ b/tests/fixtures/transaction/created-again.xml
@@ -32,6 +32,7 @@ Location: https://api.recurly.com/v2/transactions/123456789012345678901234567890
   <test type="boolean">true</test>
   <voidable type="boolean">true</voidable>
   <refundable type="boolean">true</refundable>
+  <ip_address>127.0.0.1</ip_address>
   <cvv_result code="" nil="nil"></cvv_result>
   <avs_result code="" nil="nil"></avs_result>
   <avs_result_street nil="nil"></avs_result_street>

--- a/tests/fixtures/transaction/partial-refunded-transaction.xml
+++ b/tests/fixtures/transaction/partial-refunded-transaction.xml
@@ -22,6 +22,7 @@ Content-Type: application/xml; charset=utf-8
   <test type="boolean">true</test>
   <voidable type="boolean">true</voidable>
   <refundable type="boolean">false</refundable>
+  <ip_address>127.0.0.1</ip_address>
   <cvv_result code="" nil="nil"></cvv_result>
   <avs_result code="" nil="nil"></avs_result>
   <avs_result_street nil="nil"></avs_result_street>

--- a/tests/fixtures/transaction/partial-refunded.xml
+++ b/tests/fixtures/transaction/partial-refunded.xml
@@ -23,6 +23,7 @@ Content-Type: application/xml; charset=utf-8
   <test type="boolean">true</test>
   <voidable type="boolean">true</voidable>
   <refundable type="boolean">true</refundable>
+  <ip_address>127.0.0.1</ip_address>
   <cvv_result code="" nil="nil"></cvv_result>
   <avs_result code="" nil="nil"></avs_result>
   <avs_result_street nil="nil"></avs_result_street>

--- a/tests/fixtures/transaction/refund-transaction.xml
+++ b/tests/fixtures/transaction/refund-transaction.xml
@@ -22,6 +22,7 @@ Content-Type: application/xml; charset=utf-8
   <test type="boolean">true</test>
   <voidable type="boolean">true</voidable>
   <refundable type="boolean">false</refundable>
+  <ip_address>127.0.0.1</ip_address>
   <cvv_result code="" nil="nil"></cvv_result>
   <avs_result code="" nil="nil"></avs_result>
   <avs_result_street nil="nil"></avs_result_street>

--- a/tests/fixtures/transaction/refunded.xml
+++ b/tests/fixtures/transaction/refunded.xml
@@ -23,6 +23,7 @@ Content-Type: application/xml; charset=utf-8
   <test type="boolean">true</test>
   <voidable type="boolean">true</voidable>
   <refundable type="boolean">true</refundable>
+  <ip_address>127.0.0.1</ip_address>
   <cvv_result code="" nil="nil"></cvv_result>
   <avs_result code="" nil="nil"></avs_result>
   <avs_result_street nil="nil"></avs_result_street>


### PR DESCRIPTION
Adding `ip_address` to transactions now that it's exposed
https://docs.recurly.com/api/transactions#create-transaction

cc: @bhelx 

`trans = recurly.Transaction.get(‘<uuid>’)`
`print trans.ip_address`