### PR TITLE
Adding `mark_failed` API call to `Invoice`

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -622,6 +622,10 @@ class Invoice(Resource):
       except AttributeError:
         raise AttributeError("redemption")
 
+    def mark_failed(self):
+        url = urljoin(self._url, '%s/mark_failed' % self.invoice_number)
+        return self.put(url)
+
 class Subscription(Resource):
 
     """A customer account's subscription to your service."""

--- a/tests/fixtures/invoice/failed.xml
+++ b/tests/fixtures/invoice/failed.xml
@@ -1,9 +1,9 @@
-PUT https://api.recurly.com/v2/accounts/invoicemock/invoices/1000/mark_failed HTTP/1.1
+PUT https://api.recurly.com/v2/invoices/1001/mark_failed HTTP/1.1
 X-Api-Version: 2.1
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: recurly-python/{version}
-Content-Length: 0
+Content-Type: application/xml; charset=utf-8
 
 
 HTTP/1.1 200 Updated

--- a/tests/fixtures/invoice/failed.xml
+++ b/tests/fixtures/invoice/failed.xml
@@ -1,0 +1,34 @@
+PUT https://api.recurly.com/v2/accounts/invoicemock/invoices/1000/mark_failed HTTP/1.1
+X-Api-Version: 2.1
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: recurly-python/{version}
+Content-Length: 0
+
+
+HTTP/1.1 200 Updated
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice href="http://api.recurly.com/v2/invoices/1000">
+  <account href="http://api.recurly.com/v2/accounts/csmb"/>
+  <uuid>32a564048f2242acd1d20d4f76afdbe3</uuid>
+  <state>failed</state>
+  <invoice_number_prefix/>
+  <invoice_number type="integer">1000</invoice_number>
+  <po_number/>
+  <vat_number/>
+  <subtotal_in_cents type="integer">10000</subtotal_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <total_in_cents type="integer">10000</total_in_cents>
+  <currency>USD</currency>
+  <created_at type="datetime">2015-11-23T23:06:00Z</created_at>
+  <closed_at type="datetime">2015-11-23T23:06:13Z</closed_at>
+  <terms_and_conditions/>
+  <customer_notes/>
+  <net_terms type="integer">0</net_terms>
+  <collection_method>manual</collection_method>
+  <transactions type="array">
+  </transactions>
+</invoice>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -635,6 +635,20 @@ class TestResources(RecurlyTest):
         self.assertEqual(invoice.terms_and_conditions, 'Some Terms and Conditions')
         self.assertEqual(invoice.customer_notes, 'Some Customer Notes')
 
+    def test_invoice_mark_failed(self):
+        account = Account(account_code='invoice%s' % self.test_id)
+        with self.mock_request('invoice/account-created.xml'):
+            account.save()
+
+        with self.mock_request('invoice/invoiced-with-optionals.xml'):
+            invoice = account.invoice(terms_and_conditions='Some Terms and Conditions',
+                    customer_notes='Some Customer Notes')
+
+        with self.mock_request('invoice/failed.xml'):
+            invoice.mark_failed()
+
+        self.assertEqual(invoice.state, 'failed')
+
     def test_build_invoice(self):
         account = Account(account_code='invoice%s' % self.test_id)
         with self.mock_request('invoice/account-created.xml'):


### PR DESCRIPTION
Adding a missing `mark_failed` API call to `Invoice`.