### PR TITLE
API version 2.3

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -33,7 +33,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.2'
+API_VERSION = '2.3'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None
@@ -70,6 +70,16 @@ class Address(Resource):
         'phone',
     )
 
+class AccountBalance(Resource):
+
+    """The Balance on an account"""
+
+    nodename = 'account_balance'
+
+    attributes = (
+        'balance_in_cents',
+        'past_due',
+    )
 
 class Account(Resource):
 
@@ -92,10 +102,11 @@ class Account(Resource):
         'entity_use_code',
         'accept_language',
         'cc_emails',
+        'account_balance',
         'created_at',
     )
 
-    _classes_for_nodename = {'address': Address}
+    _classes_for_nodename = { 'address': Address }
 
     sensitive_attributes = ('number', 'verification_value',)
 
@@ -470,6 +481,7 @@ class Adjustment(Resource):
         'end_date',
         'created_at',
         'type',
+        'revenue_schedule_type',
     )
     xml_attribute_attributes = ('type',)
     _classes_for_nodename = {'tax_detail': TaxDetail,}
@@ -672,6 +684,7 @@ class Subscription(Resource):
         'vat_reverse_charge_notes',
         'bank_account_authorized_at',
         'redemptions',
+        'evenue_schedule_type',
     )
     sensitive_attributes = ('number', 'verification_value', 'bulk')
 
@@ -801,6 +814,7 @@ class Transaction(Resource):
         'tax_code',
         'accounting_code',
         'fraud',
+        'original_transaction',
     )
     xml_attribute_attributes = ('type',)
     sensitive_attributes = ('number', 'verification_value',)
@@ -898,6 +912,8 @@ class Plan(Resource):
         'unit_amount_in_cents',
         'setup_fee_in_cents',
         'total_billing_cycles',
+        'revenue_schedule_type',
+        'setup_fee_revenue_schedule_type',
     )
 
     def get_add_on(self, add_on_code):
@@ -966,6 +982,7 @@ class AddOn(Resource):
         'usage_type',
         'add_on_type',
         'tax_code',
+        'revenue_schedule_type',
         'created_at',
     )
 

--- a/tests/fixtures/account-balance/exists.xml
+++ b/tests/fixtures/account-balance/exists.xml
@@ -1,0 +1,19 @@
+GET https://api.recurly.com/v2/accounts/testmock/balance HTTP/1.1
+X-Api-Version: 2.3
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account_balance href="https://api.recurly.com/v2/accounts/testmock/balance">
+    <account href="https://api.recurly.com/v2/accounts/testmock"/>
+    <past_due type="boolean">true</past_due>
+    <balance_in_cents>
+        <USD type="integer">2910</USD>
+        <EUR type="integer">-520</EUR>
+    </balance_in_cents>
+</account_balance>

--- a/tests/fixtures/account-notes/account1-created.xml
+++ b/tests/fixtures/account-notes/account1-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account-notes/account1-deleted.xml
+++ b/tests/fixtures/account-notes/account1-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/notemock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account-notes/account1-note-list.xml
+++ b/tests/fixtures/account-notes/account1-note-list.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/notemock/notes HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account-notes/account2-created.xml
+++ b/tests/fixtures/account-notes/account2-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account-notes/account2-deleted.xml
+++ b/tests/fixtures/account-notes/account2-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/notemock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account-notes/account2-note-list.xml
+++ b/tests/fixtures/account-notes/account2-note-list.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/notemock/notes HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/created-with-address.xml
+++ b/tests/fixtures/account/created-with-address.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/created.xml
+++ b/tests/fixtures/account/created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/deleted.xml
+++ b/tests/fixtures/account/deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/testmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/does-not-exist.xml
+++ b/tests/fixtures/account/does-not-exist.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/testmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/exists.xml
+++ b/tests/fixtures/account/exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/testmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}
@@ -15,6 +15,7 @@ Content-Type: application/xml; charset=utf-8
   <invoices href="https://api.recurly.com/v2/accounts/testmock/invoices"/>
   <subscriptions href="https://api.recurly.com/v2/accounts/testmock/subscriptions"/>
   <transactions href="https://api.recurly.com/v2/accounts/testmock/transactions"/>
+  <account_balance href="https://api.recurly.com/v2/accounts/testmock/balance"/>
   <account_code>testmock</account_code>
   <username nil="nil"></username>
   <email nil="nil"></email>

