### PR TITLE
Support cc_emails on Account class

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 - Add the python version to the user agent string
 - Fix the `delete_url` on the Redemption class by removing the override
+- Add support for `cc_emails` attribute in `Account` class
 
 ## Version 2.2.17 October 2, 2015
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -91,6 +91,7 @@ class Account(Resource):
         'tax_exempt',
         'entity_use_code',
         'accept_language',
+        'cc_emails',
         'created_at',
     )
 

--- a/tests/fixtures/account/created.xml
+++ b/tests/fixtures/account/created.xml
@@ -29,6 +29,7 @@ Location: https://api.recurly.com/v2/accounts/testmock
   <last_name nil="nil"></last_name>
   <company_name nil="nil"></company_name>
   <vat_number>444444-UK</vat_number>
+  <cc_emails>test1@example.com,test2@example.com</cc_emails>
   <address>
     <address1>123 Main St</address1>
     <address2 nil="nil"></address2>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -43,6 +43,8 @@ class TestResources(RecurlyTest):
         self.assertEqual(account._url, urljoin(recurly.base_uri(), 'accounts/%s' % account_code))
         self.assertEqual(account.vat_number, '444444-UK')
         self.assertEqual(account.vat_location_enabled, True)
+        self.assertEqual(account.cc_emails,
+                'test1@example.com,test2@example.com')
 
         with self.mock_request('account/list-active.xml'):
             active = Account.all_active()


### PR DESCRIPTION
Adds support for `cc_emails` on the account class. You should be able to set and retrieve this as a string.

### Testing

```python
import recurly

# Set and save the attribute
account = recurly.Account.get('benjamin')
account.cc_emails = 'test1@example.com,test2@example.com'
account.save()

# Fetch again
account = recurly.Account.get('benjamin')
print account.cc_emails # should print out emails
``` 

Approvers: @csmb 