### PR TITLE
Remove delete_url method on Redemption

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add the python version to the user agent string
+- Fix the `delete_url` on the Redemption class by removing the override
 
 ## Version 2.2.17 October 2, 2015
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -425,10 +425,6 @@ class Redemption(Resource):
         'created_at',
     )
 
-    def delete_url(self):
-      return self._url + "s/" + self.uuid
-
-
 class TaxDetail(Resource):
 
     """A charge's tax breakdown"""

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -665,14 +665,9 @@ class Resource(object):
     def delete(self):
         """Submits a deletion request for this `Resource` instance as
         a ``DELETE`` request to its URL."""
-        url = self.delete_url()
-
-        response = self.http_request(url, 'DELETE')
+        response = self.http_request(self._url, 'DELETE')
         if response.status != 204:
             self.raise_http_error(response)
-
-    def delete_url(self):
-      return self._url
 
     @classmethod
     def raise_http_error(cls, response):

--- a/tests/fixtures/coupon/redeemed.xml
+++ b/tests/fixtures/coupon/redeemed.xml
@@ -16,7 +16,7 @@ Content-Type: application/xml; charset=utf-8
 Location: https://api.recurly.com/v2/accounts/couponmock/redemption
 
 <?xml version="1.0" encoding="UTF-8"?>
-<redemption href="https://api.recurly.com/v2/accounts/couponmock/redemption">
+<redemption href="https://api.recurly.com/v2/accounts/couponmock/redemptions/301bc7686bc4b4bb383f9e4218acaac5">
   <coupon href="https://api.recurly.com/v2/coupons/couponmock"/>
   <account href="https://api.recurly.com/v2/accounts/couponmock"/>
   <uuid>301bc7686bc4b4bb383f9e4218acaac5</uuid>

--- a/tests/fixtures/coupon/redemption-exists.xml
+++ b/tests/fixtures/coupon/redemption-exists.xml
@@ -10,10 +10,10 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <redemptions type="array">
-  <redemption href="https://api.recurly.com/v2/accounts/couponmock/redemption">
+  <redemption href="https://api.recurly.com/v2/accounts/couponmock/redemptions/301bc7686bc4b4bb383f9e4218acaac5">
     <coupon href="https://api.recurly.com/v2/coupons/couponmock"/>
     <account href="https://api.recurly.com/v2/accounts/couponmock"/>
-    <uuid>301bbdaa33b891b2dee54f4c84994abc</uuid>
+    <uuid>301bc7686bc4b4bb383f9e4218acaac5</uuid>
     <single_use type="boolean">false</single_use>
     <total_discounted_in_cents type="integer">0</total_discounted_in_cents>
     <currency>USD</currency>


### PR DESCRIPTION
Fixes Issue https://github.com/recurly/recurly-client-python/issues/143

It appears this method was added as a workaround which was resolved in the API.

To test:

```python
# get an account with an active redemption
account = recurly.Account.get('my_account_code')

# get first redemption
redemption = account.redemption()

# should succeed and you should see the redemption was expired on the account
redemption.delete()
```

\cc @priitlatt
\cc @shulmang 