--- a/tests/fixtures/account/list-active-when-closed.xml
+++ b/tests/fixtures/account/list-active-when-closed.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts?state=active HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/list-active.xml
+++ b/tests/fixtures/account/list-active.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts?state=active HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/list-closed.xml
+++ b/tests/fixtures/account/list-closed.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts?state=closed HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/numeric-created.xml
+++ b/tests/fixtures/account/numeric-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/numeric-deleted.xml
+++ b/tests/fixtures/account/numeric-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/58 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/reopened.xml
+++ b/tests/fixtures/account/reopened.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/accounts/testmock/reopen HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/show-taxed.xml
+++ b/tests/fixtures/account/show-taxed.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/testmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/update-bad-email.xml
+++ b/tests/fixtures/account/update-bad-email.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/accounts/testmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/account/updated.xml
+++ b/tests/fixtures/account/updated.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/accounts/testmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/add-on/created.xml
+++ b/tests/fixtures/add-on/created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/plans/planmock/add_ons HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/add-on/deleted.xml
+++ b/tests/fixtures/add-on/deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/plans/planmock/add_ons/addonmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/add-on/exists.xml
+++ b/tests/fixtures/add-on/exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/plans/planmock/add_ons/addonmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/add-on/need-amount.xml
+++ b/tests/fixtures/add-on/need-amount.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/plans/planmock/add_ons HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/add-on/plan-created.xml
+++ b/tests/fixtures/add-on/plan-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/plans HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/add-on/plan-deleted.xml
+++ b/tests/fixtures/add-on/plan-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/plans/planmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/adjustment/account-created.xml
+++ b/tests/fixtures/adjustment/account-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/adjustment/account-deleted.xml
+++ b/tests/fixtures/adjustment/account-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/chargemock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/adjustment/account-has-adjustments.xml
+++ b/tests/fixtures/adjustment/account-has-adjustments.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/chargemock/adjustments HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/adjustment/account-has-charges.xml
+++ b/tests/fixtures/adjustment/account-has-charges.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/chargemock/adjustments?type=charge HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/adjustment/account-has-no-charges.xml
+++ b/tests/fixtures/adjustment/account-has-no-charges.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/chargemock/adjustments HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/adjustment/account-has-no-credits.xml
+++ b/tests/fixtures/adjustment/account-has-no-credits.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/chargemock/adjustments?type=credit HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/adjustment/charged.xml
+++ b/tests/fixtures/adjustment/charged.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/chargemock/adjustments HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/adjustment/original-adjustment-lookup.xml
+++ b/tests/fixtures/adjustment/original-adjustment-lookup.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/adjustments/2bd3381e9ffb7fddc18128454d835e83 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/adjustment/original-adjustment-uuid.xml
+++ b/tests/fixtures/adjustment/original-adjustment-uuid.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/adjustments/2c06b94abe047189b225d94dd0adb71f HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/adjustment/original-adjustment.xml
+++ b/tests/fixtures/adjustment/original-adjustment.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/adjustments/2c06b94abe047189b225d94dd0adb71f HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/adjustment/show-taxed.xml
+++ b/tests/fixtures/adjustment/show-taxed.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/chargemock/adjustments HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/authentication/unauthenticated.xml
+++ b/tests/fixtures/authentication/unauthenticated.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/testmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 User-Agent: {user-agent}
 

