### PR TITLE
Bump 2.2.21

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
-## Unreleased
+## Version 2.2.21 June 29, 2016
 
 - Adding `collection_path` to `MeasuredUnit`
+- Adding `TransactionError` parsing inside `ValidationError`
 
 ## Version 2.2.20 May 23, 2016
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -19,7 +19,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.2.20'
+__version__ = '2.2.21'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 USER_AGENT = 'recurly-python/%s; python %s' % (recurly.__version__, recurly.__python_version__)


### PR DESCRIPTION
- Adding `collection_path` to `MeasuredUnit` https://github.com/recurly/recurly-client-python/pull/168
- Adding `TransactionError` parsing inside `ValidationError` https://github.com/recurly/recurly-client-python/pull/170