### PR TITLE
Support total billing cycles on Plan

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add `total_billing_cycles` to `Plan`
+
 ## Version 2.2.14 August 10, 2015
 
 - Add `gateway_error_code` to `TransactionError`

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -826,6 +826,7 @@ class Plan(Resource):
         'tax_code',
         'unit_amount_in_cents',
         'setup_fee_in_cents',
+        'total_billing_cycles',
     )
 
     def get_add_on(self, add_on_code):

--- a/tests/fixtures/plan/created.xml
+++ b/tests/fixtures/plan/created.xml
@@ -14,6 +14,7 @@ Content-Type: application/xml; charset=utf-8
   <setup_fee_in_cents>
     <USD type="integer">0</USD>
   </setup_fee_in_cents>
+  <total_billing_cycles type="integer">10</total_billing_cycles>
 </plan>
 
 HTTP/1.1 201 Created
@@ -38,6 +39,7 @@ Location: https://api.recurly.com/v2/plans/planmock
   <plan_interval_unit>months</plan_interval_unit>
   <trial_interval_length type="integer">0</trial_interval_length>
   <trial_interval_unit>days</trial_interval_unit>
+  <total_billing_cycles type="integer">10</total_billing_cycles>
   <created_at type="datetime">2011-10-03T22:23:12Z</created_at>
   <unit_amount_in_cents>
     <USD type="integer">1000</USD>

--- a/tests/fixtures/plan/exists.xml
+++ b/tests/fixtures/plan/exists.xml
@@ -25,6 +25,7 @@ Content-Type: application/xml; charset=utf-8
   <plan_interval_unit>months</plan_interval_unit>
   <trial_interval_length type="integer">0</trial_interval_length>
   <trial_interval_unit>days</trial_interval_unit>
+  <total_billing_cycles type="integer">10</total_billing_cycles>
   <created_at type="datetime">2011-10-03T22:23:12Z</created_at>
   <unit_amount_in_cents>
   </unit_amount_in_cents>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -682,6 +682,7 @@ class TestResources(RecurlyTest):
             name='Mock Plan',
             setup_fee_in_cents=Money(0),
             unit_amount_in_cents=Money(1000),
+            total_billing_cycles=10
         )
         with self.mock_request('plan/created.xml'):
             plan.save()
@@ -693,6 +694,7 @@ class TestResources(RecurlyTest):
                 same_plan = Plan.get(plan_code)
             self.assertEqual(same_plan.plan_code, plan_code)
             self.assertEqual(same_plan.name, 'Mock Plan')
+            self.assertEqual(same_plan.total_billing_cycles, 10)
 
             plan.plan_interval_length = 2
             plan.plan_interval_unit = 'months'


### PR DESCRIPTION
Addresses abandoned PR: https://github.com/recurly/recurly-client-python/pull/112

Approvers: @csmb 

### Testing

```python
from recurly import Money, Plan

plan = Plan(
        plan_code="myplan",
        name="My Plan",
        setup_fee_in_cents=Money(0),
        unit_amount_in_cents=Money(1000),
        total_billing_cycles=10
        )

plan.save()

plan = Plan.get(plan.plan_code)

print plan.total_billing_cycles
# => 10
```