### PR TITLE
Adding collection_path to MeasuredUnit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Adding `collection_path` to `MeasuredUnit`
+
 ## Version 2.2.20 May 23, 2016
 
 - Add `ConfigurationException` when API_KEY or SUBDOMAIN is unicode

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -938,6 +938,7 @@ class MeasuredUnit(Resource):
 
     nodename = 'measured_unit'
     member_path = 'measured_units/%s'
+    collection_path = 'measured_units'
 
     attributes = (
         'id',


### PR DESCRIPTION
Listing and Creating `MeasuredUnit` now supported. Adding `collection_path` to support those operations.