### PR TITLE
Remove forced TLSv1.0

### DIFF
--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -193,8 +193,7 @@ class _ValidatedHTTPSConnection(http_client.HTTPSConnection):
             self._tunnel()
 
         ssl_sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
-            ssl_version=ssl.PROTOCOL_TLSv1, cert_reqs=ssl.CERT_REQUIRED,
-            ca_certs=recurly.CA_CERTS_FILE)
+            cert_reqs=ssl.CERT_REQUIRED, ca_certs=recurly.CA_CERTS_FILE)
 
         # Let the CertificateError for failure be raised to the caller.
         match_hostname(ssl_sock.getpeercert(), self.host)


### PR DESCRIPTION
SSLv3 was previously swapped out for TLS here: https://github.com/recurly/recurly-client-python/pull/92

But this was using TLSv1.0 which is being deprecated in the PCI spec and is showing it's age. For now, it's best to let the client get the protocol from the server.

This affects people who are specifying their cert path.

Script used to test:

```python
from six.moves import http_client
from six.moves.urllib.parse import urlencode, urljoin, urlsplit

import sys, six, socket, ssl

if six.PY3:
    from ssl import match_hostname
else:
    from backports.ssl_match_hostname import match_hostname

class _ValidatedHTTPSConnection(http_client.HTTPSConnection):
    def connect(self):
        socket_timeout = self.timeout
        if sys.version_info < (2, 7):
            sock = socket.create_connection((self.host, self.port),
                                            socket_timeout)
        else:
            sock = socket.create_connection((self.host, self.port),
                                            socket_timeout, self.source_address)

        if self._tunnel_host:
            self.sock = sock
            self._tunnel()

        ssl_sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
            cert_reqs=ssl.CERT_REQUIRED,
            ca_certs= '/usr/local/etc/openssl/cert.pem') # on os x

        # Let the CertificateError for failure be raised to the caller.
        match_hostname(ssl_sock.getpeercert(), self.host)

        self.sock = ssl_sock

urlparts = urlsplit('https://www.howsmyssl.com/a/check')

connection = _ValidatedHTTPSConnection(urlparts.netloc)

connection.request('GET', '/')

print connection.getresponse().read()
```

It hits this url to check the connection: https://www.howsmyssl.com/a/check

With the forced TLS protocol (how it currently works):

```
$ python ssl_test.py | grep -A 5  Version
          <h2>Version</h2>

          <p><span class="label bad">Bad</span> Your client is using
            TLS 1.0, which is very old, possibly susceptible
            to the BEAST attack, and doesn't have the best cipher
            suites available on it. Additions like AES-GCM, and SHA256
```

Without it:

```
$ python ssl_test.py | grep -A 5  Version
          <h2>Version</h2>

          <p><span class="label okay">Good</span> Your client is using
          TLS 1.2, the most modern version of the encryption
          protocol. It gives you access to the fastest, most secure
```

/cc @rmascardo 