### PR TITLE
Add cached rate limiting headers

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -1,5 +1,7 @@
 import logging
 import sys
+import re
+from datetime import datetime
 from six.moves.urllib.parse import urljoin
 from xml.etree import ElementTree
 
@@ -21,6 +23,13 @@ https://dev.recurly.com/docs/getting-started
 
 __version__ = '2.4.2'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
+
+cached_rate_limits = {
+        'limit': None,
+        'remaining': None,
+        'resets_at': None,
+        'cached_at': None,
+        }
 
 USER_AGENT = 'recurly-python/%s; python %s' % (recurly.__version__, recurly.__python_version__)
 
@@ -55,6 +64,18 @@ def base_uri():
 
 def api_version():
     return API_VERSION
+
+def cache_rate_limit_headers(resp_headers):
+    try:
+        recurly.cached_rate_limits = {
+                'cached_at': datetime.utcnow(),
+                'limit': int(resp_headers['X-RateLimit-Limit']),
+                'remaining': int(resp_headers['X-RateLimit-Remaining']),
+                'resets_at': datetime.utcfromtimestamp(int(resp_headers['X-RateLimit-Reset']))
+                }
+    except:
+        log = logging.getLogger('recurly.cached_rate_limits')
+        log.info('Failed to parse rate limits from header')
 
 class Address(Resource):
 

--- a/tests/fixtures/account/exists-with-rate-limit-headers.xml
+++ b/tests/fixtures/account/exists-with-rate-limit-headers.xml
@@ -1,0 +1,30 @@
+GET https://api.recurly.com/v2/accounts/testmock HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+X-RateLimit-Limit: 2000
+X-RateLimit-Reset: 1486064760
+X-RateLimit-Remaining: 1992
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/testmock">
+  <adjustments href="https://api.recurly.com/v2/accounts/testmock/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/testmock/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/testmock/invoices"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/testmock/subscriptions"/>
+  <transactions href="https://api.recurly.com/v2/accounts/testmock/transactions"/>
+  <account_balance href="https://api.recurly.com/v2/accounts/testmock/balance"/>
+  <account_code>testmock</account_code>
+  <username nil="nil"></username>
+  <email nil="nil"></email>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
+  <company_name nil="nil"></company_name>
+  <entity_use_code>I</entity_use_code>
+  <accept_language nil="nil"></accept_language>
+</account>

--- a/tests/recurlytests.py
+++ b/tests/recurlytests.py
@@ -10,6 +10,7 @@ from xml.etree import ElementTree
 
 import mock
 import six
+import recurly
 
 from six.moves import http_client
 
@@ -94,8 +95,11 @@ class MockRequestManager(object):
         response = http_client.HTTPResponse(sock, method=self.method)
         response.begin()
 
+
         self.response_context = mock.patch.object(http_client.HTTPConnection, 'getresponse', lambda self: response)
         self.response_mock = self.response_context.__enter__()
+
+        recurly.cache_rate_limit_headers(self.headers)
 
         return self
 


### PR DESCRIPTION
This caches the rate limiting headers after each response on `recurly.rate_limits`. All the times are in UTC.

```python
from recurly import Account
Account.get('19d43a09-607b-4206-8ab4-2bd0e8f937ea')

print recurly.cached_rate_limits
#=> {'resets_at': datetime.datetime(2017, 2, 3, 17, 33), 'limit': 2000,
#=>     'cached_at': datetime.datetime(2017, 2, 3, 17, 28, 6, 806473), 'remaining': 1993}
```

\cc @AnthonySalierno 