### PR TITLE
Parse fraud info if available

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -751,6 +751,12 @@ class TransactionError(recurly.Resource):
         'gateway_error_code',
     )
 
+class TransactionFraudInfo(recurly.Resource):
+    node_name = 'fraud'
+    attributes = (
+        'score',
+        'decision',
+    )
 
 class Transaction(Resource):
 
@@ -786,11 +792,13 @@ class Transaction(Resource):
         'tax_exempt',
         'tax_code',
         'accounting_code',
+        'fraud',
     )
     xml_attribute_attributes = ('type',)
     sensitive_attributes = ('number', 'verification_value',)
     _classes_for_nodename = {
         'details': TransactionDetails,
+        'fraud': TransactionFraudInfo,
         'transaction_error': TransactionError
     }
 

--- a/tests/fixtures/transaction/created.xml
+++ b/tests/fixtures/transaction/created.xml
@@ -78,5 +78,9 @@ Location: https://api.recurly.com/v2/transactions/123456789012345678901234567890
       </billing_info>
     </account>
   </details>
+  <fraud>
+    <score type="integer">88</score>
+    <decision>DECLINED</decision>
+  </fraud>
   <a name="refund" href="https://api.recurly.com/v2/transactions/123456789012345678901234567890ab" method="delete"/>
 </transaction>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1093,6 +1093,10 @@ class TestResources(RecurlyTest):
         with self.mock_request('transaction/created.xml'):
             transaction.save()
 
+        fraud_info = transaction.fraud
+        self.assertEquals(fraud_info.score, 88)
+        self.assertEquals(fraud_info.decision, 'DECLINED')
+
         logger.removeHandler(log_handler)
 
         try:


### PR DESCRIPTION
If it's available, the transaction may contain a fraud object with some fraud information. 

Ruby PR: https://github.com/recurly/recurly-client-ruby/pull/244