### PR TITLE
Add transaction_error_code property to ValidationError class

### DIFF
--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -144,6 +144,15 @@ class ValidationError(ClientError):
     """An error indicating some values in the submitted request body
     were not valid."""
 
+    @property
+    def transaction_error_code(self):
+        """The machine-readable error code for a transaction error."""
+        error = self.response_doc.find('transaction_error')
+        if error is not None:
+            code = error.find('error_code')
+            if code is not None:
+                return code.text
+
     class Suberror(object):
 
         """An error describing the invalidity of a single invalid

--- a/tests/fixtures/transaction/declined-transaction.xml
+++ b/tests/fixtures/transaction/declined-transaction.xml
@@ -1,4 +1,5 @@
 POST https://api.recurly.com/v2/transactions HTTP/1.1
+X-Api-Version: 2.1
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}
@@ -17,10 +18,12 @@ HTTP/1.1 422
 Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
-<transaction_error>
-  <error_code>insufficient_funds</error_code>
-  <error_category>soft</error_category>
-  <customer_message lang="en-US">The transaction was declined due to insufficient funds in your account. Please use a different card or contact your bank.</customer_message>
-  <merchant_message lang="en-US">The card has insufficient funds to cover the cost of the transaction.</merchant_message>
-  <gateway_error_code>123</gateway_error_code>
-</transaction_error>
+<errors>
+  <transaction_error>
+    <error_code>insufficient_funds</error_code>
+    <error_category>soft</error_category>
+    <customer_message lang="en-US">The transaction was declined due to insufficient funds in your account. Please use a different card or contact your bank.</customer_message>
+    <merchant_message lang="en-US">The card has insufficient funds to cover the cost of the transaction.</merchant_message>
+    <gateway_error_code>123</gateway_error_code>
+  </transaction_error>
+</errors>

--- a/tests/tests_errors.py
+++ b/tests/tests_errors.py
@@ -1,7 +1,8 @@
-import unittest
 import recurly
+from recurly import Account, Transaction, ValidationError
+from recurlytests import RecurlyTest
 
-class RecurlyExceptionTests(unittest.TestCase):
+class RecurlyExceptionTests(RecurlyTest):
     def test_error_printable(self):
         """ Make sure __str__/__unicode__ works correctly in Python 2/3"""
         str(recurly.UnauthorizedError('recurly.API_KEY not set'))
@@ -14,3 +15,22 @@ class RecurlyExceptionTests(unittest.TestCase):
         validation_error = recurly.ValidationError('')
         validation_error.__dict__['errors'] = suberrors
         str(validation_error)
+
+    def test_transaction_error_code_property(self):
+        """ Test ValidationError class 'transaction_error_code' property"""
+        transaction = Transaction(
+            amount_in_cents=1000,
+            currency='USD',
+            account=Account(
+                account_code='transactionmock'
+            )
+        )
+
+        # Mock 'save transaction' request to throw declined
+        # transaction validation error
+        with self.mock_request('transaction/declined-transaction.xml'):
+            try:
+                transaction.save()
+            except ValidationError as e:
+                error = e
+        self.assertEqual(error.transaction_error_code, 'insufficient_funds')


### PR DESCRIPTION
This adds the `transaction_error_code` property to the `ValidationError` class so we can easily determine the error type for transaction errors returned by the Recurly API.

Reasoning: We want to maintain a dictionary of our own error messages so they can be translated into multiple languages - using the error_code as a lookup key provides a quick and efficient way to do this.