### PR TITLE
Add support for refund_apply_order when refunding

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
 
 - Add `ip_address` to `Transaction`
 - Add `closed_at` to `Invoice`
+- Add `refund_apply_order` to `Invoice` for specifying credits or transactions
+to be refunded first
 
 ## Version 2.2.11 May 6, 2015
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -528,22 +528,25 @@ class Invoice(Resource):
         pdf_response = cls.http_request(url, headers={'Accept': 'application/pdf'})
         return pdf_response.read()
 
-    def refund_amount(self, amount_in_cents):
-        amount_element = self.refund_open_amount_xml(amount_in_cents)
+    def refund_amount(self, amount_in_cents, refund_apply_order = 'credit'):
+        amount_element = self.refund_open_amount_xml(amount_in_cents, refund_apply_order)
         return self._create_refund_invoice(amount_element)
 
-    def refund(self, adjustments):
-        adjustments_element = self.refund_line_items_xml(adjustments)
+    def refund(self, adjustments, refund_apply_order = 'credit'):
+        adjustments_element = self.refund_line_items_xml(adjustments, refund_apply_order)
         return self._create_refund_invoice(adjustments_element)
 
-    def refund_open_amount_xml(self, amount_in_cents):
+    def refund_open_amount_xml(self, amount_in_cents, refund_apply_order):
         elem = ElementTree.Element(self.nodename)
+        elem.append(Resource.element_for_value('refund_apply_order', refund_apply_order))
         elem.append(Resource.element_for_value('amount_in_cents',
             amount_in_cents))
         return elem
 
-    def refund_line_items_xml(self, line_items):
+    def refund_line_items_xml(self, line_items, refund_apply_order):
         elem = ElementTree.Element(self.nodename)
+        elem.append(Resource.element_for_value('refund_apply_order', refund_apply_order))
+
         line_items_elem = ElementTree.Element('line_items')
 
         for item in line_items:

--- a/tests/fixtures/invoice/line-item-refunded.xml
+++ b/tests/fixtures/invoice/line-item-refunded.xml
@@ -6,6 +6,7 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <invoice>
+    <refund_apply_order>credit</refund_apply_order>
     <line_items>
         <adjustment>
             <uuid>2bc3cf4cb513049c6aec1b419c97b508</uuid>

--- a/tests/fixtures/invoice/refunded.xml
+++ b/tests/fixtures/invoice/refunded.xml
@@ -6,6 +6,7 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <invoice>
+    <refund_apply_order>credit</refund_apply_order>
     <amount_in_cents type="integer">1000</amount_in_cents>
 </invoice>
 


### PR DESCRIPTION
cc/ @bhelx 

tests:

- Create a new invoice and make sure it is paid
- Attempt a transaction first line item refund:

```python
invoice = recurly.Invoice.get('<invoice_number>')
adjustments = [{'adjustment':invoice.line_items[0], 'quantity':1, 'prorate':False}]
ref = invoice.refund(adjustments, 'transaction')
print ref.invoice_number
```

- Create another invoice and make sure it is paid
- Attempt a transaction first open amount refund:

```python
invoice = recurly.Invoice.get('<invoice_number>')
ref = invoice.refund_amount(1000, 'transaction')
print ref.invoice_number
```