### PR TITLE
Remove old python references from readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,15 +43,9 @@ Set your API key and optionally set a certificate authority certificate file and
 Recurly Python Client Tests
 ---------------------------
 
-To run these tests in Python 2.7, use the `unittest` test runner:
+To run these tests, use the `unittest` test runner:
 
     $ python -m unittest discover -s tests
-
-Under Python 2.6 or earlier, install the `unittest2` distribution and use it
-instead:
-
-    $ pip install unittest2  # or easy_install
-    $ python -m unittest2 discover -s tests
 
 The resource tests in `test_resources.py` will run using the HTTP fixtures in
 `tests/fixtures`. To run the tests against a live Recurly API endpoint,
@@ -66,12 +60,10 @@ be a filename of concatenated certificate authority X.509 certificates:
 
     $ RECURLY_API_KEY=1274...54e3 RECURLY_CA_CERTS_FILE=/etc/pki/tls/certs/ca-bundle.crt -m unittest tests.test_resources
 
-
 Usage
 -----
 
 Please see the `Recurly API <https://dev.recurly.com/docs/getting-started>`_ for more information.
-
 
 Support
 -------


### PR DESCRIPTION
We no longer support python < 2.7