### PR TITLE
Add Exception when using unicode config vars

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
+## Unreleased
 
+- Add `ConfigurationException` when API_KEY or SUBDOMAIN is unicode
 ## Version 2.2.19 February 22, 2016
 
 - Added `currency` attribute to the `BillingInfo` class

--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -67,7 +67,6 @@ class ClientError(ResponseError):
     is, an error with an HTTP ``4xx`` status code)."""
     pass
 
-
 class BadRequestError(ClientError):
     """An error showing the request was invalid or could not be
     understood by the server.
@@ -78,6 +77,9 @@ class BadRequestError(ClientError):
     """
     pass
 
+class ConfigurationError(Exception):
+    """An error related to a bad configuration"""
+    pass
 
 class UnauthorizedError(ClientError):
 
@@ -256,5 +258,5 @@ def error_class_for_http_status(status):
             return UnexpectedStatusError(status, xml_response)
         return new_status_error
 
-
-__all__ = [x.__name__ for x in error_classes.values()]
+other_errors = [ConfigurationError]
+__all__ = [x.__name__ for x in list(error_classes.values()) + other_errors]

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -230,6 +230,18 @@ class Resource(object):
         respectively.
 
         """
+
+        if recurly.API_KEY is None:
+            raise recurly.UnauthorizedError('recurly.API_KEY not set')
+
+        is_non_ascii = lambda s: any(ord(c) >= 128 for c in s)
+
+        if is_non_ascii(recurly.API_KEY) or is_non_ascii(recurly.SUBDOMAIN):
+            raise recurly.ConfigurationError("""Setting API_KEY or SUBDOMAIN to
+                    unicode strings may cause problems. Please use strings.
+                    Issue described here:
+                    https://gist.github.com/maximehardy/d3a0a6427d2b6791b3dc""")
+
         urlparts = urlsplit(url)
         if urlparts.scheme != 'https':
             connection = http_client.HTTPConnection(urlparts.netloc)
@@ -245,8 +257,6 @@ class Resource(object):
             'User-Agent': recurly.USER_AGENT
         })
         headers['X-Api-Version'] = recurly.api_version()
-        if recurly.API_KEY is None:
-            raise recurly.UnauthorizedError('recurly.API_KEY not set')
         headers['Authorization'] = 'Basic %s' % base64.b64encode(six.b('%s:' % recurly.API_KEY)).decode()
 
         log = logging.getLogger('recurly.http.request')

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -31,6 +31,17 @@ class TestResources(RecurlyTest):
         else:
             self.fail("Updating account with invalid email address did not raise a ValidationError")
 
+    def test_config_string_types(self):
+        recurly.API_KEY = six.u('\xe4 unicode string')
+
+        account_code = 'test%s' % self.test_id
+        try:
+            Account.get(account_code)
+        except recurly.ConfigurationError as exc:
+            pass
+        else:
+            self.fail("Updating account with invalid email address did not raise a ValidationError")
+
     def test_account(self):
         account_code = 'test%s' % self.test_id
         with self.mock_request('account/does-not-exist.xml'):


### PR DESCRIPTION
Throws a `ConfigurationException` when you use unicode for the API_KEY or the SUBDOMAIN.

Addresses: https://github.com/recurly/recurly-client-python/issues/138 