### PR TITLE
add tax_code, tax_exempt, accounting_code to Transaction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Require a version of six library >= 1.4.0
+- Add `tax_exempt`, `tax_code`, `accounting_code` to `Transaction`
 
 ## Version 2.2.12 June 25, 2015
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -725,6 +725,9 @@ class Transaction(Resource):
         'transaction_error',
         'type',
         'ip_address',
+        'tax_exempt',
+        'tax_code',
+        'accounting_code',
     )
     xml_attribute_attributes = ('type',)
     sensitive_attributes = ('number', 'verification_value',)


### PR DESCRIPTION
cc/ @bhelx 

tests:

- the following should create a tax exempt transaction

```python
t = recurly.Transaction(
  amount_in_cents=1000,
  currency='USD',
  account=recurly.Account.get('<account_code>'),
  tax_exempt=True
)
t.save()
print t.uuid
```