### PR TITLE
add tests to new gift cards features and fix redemption url generation

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -396,6 +396,8 @@ class GiftCard(Resource):
             Account}
 
     def preview(self):
+        """Preview the purchase of this gift card"""
+
         if hasattr(self, '_url'):
             url = self._url + '/preview'
             return self.post(url)
@@ -405,7 +407,14 @@ class GiftCard(Resource):
 
     def redeem(self, account_code):
         """Redeem this gift card on the specified account code"""
-        url = urljoin(self._url, '%s/redeem' % (self.redemption_code))
+
+        redemption_path = '%s/redeem' % (self.redemption_code)
+
+        if hasattr(self, '_url'):
+            url = urljoin(self._url, redemption_path)
+        else:
+            url = urljoin(recurly.base_uri(), self.collection_path) + '/' + redemption_path
+
         recipient_account = _RecipientAccount(account_code=account_code)
         return self.post(url, recipient_account)
 

--- a/tests/fixtures/gift_cards/preview.xml
+++ b/tests/fixtures/gift_cards/preview.xml
@@ -1,4 +1,4 @@
-POST https://api.recurly.com/v2/gift_cards HTTP/1.1
+POST https://api.recurly.com/v2/gift_cards/preview HTTP/1.1
 X-Api-Version: {api-version}
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
@@ -39,16 +39,14 @@ Content-Type: application/xml; charset=utf-8
     <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
 </gift_card>
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-Location: https://api.recurly.com/v2/gift_cards/2018434791876074812
 
 <?xml version="1.0" encoding="UTF-8"?>
-<gift_card href="https://api.recurly.com/v2/gift_cards/2018434791876074812">
-    <gifter_account href="https://api.recurly.com/v2/accounts/e0004e3c-216c-4254-8767-9be605cd0b03"/>
-    <invoice href="https://api.recurly.com/v2/invoices/2096"/>
-    <id type="integer">2018434791876074812</id>
-    <redemption_code>9FC359369CD3892E</redemption_code>
+<gift_card href="">
+    <gifter_account href=""/>
+    <id nil="nil"></id>
+    <redemption_code></redemption_code>
     <product_code>test_gift_card</product_code>
     <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
     <currency>USD</currency>
@@ -70,10 +68,9 @@ Location: https://api.recurly.com/v2/gift_cards/2018434791876074812
         <gifter_name nil="nil"></gifter_name>
         <personal_message nil="nil"></personal_message>
     </delivery>
-    <created_at type="datetime">2016-08-16T21:49:37Z</created_at>
-    <updated_at type="datetime">2016-08-16T21:49:37Z</updated_at>
+    <created_at nil="nil"></created_at>
+    <updated_at nil="nil"></updated_at>
     <delivered_at nil="nil"></delivered_at>
     <redeemed_at nil="nil"></redeemed_at>
     <canceled_at nil="nil"></canceled_at>
-    <a name="redeem" href="https://api.recurly.com/v2/gift_cards/9FC359369CD3892E/redeem" method="post"/>
 </gift_card>

--- a/tests/fixtures/gift_cards/redeem.xml
+++ b/tests/fixtures/gift_cards/redeem.xml
@@ -1,4 +1,4 @@
-POST https://api.recurly.com/v2/gift_cards HTTP/1.1
+POST https://api.recurly.com/v2/gift_cards/9FC359369CD3892E/redeem HTTP/1.1
 X-Api-Version: {api-version}
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
@@ -6,42 +6,12 @@ User-Agent: {user-agent}
 Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
-<gift_card>
-    <currency>USD</currency>
-    <delivery>
-        <address>
-            <address1>400 Alabama St</address1>
-            <city>San Francisco</city>
-            <state>CA</state>
-            <zip>94110</zip>
-            <country>US</country>
-        </address>
-        <email_address>john@email.com</email_address>
-        <method>email</method>
-    </delivery>
-    <gifter_account>
-        <account_code>e0004e3c-216c-4254-8767-9be605cd0b03</account_code>
-        <email>verena@example.com</email>
-        <first_name>Verena</first_name>
-        <last_name>Example</last_name>
-        <billing_info>
-            <first_name>Verena</first_name>
-            <last_name>Example</last_name>
-            <number>4111-1111-1111-1111</number>
-            <verification_value>123</verification_value>
-            <year type="integer">2019</year>
-            <month type="integer">11</month>
-            <country>US</country>
-            <currency>USD</currency>
-        </billing_info>
-    </gifter_account>
-    <product_code>test_gift_card</product_code>
-    <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
-</gift_card>
+<recipient_account>
+    <account_code>e0004e3c-216c-4254-8767-9be605cd0b03</account_code>
+</recipient_account>
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-Location: https://api.recurly.com/v2/gift_cards/2018434791876074812
 
 <?xml version="1.0" encoding="UTF-8"?>
 <gift_card href="https://api.recurly.com/v2/gift_cards/2018434791876074812">
@@ -73,7 +43,6 @@ Location: https://api.recurly.com/v2/gift_cards/2018434791876074812
     <created_at type="datetime">2016-08-16T21:49:37Z</created_at>
     <updated_at type="datetime">2016-08-16T21:49:37Z</updated_at>
     <delivered_at nil="nil"></delivered_at>
-    <redeemed_at nil="nil"></redeemed_at>
+    <redeemed_at type="datetime">2016-08-17T21:49:37Z</redeemed_at>
     <canceled_at nil="nil"></canceled_at>
-    <a name="redeem" href="https://api.recurly.com/v2/gift_cards/9FC359369CD3892E/redeem" method="post"/>
 </gift_card>


### PR DESCRIPTION
See previously #188 

The change to the `redeem` method allows for redeeming a gift card without having fetched it previously from the API such that the `_url` attribute was set. You can simply instantiate a new `GiftCard` object with a `redemption_code` and call `redeem` with an account code.