### PR TITLE
Correct __str__ behaviour on Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
   - "3.3"
+  - "3.4"
 install:
   - pip install six mock iso8601 backports.ssl-match-hostname --use-mirrors
   - python setup.py install

--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -50,7 +50,7 @@ class ResponseError(Exception):
             return el.text
 
     def __str__(self):
-        return six.text_type(self).encode('utf8')
+        return self.__unicode__()
 
     def __unicode__(self):
         symbol = self.symbol
@@ -85,9 +85,6 @@ class UnauthorizedError(ClientError):
 
     def __init__(self, response_xml):
         self.response_text = response_xml
-
-    def __str__(self):
-        return six.text_type(self).encode('utf-8')
 
     def __unicode__(self):
         return six.text_type(self.response_text)
@@ -154,9 +151,6 @@ class ValidationError(ClientError):
             self.field = field
             self.symbol = symbol
             self.message = message
-
-        def __str__(self):
-            return self.message.encode('utf8')
 
         def __unicode__(self):
             return six.u('%s: %s %s') % (self.symbol, self.field, self.message)

--- a/tests/tests_errors.py
+++ b/tests/tests_errors.py
@@ -1,0 +1,7 @@
+import unittest
+import recurly
+
+class RecurlyExceptionTests(unittest.TestCase):
+    def test_error_printable(self):
+        """ Make sure __str__/__unicode__ works correctly in Python 2/3"""
+        str(recurly.UnauthorizedError('recurly.API_KEY not set'))


### PR DESCRIPTION
On Python 3, calling `str(self)` in def `__str__(self)` causes an infinite loop. I think it's fine to just call out to __unicode__ and return that. Python 2.x versions that still use __str__ are really old right now and not supported by this package anyway.