### PR TITLE
Remove parsing of X-Records header

### DIFF
--- a/tests/fixtures/pages/count.xml
+++ b/tests/fixtures/pages/count.xml
@@ -1,0 +1,9 @@
+HEAD https://api.recurly.com/v2/accounts?begin_time=2017-05-01T10%3A30%3A01-06%3A00 HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 23

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -774,6 +774,15 @@ class TestResources(RecurlyTest):
             with self.mock_request('invoice/account-deleted.xml'):
                 account.delete()
 
+    def test_count(self):
+        try:
+            with self.mock_request('pages/count.xml'):
+                num_accounts = Account.count(begin_time='2017-05-01T10:30:01-06:00')
+
+            self.assertTrue(num_accounts, 23)
+        finally:
+            pass
+
     def test_pages(self):
         account_code = 'pages-%s-%%d' % self.test_id
         all_test_accounts = list()


### PR DESCRIPTION
We are no longer returning the `X-Records` header in every page unless you explicitly request it using a `HEAD` method.

This will result in a breaking change as you can no longer use `__len__()` (or `len(page)`) on a `Page`. You must now use `Resource.count(**kwargs)`. This takes the same kwargs as the list endpoint (or `Resource.all(**kwargs)`).

Example, count all invoices after 2017-05-01 at 10:30. Resource.count returns an int:

```python
num_invoices = recurly.Invoice.count(begin_time='2017-05-01T10:30:01-06:00')
```

Ensure that pagination still works by paginating something with multiple pages

```python
for invoice in recurly.Invoice.all(begin_time='2017-04-01T10:30:01-06:00'):
    print invoice.invoice_number
```

