### PR TITLE
Add `gateway_error_code` to `TransactionError`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add `gateway_error_code` to `TransactionError`
+
 ## Version 2.2.13 July 31, 2015
 
 - Require a version of six library >= 1.4.0

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -59,7 +59,7 @@ class Address(Resource):
         'state',
         'zip',
         'country',
-        'phone'
+        'phone',
     )
 
 
@@ -664,7 +664,7 @@ class TransactionBillingInfo(recurly.Resource):
         'card_type',
         'month',
         'year',
-        'transaction_uuid'
+        'transaction_uuid',
     )
 
 
@@ -675,7 +675,7 @@ class TransactionAccount(recurly.Resource):
         'last_name',
         'company',
         'email',
-        'account_code'
+        'account_code',
     )
     _classes_for_nodename = {'billing_info': TransactionBillingInfo}
 
@@ -693,7 +693,8 @@ class TransactionError(recurly.Resource):
         'merchant_message',
         'error_caterogy',
         'customer_message',
-        'error_code'
+        'error_code',
+        'gateway_error_code',
     )
 
 

--- a/tests/fixtures/transaction/declined-transaction.xml
+++ b/tests/fixtures/transaction/declined-transaction.xml
@@ -1,0 +1,26 @@
+POST https://api.recurly.com/v2/transactions HTTP/1.1
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: recurly-python/{version}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction>
+  <account>
+    <account_code>transactionmock</account_code>
+  </account>
+  <currency>USD</currency>
+  <amount_in_cents type="integer">1000</amount_in_cents>
+</transaction>
+
+HTTP/1.1 422
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction_error>
+  <error_code>insufficient_funds</error_code>
+  <error_category>soft</error_category>
+  <customer_message lang="en-US">The transaction was declined due to insufficient funds in your account. Please use a different card or contact your bank.</customer_message>
+  <merchant_message lang="en-US">The card has insufficient funds to cover the cost of the transaction.</merchant_message>
+  <gateway_error_code>123</gateway_error_code>
+</transaction_error>


### PR DESCRIPTION
**Description**:
Adding a `gateway_error_code` to transactions since it's included in a failed transaction response.

**Additional approvers**:
cc: @bhelx 

**Testing**:
Failed transactions should now have `gateway_error_code` under `transaction_error`