### PR TITLE
Update symbol property on ResponseError class

### DIFF
--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -27,6 +27,12 @@ class ResponseError(Exception):
         if el is not None:
             return el.text
 
+        # If a symbol element doesn't exist, return the symbol attribute
+        # of the first found error node
+        err = self.response_doc.find('error')
+        if err is not None:
+            return err.get('symbol')
+
     @property
     def message(self):
         """The human-readable description of the error."""

--- a/tests/fixtures/transaction/declined-transaction.xml
+++ b/tests/fixtures/transaction/declined-transaction.xml
@@ -1,4 +1,5 @@
 POST https://api.recurly.com/v2/transactions HTTP/1.1
+X-Api-Version: 2.1
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}
@@ -17,10 +18,15 @@ HTTP/1.1 422
 Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
-<transaction_error>
-  <error_code>insufficient_funds</error_code>
-  <error_category>soft</error_category>
-  <customer_message lang="en-US">The transaction was declined due to insufficient funds in your account. Please use a different card or contact your bank.</customer_message>
-  <merchant_message lang="en-US">The card has insufficient funds to cover the cost of the transaction.</merchant_message>
-  <gateway_error_code>123</gateway_error_code>
-</transaction_error>
+<errors>
+  <error field="subscription.account.base" symbol="declined">
+    The transaction was declined due to insufficient funds in your account. Please use a different card or contact your bank.
+  </error>
+  <transaction_error>
+    <error_code>insufficient_funds</error_code>
+    <error_category>soft</error_category>
+    <customer_message lang="en-US">The transaction was declined due to insufficient funds in your account. Please use a different card or contact your bank.</customer_message>
+    <merchant_message lang="en-US">The card has insufficient funds to cover the cost of the transaction.</merchant_message>
+    <gateway_error_code>123</gateway_error_code>
+  </transaction_error>
+</errors>

--- a/tests/tests_errors.py
+++ b/tests/tests_errors.py
@@ -1,7 +1,8 @@
-import unittest
 import recurly
+from recurly import Account, Transaction, ValidationError
+from recurlytests import RecurlyTest
 
-class RecurlyExceptionTests(unittest.TestCase):
+class RecurlyExceptionTests(RecurlyTest):
     def test_error_printable(self):
         """ Make sure __str__/__unicode__ works correctly in Python 2/3"""
         str(recurly.UnauthorizedError('recurly.API_KEY not set'))
@@ -14,3 +15,22 @@ class RecurlyExceptionTests(unittest.TestCase):
         validation_error = recurly.ValidationError('')
         validation_error.__dict__['errors'] = suberrors
         str(validation_error)
+
+    def test_symbol_property(self):
+        """ Test ResponseError class 'symbol' property"""
+        transaction = Transaction(
+            amount_in_cents=1000,
+            currency='USD',
+            account=Account(
+                account_code='transactionmock'
+            )
+        )
+
+        # Mock 'save transaction' request to throw declined
+        # transaction validation error
+        with self.mock_request('transaction/declined-transaction.xml'):
+            try:
+                transaction.save()
+            except ValidationError as e:
+                error = e
+        self.assertEqual(error.symbol, 'declined')


### PR DESCRIPTION
This updates the `symbol` property on the `ResponseError` class to use the symbol attribute of the first error subelement so we can easily determine the error type returned by the Recurly API.

Reasoning: We want to maintain a dictionary of our own error messages so they can be translated into multiple languages - using the error symbol as a lookup key provides a quick and efficient way to do this.