--- a/tests/fixtures/billing-info/account-created.xml
+++ b/tests/fixtures/billing-info/account-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/billing-info/account-deleted.xml
+++ b/tests/fixtures/billing-info/account-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/binfomock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/billing-info/account-embed-created.xml
+++ b/tests/fixtures/billing-info/account-embed-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/billing-info/account-embed-deleted.xml
+++ b/tests/fixtures/billing-info/account-embed-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/binfo-mock-2 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/billing-info/account-embed-exists.xml
+++ b/tests/fixtures/billing-info/account-embed-exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/binfo-mock-2 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/billing-info/account-embed-token.xml
+++ b/tests/fixtures/billing-info/account-embed-token.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/billing-info/account-exists.xml
+++ b/tests/fixtures/billing-info/account-exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/binfomock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/billing-info/created.xml
+++ b/tests/fixtures/billing-info/created.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/accounts/binfomock/billing_info HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/billing-info/deleted.xml
+++ b/tests/fixtures/billing-info/deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/binfomock/billing_info HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/billing-info/embedded-exists.xml
+++ b/tests/fixtures/billing-info/embedded-exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/binfo-mock-2/billing_info HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/billing-info/exists.xml
+++ b/tests/fixtures/billing-info/exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/binfomock/billing_info HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/account-created.xml
+++ b/tests/fixtures/coupon/account-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/account-deleted.xml
+++ b/tests/fixtures/coupon/account-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/couponmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/account-with-redemption.xml
+++ b/tests/fixtures/coupon/account-with-redemption.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/couponmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/created.xml
+++ b/tests/fixtures/coupon/created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/coupons HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/deleted.xml
+++ b/tests/fixtures/coupon/deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/coupons/couponmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/does-not-exist.xml
+++ b/tests/fixtures/coupon/does-not-exist.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/coupons/couponmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/exists.xml
+++ b/tests/fixtures/coupon/exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/coupons/couponmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/plan-coupon-created.xml
+++ b/tests/fixtures/coupon/plan-coupon-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/coupons HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/plan-coupon-deleted.xml
+++ b/tests/fixtures/coupon/plan-coupon-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/coupons/plancouponmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/plan-created.xml
+++ b/tests/fixtures/coupon/plan-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/plans HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/plan-deleted.xml
+++ b/tests/fixtures/coupon/plan-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/plans/basicplan HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/redeemed.xml
+++ b/tests/fixtures/coupon/redeemed.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/coupons/couponmock/redeem HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/redemption-exists.xml
+++ b/tests/fixtures/coupon/redemption-exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/couponmock/redemptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/restored.xml
+++ b/tests/fixtures/coupon/restored.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/coupons/couponmock/restore HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/second-account-deleted.xml
+++ b/tests/fixtures/coupon/second-account-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/coupon-mock-2 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/second-account-exists.xml
+++ b/tests/fixtures/coupon/second-account-exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/coupon-mock-2 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/second-account-redemption.xml
+++ b/tests/fixtures/coupon/second-account-redemption.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/coupon-mock-2/redemptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/subscribed.xml
+++ b/tests/fixtures/coupon/subscribed.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/subscriptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/unredeemed.xml
+++ b/tests/fixtures/coupon/unredeemed.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/couponmock/redemptions/301bc7686bc4b4bb383f9e4218acaac5 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/coupon/updated.xml
+++ b/tests/fixtures/coupon/updated.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/coupons/couponmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/account-created.xml
+++ b/tests/fixtures/invoice/account-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/account-deleted.xml
+++ b/tests/fixtures/invoice/account-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/invoicemock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/account-has-invoices.xml
+++ b/tests/fixtures/invoice/account-has-invoices.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/invoicemock/invoices HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/account-has-no-invoices.xml
+++ b/tests/fixtures/invoice/account-has-no-invoices.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/invoicemock/invoices HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/charged.xml
+++ b/tests/fixtures/invoice/charged.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/invoicemock/adjustments HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/error-no-charges.xml
+++ b/tests/fixtures/invoice/error-no-charges.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/invoicemock/invoices HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/invoiced-line-items.xml
+++ b/tests/fixtures/invoice/invoiced-line-items.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/invoicemock/invoices HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/invoiced-with-optionals.xml
+++ b/tests/fixtures/invoice/invoiced-with-optionals.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/invoicemock/invoices HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/invoiced.xml
+++ b/tests/fixtures/invoice/invoiced.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/invoicemock/invoices HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/line-item-refunded.xml
+++ b/tests/fixtures/invoice/line-item-refunded.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/invoices/1001/refund HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/preview-error-no-charges.xml
+++ b/tests/fixtures/invoice/preview-error-no-charges.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/invoicemock/invoices/preview HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/preview-invoice.xml
+++ b/tests/fixtures/invoice/preview-invoice.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/invoicemock/invoices/preview HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/refunded.xml
+++ b/tests/fixtures/invoice/refunded.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/invoices/1001/refund HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/show-taxed.xml
+++ b/tests/fixtures/invoice/show-taxed.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/invoicemock/invoices HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/invoice/show-with-prefix.xml
+++ b/tests/fixtures/invoice/show-with-prefix.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/invoicemock/invoices HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/measured-units/exists.xml
+++ b/tests/fixtures/measured-units/exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/measured_units/123456 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-1-created.xml
+++ b/tests/fixtures/pages/account-1-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-1-deleted.xml
+++ b/tests/fixtures/pages/account-1-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/pages-mock-1 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-2-created.xml
+++ b/tests/fixtures/pages/account-2-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-2-deleted.xml
+++ b/tests/fixtures/pages/account-2-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/pages-mock-2 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-3-created.xml
+++ b/tests/fixtures/pages/account-3-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-3-deleted.xml
+++ b/tests/fixtures/pages/account-3-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/pages-mock-3 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-4-created.xml
+++ b/tests/fixtures/pages/account-4-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-4-deleted.xml
+++ b/tests/fixtures/pages/account-4-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/pages-mock-4 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-5-created.xml
+++ b/tests/fixtures/pages/account-5-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-5-deleted.xml
+++ b/tests/fixtures/pages/account-5-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/pages-mock-5 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-6-created.xml
+++ b/tests/fixtures/pages/account-6-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-6-deleted.xml
+++ b/tests/fixtures/pages/account-6-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/pages-mock-6 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-7-created.xml
+++ b/tests/fixtures/pages/account-7-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/account-7-deleted.xml
+++ b/tests/fixtures/pages/account-7-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/pages-mock-7 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/list.xml
+++ b/tests/fixtures/pages/list.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts?per_page=4 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/pages/next-list.xml
+++ b/tests/fixtures/pages/next-list.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts?cursor=1304958672&per_page=4 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/plan/created.xml
+++ b/tests/fixtures/plan/created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/plans HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/plan/deleted.xml
+++ b/tests/fixtures/plan/deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/plans/planmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/plan/does-not-exist.xml
+++ b/tests/fixtures/plan/does-not-exist.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/plans/planmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/plan/exists-usage.xml
+++ b/tests/fixtures/plan/exists-usage.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/plans/planmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/plan/exists.xml
+++ b/tests/fixtures/plan/exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/plans/planmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/plan/show-taxed.xml
+++ b/tests/fixtures/plan/show-taxed.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/plans/planmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/plan/updated.xml
+++ b/tests/fixtures/plan/updated.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/plans/planmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscribe-add-on/account-deleted.xml
+++ b/tests/fixtures/subscribe-add-on/account-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/sad-on-mock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscribe-add-on/account-exists.xml
+++ b/tests/fixtures/subscribe-add-on/account-exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/sad-on-mock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscribe-add-on/add-on-created.xml
+++ b/tests/fixtures/subscribe-add-on/add-on-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/plans/basicplan/add_ons HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscribe-add-on/plan-created.xml
+++ b/tests/fixtures/subscribe-add-on/plan-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/plans HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscribe-add-on/plan-deleted.xml
+++ b/tests/fixtures/subscribe-add-on/plan-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/plans/basicplan HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscribe-add-on/second-add-on-created.xml
+++ b/tests/fixtures/subscribe-add-on/second-add-on-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/plans/basicplan/add_ons HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscribe-add-on/subscribed.xml
+++ b/tests/fixtures/subscribe-add-on/subscribed.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/subscriptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/account-created.xml
+++ b/tests/fixtures/subscription/account-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/account-deleted.xml
+++ b/tests/fixtures/subscription/account-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/subscribemock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/account-subscriptions.xml
+++ b/tests/fixtures/subscription/account-subscriptions.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/subscribemock/subscriptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/all-subscriptions.xml
+++ b/tests/fixtures/subscription/all-subscriptions.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/subscriptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/cancelled.xml
+++ b/tests/fixtures/subscription/cancelled.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/cancel HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/change-preview.xml
+++ b/tests/fixtures/subscription/change-preview.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/preview HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/embedded-account-deleted.xml
+++ b/tests/fixtures/subscription/embedded-account-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/subscribe-mock-2 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/embedded-account-exists.xml
+++ b/tests/fixtures/subscription/embedded-account-exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/subscribe-mock-2 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/error-no-billing-info.xml
+++ b/tests/fixtures/subscription/error-no-billing-info.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/subscribemock/subscriptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/error-priceless-plan.xml
+++ b/tests/fixtures/subscription/error-priceless-plan.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/subscribemock/subscriptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/plan-created.xml
+++ b/tests/fixtures/subscription/plan-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/plans HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/plan-deleted.xml
+++ b/tests/fixtures/subscription/plan-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/plans/basicplan HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/plan-updated-price.xml
+++ b/tests/fixtures/subscription/plan-updated-price.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/plans/basicplan HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/reactivated.xml
+++ b/tests/fixtures/subscription/reactivated.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/reactivate HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/redemptions.xml
+++ b/tests/fixtures/subscription/redemptions.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/redemptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/show.xml
+++ b/tests/fixtures/subscription/show.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/subscribe-embedded-account.xml
+++ b/tests/fixtures/subscription/subscribe-embedded-account.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/subscriptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/subscribed-billing-info.xml
+++ b/tests/fixtures/subscription/subscribed-billing-info.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/subscribemock/subscriptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/subscribed-manual.xml
+++ b/tests/fixtures/subscription/subscribed-manual.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/subscribemock/subscriptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/subscribed.xml
+++ b/tests/fixtures/subscription/subscribed.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/subscribemock/subscriptions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/terminated.xml
+++ b/tests/fixtures/subscription/terminated.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/terminate?refund=none HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/update-billing-info.xml
+++ b/tests/fixtures/subscription/update-billing-info.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/accounts/subscribemock/billing_info HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/subscription/updated-at-renewal.xml
+++ b/tests/fixtures/subscription/updated-at-renewal.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction-balance/account-created.xml
+++ b/tests/fixtures/transaction-balance/account-created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction-balance/account-deleted.xml
+++ b/tests/fixtures/transaction-balance/account-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/transbalancemock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction-balance/credited.xml
+++ b/tests/fixtures/transaction-balance/credited.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/accounts/transbalancemock/adjustments HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction-balance/set-billing-info.xml
+++ b/tests/fixtures/transaction-balance/set-billing-info.xml
@@ -1,5 +1,5 @@
 PUT https://api.recurly.com/v2/accounts/transbalancemock/billing_info HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction-balance/transacted-2.xml
