### PR TITLE
Bump 2.2.20

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,16 @@
 ## Unreleased
 
+## Version 2.2.20 May 23, 2016
+
 - Add `ConfigurationException` when API_KEY or SUBDOMAIN is unicode
+- Add transaction_error_code property to ValidationError class
+- Fix apply timeout to connection object
+- Add python 3.5 to travis tests
+- Add fraud info if available on `Transaction`
+- Add Usage Based Billing
+- Add generator comprehensions in js module
+- Add Free Trial Coupons
+
 ## Version 2.2.19 February 22, 2016
 
 - Added `currency` attribute to the `BillingInfo` class

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -19,7 +19,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.2.19'
+__version__ = '2.2.20'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 USER_AGENT = 'recurly-python/%s; python %s' % (recurly.__version__, recurly.__python_version__)


### PR DESCRIPTION
Bumping to version 2.2.20

- https://github.com/recurly/recurly-client-python/pull/166
- https://github.com/recurly/recurly-client-python/pull/165
- https://github.com/recurly/recurly-client-python/pull/164
- https://github.com/recurly/recurly-client-python/pull/161
- https://github.com/recurly/recurly-client-python/pull/160
- https://github.com/recurly/recurly-client-python/pull/159
- https://github.com/recurly/recurly-client-python/pull/158