### PR TITLE
Add canceled at, preview, and redeem-on-account support to gift cards

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add canceled_at, preview, and redeem-on-account support for gift cards
+
 ## Version 2.4.2 September 12, 2016
 
 - Add ability to create shipping address on existing account

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -363,6 +363,10 @@ class Delivery(Resource):
         'personal_message',
     )
 
+# This is used internally for proper XML generation
+class _RecipientAccount(Account):
+    nodename = 'recipient_account'
+
 class GiftCard(Resource):
 
     """A Gift Card for a customer to purchase or apply to a subscription or account."""
@@ -374,8 +378,9 @@ class GiftCard(Resource):
 
     attributes = (
         'balance_in_cents',
-        'currency',
+        'canceled_at',
         'created_at',
+        'currency',
         'delivery',
         'gifter_account',
         'id',
@@ -389,6 +394,20 @@ class GiftCard(Resource):
     )
     _classes_for_nodename = {'recipient_account': Account,'gifter_account':
             Account}
+
+    def preview(self):
+        if hasattr(self, '_url'):
+            url = self._url + '/preview'
+            return self.post(url)
+        else:
+            url = urljoin(recurly.base_uri(), self.collection_path) + '/preview'
+            return self.post(url)
+
+    def redeem(self, account_code):
+        """Redeem this gift card on the specified account code"""
+        url = urljoin(self._url, '%s/redeem' % (self.redemption_code))
+        recipient_account = _RecipientAccount(account_code=account_code)
+        return self.post(url, recipient_account)
 
     def to_element(self, root_name=None):
         elem = super(GiftCard, self).to_element(root_name)


### PR DESCRIPTION
This PR includes 3 additions:

1. Support for the `canceled_at` timestamp on the `GiftCard` resource. Gift cards, if they have not already been redeemed, can be canceled and the timestamp denotes when the cancelation happens.
2. Ability to preview the purchase of a gift card. This is useful for checking an invoice total, checking for errors, etc.
3. An account can redeem a gift card directly. If an account already has a subscription or is unsure which plan they might choose, they can still redeem a gift card and the credit becomes available on their account.