### PR TITLE
[SUPPORTENG-1140] Python library Free Trial Coupons

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -339,6 +339,8 @@ class Coupon(Resource):
         'coupon_type',
         'unique_code_template',
         'unique_coupon_codes',
+        'free_trial_unit',
+        'free_trial_amount',
     )
 
     @classmethod


### PR DESCRIPTION
__Description:__
Recurly added free trial coupons to the UI and API and the python library does not support the needed attributes

__Impact:__
Merchants will be able to add these coupons through the api, and redeem free trial coupons on new subscriptions using the python client library

__testing:__

- create a new free trial coupon
```
# example - note discount_type, free_trial_unit and free_trial_amount
coupon = Coupon(coupon_code='testing')
coupon.name = 'testing'
coupon.discount_type = 'free_trial'
coupon.coupon_type = 'single_code'
coupon.free_trial_unit = 'day'
coupon.free_trial_amount = 14
coupon.max_redemptions_per_account = 1
coupon.duration = 'single_use'
coupon.save()
```
- create a new subscription with that coupon
- confirm in get list of coupons
- confirm put (e.g. name)
- confirm delete