+++ b/tests/fixtures/transaction-balance/transacted-2.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/transactions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction-balance/transacted-3.xml
+++ b/tests/fixtures/transaction-balance/transacted-3.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/transactions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction-balance/transacted.xml
+++ b/tests/fixtures/transaction-balance/transacted.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/transactions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction-balance/transaction-no-account.xml
+++ b/tests/fixtures/transaction-balance/transaction-no-account.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/transactions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction-balance/transaction-no-billing-fails.xml
+++ b/tests/fixtures/transaction-balance/transaction-no-billing-fails.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/transactions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction/account-deleted.xml
+++ b/tests/fixtures/transaction/account-deleted.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/accounts/transactionmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction/account-exists.xml
+++ b/tests/fixtures/transaction/account-exists.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/accounts/transactionmock HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction/created-again.xml
+++ b/tests/fixtures/transaction/created-again.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/transactions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction/created.xml
+++ b/tests/fixtures/transaction/created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/transactions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction/declined-transaction.xml
+++ b/tests/fixtures/transaction/declined-transaction.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/transactions HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction/partial-refunded-transaction.xml
+++ b/tests/fixtures/transaction/partial-refunded-transaction.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/transactions/123456789012345678901234567890ad HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction/partial-refunded.xml
+++ b/tests/fixtures/transaction/partial-refunded.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/transactions/123456789012345678901234567890ac?amount_in_cents=700 HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction/refund-transaction.xml
+++ b/tests/fixtures/transaction/refund-transaction.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/transactions/123456789012345678901234567890ae HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/transaction/refunded.xml
+++ b/tests/fixtures/transaction/refunded.xml
@@ -1,5 +1,5 @@
 DELETE https://api.recurly.com/v2/transactions/123456789012345678901234567890ab HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/usage/created.xml
