### PR TITLE
Adding `closed_at` to `Invoice`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add `ip_address` to `Transaction`
+- Add `closed_at` to `Invoice`
 
 ## Version 2.2.11 May 6, 2015
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -467,6 +467,7 @@ class Invoice(Resource):
         'terms_and_conditions',
         'customer_notes',
         'address',
+        'closed_at',
     )
 
     blacklist_attributes = (


### PR DESCRIPTION
Adding `closed_at` to Invoices since it’s exposed in the XML response.

`invoice = recurly.Invoice.get(<closed invoice>)`
`print invoice.closed_at`