### PR TITLE
Adding collection_method and net_terms attributes for invoice calls

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -514,6 +514,8 @@ class Invoice(Resource):
         'customer_notes',
         'address',
         'closed_at',
+        'collection_method',
+        'net_terms',
     )
 
     blacklist_attributes = (

--- a/tests/fixtures/invoice/invoiced-with-optionals.xml
+++ b/tests/fixtures/invoice/invoiced-with-optionals.xml
@@ -9,6 +9,8 @@ Content-Type: application/xml; charset=utf-8
 <invoice>
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
   <customer_notes>Some Customer Notes</customer_notes>
+  <collection_method>manual</collection_method>
+  <net_terms type="integer">30</net_terms>
 </invoice>
 
 HTTP/1.1 201 Created
@@ -26,6 +28,8 @@ Location: https://api.recurly.com/v2/invoices/4ba1531325014b4f969cd13676f514d8
   </amount_in_cents>
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
   <customer_notes>Some Customer Notes</customer_notes>
+  <collection_method>manual</collection_method>
+  <net_terms type="integer">30</net_terms>
   <start_date type="datetime">2009-11-03T23:27:46-08:00</start_date>
   <end_date type="datetime"></end_date>
   <description>test charge</description>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -629,11 +629,14 @@ class TestResources(RecurlyTest):
 
         with self.mock_request('invoice/invoiced-with-optionals.xml'):
             invoice = account.invoice(terms_and_conditions='Some Terms and Conditions',
-                    customer_notes='Some Customer Notes')
+                    customer_notes='Some Customer Notes', collection_method="manual",
+                    net_terms=30)
 
         self.assertEqual(type(invoice), recurly.Invoice)
         self.assertEqual(invoice.terms_and_conditions, 'Some Terms and Conditions')
         self.assertEqual(invoice.customer_notes, 'Some Customer Notes')
+        self.assertEqual(invoice.collection_method, 'manual')
+        self.assertEqual(invoice.net_terms, 30)
 
     def test_build_invoice(self):
         account = Account(account_code='invoice%s' % self.test_id)


### PR DESCRIPTION
**Description**: `net_terms` and `collection_method` should be included in the invoice call to the API to allow to create manual invoices as well as invoices with different net terms.

**Testing**:
- Run the unit test and make sure all tests pass: `python -m unittest discover -s tests`
- Grab an account, add some charges to it, and generated an invoice given a `collection_method` and `net_terms`:
```
account = recurly.Account.get('test-account')
charge = Adjustment(
   description='Charge for extra bandwidth',
   unit_amount_in_cents=5000,
   currency='USD',
   quantity=1,
   accounting_code='bandwidth',
   tax_exempt=False
)
account.charge(charge)
invoice = account.invoice(collection_method="manual", net_terms=30)
```
- Go to the account on recurly, and ensure net terms is set to 30 and collection method is manual