### PR TITLE
Bump 2.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+## Version 2.4.0 August 18, 2016
+
+- Fix revenue schedule typo
+- Remove old python references from readme
+- Gift card support, bumps to api v 2.4
+- Add updated_at fields
+
 ## Version 2.3.0 July 6, 2016
 
 - Adding variable for api version in fixtures

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -19,7 +19,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.3.0'
+__version__ = '2.4.0'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 USER_AGENT = 'recurly-python/%s; python %s' % (recurly.__version__, recurly.__python_version__)


### PR DESCRIPTION
Bumps us to API version 2.4

- Fix revenue schedule typo [PR](https://github.com/recurly/recurly-client-python/pull/181)
- Remove old python references from readme [PR](https://github.com/recurly/recurly-client-python/pull/180)
- Gift card support [PR](https://github.com/recurly/recurly-client-python/pull/179)
- Add updated_at fields [PR](https://github.com/recurly/recurly-client-python/pull/178)