### PR TITLE
Bump 2.2.22

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+## Version 2.2.22 July 6, 2016
+
+- Adding variable for api version in fixtures
+- Adding `usage_percentage` and `optional` to `AddOn`
+- Upgrade API to version 2.3
+
 ## Version 2.2.21 June 29, 2016
 
 - Adding `collection_path` to `MeasuredUnit`

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -19,7 +19,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.2.21'
+__version__ = '2.2.22'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 USER_AGENT = 'recurly-python/%s; python %s' % (recurly.__version__, recurly.__python_version__)


### PR DESCRIPTION
- Use variable for api version in fixtures https://github.com/recurly/recurly-client-python/pull/175
- Add missing AddOn fields https://github.com/recurly/recurly-client-python/pull/174
- API version 2.3 https://github.com/recurly/recurly-client-python/pull/171