### PR TITLE
Add ability to create shipping address on existing account

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -276,6 +276,12 @@ class Account(Resource):
         logging.getLogger('recurly.http.response').debug(response_xml)
         billing_info.update_from_element(ElementTree.fromstring(response_xml))
 
+    def create_shipping_address(self, shipping_address):
+        """Creates a shipping address on an existing account. If you are
+        creating an account, you can embed the shipping addresses with the
+        request"""
+        url = urljoin(self._url, '%s/shipping_addresses' % self.account_code)
+        return shipping_address.post(url)
 
 class BillingInfo(Resource):
 

--- a/tests/fixtures/shipping_addresses/created-on-existing-account.xml
+++ b/tests/fixtures/shipping_addresses/created-on-existing-account.xml
@@ -1,0 +1,36 @@
+POST https://api.recurly.com/v2/accounts/testmock/shipping_addresses HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<shipping_address>
+  <address1>123 Dolores St</address1>
+  <city>San Francisco</city>
+  <country>US</country>
+  <nickname>Home</nickname>
+  <phone>8015559876</phone>
+  <state>CA</state>
+  <zip>94105</zip>
+</shipping_address>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/testmock/shipping_addresses/1234567890
+
+<?xml version="1.0" encoding="UTF-8"?>
+<shipping_address href="https://api.recurly.com/v2/accounts/testmock/shipping_addresses/1234567890">
+  <account href="https://api.recurly.com/v2/accounts/testmock" />
+  <id>1234567890</id>
+  <address1>123 Dolores St</address1>
+  <city>San Francisco</city>
+  <country>US</country>
+  <nickname>Home</nickname>
+  <phone>8015559876</phone>
+  <state>CA</state>
+  <zip>94105</zip>
+  <created_at type="datetime">2016-06-14T16:08:41Z</created_at>
+  <updated_at type="datetime">2016-06-14T16:08:41Z</updated_at>
+</shipping_address>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -174,6 +174,18 @@ class TestResources(RecurlyTest):
         with self.mock_request('account/created-with-shipping-address.xml'):
             account.save()
 
+        shipping_address = ShippingAddress()
+        shipping_address.address1 = '123 Dolores St'
+        shipping_address.city = 'San Francisco'
+        shipping_address.zip = '94105'
+        shipping_address.state = 'CA'
+        shipping_address.country = 'US'
+        shipping_address.phone = '8015559876'
+        shipping_address.nickname = 'Home'
+
+        with self.mock_request('shipping_addresses/created-on-existing-account.xml'):
+            shipping_address = account.create_shipping_address(shipping_address)
+
         """Get taxed account"""
         with self.mock_request('account/show-taxed.xml'):
             account = Account.get(account_code)


### PR DESCRIPTION
```python
import uuid
import datetime
import time
from recurly import Account, Address, BillingInfo, Subscription, ShippingAddress

account_code = str(uuid.uuid4())
account = Account()
account.account_code = account_code

shad = ShippingAddress()
shad.nickname = "Work"
shad.first_name = "Verena"
shad.last_name = "Example"
shad.company = "Recurly Inc."
shad.phone = "555-555-5555"
shad.email = "verena@example.com"
shad.address1 = "123 Main St."
shad.city = "San Francisco"
shad.state = "CA"
shad.zip = "94110"
shad.country = "US"

# embed shipping addresses on account create
account.shipping_addresses = [shad]
account.save()

shad = ShippingAddress()
shad.nickname = "Home"
shad.first_name = "Verena"
shad.last_name = "Example"
shad.phone = "555-555-5555"
shad.email = "verena@example.com"
shad.address1 = "123 Dolores St."
shad.city = "San Francisco"
shad.state = "CA"
shad.zip = "94110"
shad.country = "US"

# create a shipping address on an existing account
account.create_shipping_address(shad)

print shad.id # the shad variable has been updated with the remote resource
# => 2035701506016292675

print account.shipping_addresses() # should pull two shipping addresses
# => [<recurly.ShippingAddress object at 0x101ebd250>, <recurly.ShippingAddress object at 0x101ebd290>]
```