+++ b/tests/fixtures/usage/created.xml
@@ -1,5 +1,5 @@
 POST https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/add_ons/marketing_emails/usage HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/fixtures/usage/index.xml
+++ b/tests/fixtures/usage/index.xml
@@ -1,5 +1,5 @@
 GET https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/add_ons/marketing_emails/usage HTTP/1.1
-X-Api-Version: 2.2
+X-Api-Version: 2.3
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -71,6 +71,14 @@ class TestResources(RecurlyTest):
         self.assertTrue(same_account.entity_use_code == 'I')
         self.assertEqual(same_account._url, urljoin(recurly.base_uri(), 'accounts/%s' % account_code))
 
+        with self.mock_request('account-balance/exists.xml'):
+            account_balance = same_account.account_balance()
+
+        self.assertTrue(account_balance.past_due)
+        balance = account_balance.balance_in_cents
+        self.assertTrue(balance['USD'] == 2910)
+        self.assertTrue(balance['EUR'] == -520)
+
         account.username = 'shmohawk58'
         account.email = 'larry.david'
         account.first_name = six.u('L\xe4rry')


### PR DESCRIPTION
Changes so far:

Route changes:

- Added `GET /v2/account/:code/balance`

Request and Response Changes:

- Changed Transaction response:
  - Added `<original_transaction>` link element.
- Changed Add-On response:
  - Added `<revenue_schedule_type>` element.
- Changed Charge response:
  - Added `<revenue_schedule_type>` element.
- Changed Plan response:
  - Added `<revenue_schedule_type>` element.
  - Added `<setup_fee_revenue_schedule_type>` element.
- Changed Subscription response:
  - Added `<revenue_schedule_type>` element.
- Changed Account response:
  - Added `<account_balance>` link element.
- Added pagination options:
  - Added `sort` option: accepts `created_at`/`updated_at`, defaults to `created_at`.
  - Added `order` option: accepts `desc`/`asc`, defaults to `desc`.
  - Added `begin_time`/`end_time` options: accepts an ISO 8601 date or date and time.

\cc @drewish @ajnadel 