### PR TITLE
Adding setup_fee_accounting_code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 ## Unreleased
+- Adding `setup_fee_accounting_code` to `Plan`
 
 ## Version 2.2.14 August 10, 2015
 

--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,25 @@
-.. image:: https://travis-ci.org/recurly/recurly-client-python.png?branch=master
-:target: https://travis-ci.org/recurly/recurly-client-python
-
+*********************
 Recurly Python Client
-=====================
+*********************
+.. image:: https://travis-ci.org/recurly/recurly-client-python.png?branch=master
+ :target: https://travis-ci.org/recurly/recurly-client-python
 
-Recurly's Python client library is an interface to its `REST API <https://dev.recurly.com`_.
+Recurly's Python client library is an interface to its `REST API <https://dev.recurly.com>`_.
 
 
-Usage
------
+Installation
+------------
 
-Set your API key and optionally set a certificate
-authority certificate file and default currency::
+Recurly is packaged as a Python package. We recommend you install it with
+`PyPI <https://pypi.python.org/pypi>`_ by adding it to your ``requirements.txt``::
+
+   pip install recurly
+
+
+Configuration
+-------------
+
+Set your API key and optionally set a certificate authority certificate file and default currency::
 
    import recurly
 
@@ -52,8 +60,8 @@ be a filename of concatenated certificate authority X.509 certificates:
     $ RECURLY_API_KEY=1274...54e3 RECURLY_CA_CERTS_FILE=/etc/pki/tls/certs/ca-bundle.crt -m unittest tests.test_resources
 
 
-API Documentation
------------------
+Usage
+-----
 
 Please see the `Recurly API <https://dev.recurly.com/docs/getting-started>`_ for more information.
 

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,33 @@ authority certificate file and default currency::
    recurly.DEFAULT_CURRENCY = 'USD'
 
 
+Recurly Python Client Tests
+---------------------------
+
+To run these tests in Python 2.7, use the `unittest` test runner:
+
+    $ python -m unittest discover -s tests
+
+Under Python 2.6 or earlier, install the `unittest2` distribution and use it
+instead:
+
+    $ pip install unittest2  # or easy_install
+    $ python -m unittest2 discover -s tests
+
+The resource tests in `test_resources.py` will run using the HTTP fixtures in
+`tests/fixtures`. To run the tests against a live Recurly API endpoint,
+configure your Recurly test account and use its API key in the
+`RECURLY_API_KEY` environment variable:
+
+    $ RECURLY_API_KEY=1274...54e3 python -m unittest tests.test_resources
+
+The live Recurly API endpoint can also be tested while validating the server
+certificate with the `RECURLY_CA_CERTS_FILE` environment variable, which should
+be a filename of concatenated certificate authority X.509 certificates:
+
+    $ RECURLY_API_KEY=1274...54e3 RECURLY_CA_CERTS_FILE=/etc/pki/tls/certs/ca-bundle.crt -m unittest tests.test_resources
+
+
 API Documentation
 -----------------
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -821,6 +821,7 @@ class Plan(Resource):
         'trial_interval_length',
         'trial_interval_unit',
         'accounting_code',
+        'setup_fee_accounting_code',
         'created_at',
         'tax_exempt',
         'tax_code',

--- a/tests/fixtures/plan/created.xml
+++ b/tests/fixtures/plan/created.xml
@@ -43,6 +43,6 @@ Location: https://api.recurly.com/v2/plans/planmock
     <USD type="integer">1000</USD>
   </unit_amount_in_cents>
   <setup_fee_in_cents>
-    <USD type="integer">0</USD>
+    <USD type="integer">200</USD>
   </setup_fee_in_cents>
 </plan>

--- a/tests/fixtures/plan/updated.xml
+++ b/tests/fixtures/plan/updated.xml
@@ -8,11 +8,12 @@ Content-Type: application/xml; charset=utf-8
 <plan>
   <plan_interval_length type="integer">2</plan_interval_length>
   <plan_interval_unit>months</plan_interval_unit>
+  <setup_fee_accounting_code>Setup Fee AC</setup_fee_accounting_code>
   <unit_amount_in_cents>
     <USD type="integer">2000</USD>
   </unit_amount_in_cents>
   <setup_fee_in_cents>
-    <USD type="integer">0</USD>
+    <USD type="integer">200</USD>
   </setup_fee_in_cents>
 </plan>
 
@@ -37,11 +38,12 @@ Content-Type: application/xml; charset=utf-8
   <plan_interval_unit>months</plan_interval_unit>
   <trial_interval_length type="integer">0</trial_interval_length>
   <trial_interval_unit>days</trial_interval_unit>
+  <setup_fee_accounting_code>Setup Fee AC</setup_fee_accounting_code>
   <created_at type="datetime">2011-10-03T22:23:12Z</created_at>
   <unit_amount_in_cents>
     <USD type="integer">2000</USD>
   </unit_amount_in_cents>
   <setup_fee_in_cents>
-    <USD type="integer">0</USD>
+    <USD type="integer">200</USD>
   </setup_fee_in_cents>
 </plan>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -697,7 +697,8 @@ class TestResources(RecurlyTest):
             plan.plan_interval_length = 2
             plan.plan_interval_unit = 'months'
             plan.unit_amount_in_cents = Money(USD=2000)
-            plan.setup_fee_in_cents = Money(USD=0)
+            plan.setup_fee_in_cents = Money(USD=200)
+            plan.setup_fee_accounting_code = 'Setup Fee AC'
             with self.mock_request('plan/updated.xml'):
                 plan.save()
         finally:


### PR DESCRIPTION
Exposing a `setup_fee_accounting` code to the client library since it's now available.

Also moved tests/README.md to the top level since that's the convention followed in our ruby and php clients (.net has no docs about running tests)