### PR TITLE
Updating docs links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 Recurly Python Client
 =====================
 
-Recurly's Python client library is an interface to its `REST API <http://docs.recurly.com/api>`_.
+Recurly's Python client library is an interface to its `REST API <https://dev.recurly.com`_.
 
 
 Usage
@@ -28,7 +28,7 @@ authority certificate file and default currency::
 API Documentation
 -----------------
 
-Please see the `Recurly API <http://docs.recurly.com/api/>`_ for more information.
+Please see the `Recurly API <https://dev.recurly.com/docs/getting-started>`_ for more information.
 
 
 Support

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -14,7 +14,7 @@ Recurly's Python client library is an interface to its REST API.
 
 Please see the Recurly API documentation for more information:
 
-http://docs.recurly.com/api/
+https://dev.recurly.com/docs/getting-started
 
 """
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import re
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as README:
     DESCRIPTION = README.read()
-    
+
 VERSION_RE = re.compile("^__version__ = '(.+)'$",
                         flags=re.MULTILINE)
 with open(os.path.join(os.path.dirname(__file__),
@@ -24,7 +24,7 @@ setup(
     long_description=DESCRIPTION,
     author='Recurly',
     author_email='support@recurly.com',
-    url='http://docs.recurly.com/client-libraries/python',
+    url='https://recurly.readme.io/v2.0/page/python',
     license='MIT',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Updating all links that referenced the old docs url.

Before: https://docs.recurly.com/api

After: https://dev.recurly.com

cc: @bhelx 