### PR TITLE
Add currency to BillingInfo

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -301,6 +301,7 @@ class BillingInfo(Resource):
         'account_type',
         'routing_number',
         'account_number',
+        'currency',
     )
     sensitive_attributes = ('number', 'verification_value', 'account_number')
     xml_attribute_attributes = ('type',)

--- a/tests/fixtures/billing-info/account-embed-created.xml
+++ b/tests/fixtures/billing-info/account-embed-created.xml
@@ -20,6 +20,7 @@ Content-Type: application/xml; charset=utf-8
     <state>CA</state>
     <zip>94105</zip>
     <country>US</country>
+    <currency>USD</currency>
   </billing_info>
 </account>
 

--- a/tests/fixtures/billing-info/account-embed-token.xml
+++ b/tests/fixtures/billing-info/account-embed-token.xml
@@ -10,6 +10,7 @@ Content-Type: application/xml; charset=utf-8
   <account_code>binfo-mock-3</account_code>
   <billing_info>
     <token_id>abc123</token_id>
+    <currency>USD</currency>
   </billing_info>
 </account>
 

--- a/tests/fixtures/billing-info/created.xml
+++ b/tests/fixtures/billing-info/created.xml
@@ -18,6 +18,7 @@ Content-Type: application/xml; charset=utf-8
   <state>CA</state>
   <zip>94105</zip>
   <country>US</country>
+  <currency>USD</currency>
 </billing_info>
 
 HTTP/1.1 201 Created
@@ -38,4 +39,5 @@ Location: https://api.recurly.com/v2/accounts/binfomock/billing_info
   <month type="integer">12</month>
   <first_six>411111</first_six>
   <last_four>1111</last_four>
+  <currency>USD</currency>
 </billing_info>

--- a/tests/fixtures/billing-info/embedded-exists.xml
+++ b/tests/fixtures/billing-info/embedded-exists.xml
@@ -20,4 +20,5 @@ Content-Type: application/xml; charset=utf-8
   <card_type>visa</card_type>
   <first_six>411111</first_six>
   <last_four>1111</last_four>
+  <currency>USD</currency>
 </billing_info>

--- a/tests/fixtures/coupon/subscribed.xml
+++ b/tests/fixtures/coupon/subscribed.xml
@@ -24,6 +24,7 @@ Content-Type: application/xml; charset=utf-8
       <state>CA</state>
       <zip>94105</zip>
       <country>US</country>
+      <currency>USD</currency>
     </billing_info>
   </account>
 </subscription>

--- a/tests/fixtures/subscribe-add-on/subscribed.xml
+++ b/tests/fixtures/subscribe-add-on/subscribed.xml
@@ -31,6 +31,7 @@ Content-Type: application/xml; charset=utf-8
       <state>CA</state>
       <zip>94105</zip>
       <country>US</country>
+      <currency>USD</currency>
     </billing_info>
   </account>
 </subscription>

--- a/tests/fixtures/subscription/subscribe-embedded-account.xml
+++ b/tests/fixtures/subscription/subscribe-embedded-account.xml
@@ -23,6 +23,7 @@ Content-Type: application/xml; charset=utf-8
       <state>CA</state>
       <zip>94105</zip>
       <country>US</country>
+      <currency>USD</currency>
     </billing_info>
   </account>
 </subscription>

--- a/tests/fixtures/subscription/subscribed-billing-info.xml
+++ b/tests/fixtures/subscription/subscribed-billing-info.xml
@@ -23,6 +23,7 @@ Content-Type: application/xml; charset=utf-8
       <state>CA</state>
       <zip>94105</zip>
       <country>US</country>
+      <currency>USD</currency>
     </billing_info>
   </account>
 </subscription>

--- a/tests/fixtures/subscription/update-billing-info.xml
+++ b/tests/fixtures/subscription/update-billing-info.xml
@@ -18,6 +18,7 @@ Content-Type: application/xml; charset=utf-8
   <state>CA</state>
   <zip>94105</zip>
   <country>US</country>
+  <currency>USD</currency>
 </billing_info>
 
 HTTP/1.1 201 Created
@@ -38,4 +39,5 @@ Location: https://api.recurly.com/v2/accounts/subscribemock/billing_info
   <month type="integer">12</month>
   <first_six>411111</first_six>
   <last_four>1111</last_four>
+  <currency>USD</currency>
 </billing_info>

--- a/tests/fixtures/transaction-balance/set-billing-info.xml
+++ b/tests/fixtures/transaction-balance/set-billing-info.xml
@@ -18,6 +18,7 @@ Content-Type: application/xml; charset=utf-8
   <state>CA</state>
   <zip>94105</zip>
   <country>US</country>
+  <currency>USD</currency>
 </billing_info>
 
 HTTP/1.1 201 Created
@@ -38,4 +39,5 @@ Location: https://api.recurly.com/v2/accounts/transbalancemock/billing_info
   <month type="integer">12</month>
   <first_six>411111</first_six>
   <last_four>1111</last_four>
+  <currency>USD</currency>
 </billing_info>

--- a/tests/fixtures/transaction/created.xml
+++ b/tests/fixtures/transaction/created.xml
@@ -21,6 +21,7 @@ Content-Type: application/xml; charset=utf-8
       <state>CA</state>
       <zip>94105</zip>
       <country>US</country>
+      <currency>USD</currency>
     </billing_info>
   </account>
   <currency>USD</currency>


### PR DESCRIPTION
This allows the merchant to send a custom currency on billing info creation and update for verification purposes. For instance, if your site default is USD and you are trying to verify for EUR, you may end up 
having two verifications.

### Testing

```python
account = Account.get('benjamin')

billing_info = BillingInfo()

billing_info.first_name = 'Verena'
billing_info.last_name = 'Example'
billing_info.number = '4111-1111-1111-1111'
billing_info.verification_value = '123'
billing_info.month = 11
billing_info.year = 2019
billing_info.currency = 'EUR'

account.update_billing_info(billing_info)

```