### PR TITLE
Eliminate AttributeError when trying to print ValidationError in Python 3

### DIFF
--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -181,7 +181,7 @@ class ValidationError(ClientError):
         return suberrors
 
     def __unicode__(self):
-        return six.u('; ').join(six.text_type(error) for error in self.errors.itervalues())
+        return six.u('; ').join(six.text_type(error) for error in six.itervalues(self.errors))
 
 
 class ServerError(ResponseError):

--- a/tests/tests_errors.py
+++ b/tests/tests_errors.py
@@ -5,3 +5,12 @@ class RecurlyExceptionTests(unittest.TestCase):
     def test_error_printable(self):
         """ Make sure __str__/__unicode__ works correctly in Python 2/3"""
         str(recurly.UnauthorizedError('recurly.API_KEY not set'))
+
+    def test_validationerror_printable(self):
+        """ Make sure __str__/__unicode__ works correctly in Python 2/3"""
+        error = recurly.ValidationError.Suberror('field', 'symbol', 'message')
+        suberrors = dict()
+        suberrors['field'] = error
+        validation_error = recurly.ValidationError('')
+        validation_error.__dict__['errors'] = suberrors
+        str(validation_error)


### PR DESCRIPTION
Resolves the issue I raised here: #146. The diff is small, but you can see the fix is just changing a call on `dict.itervalues()` to use six's `six.itervalues(dict)`. I've also included a test for this. 