### PR TITLE
Bump version 2.5.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,19 @@
 ## Unreleased
 
+## Version 2.5.0 April 17, 2017
+
+- Remove parsing of X-Records header
+- Cardless Free Trial changes for 2.6
+
+### Upgrade Notes
+
+This release will upgrade us to API version 2.6. There are two breaking changes:
+
+1. Since the X-Records header was removed in the pagination endpoint, you can no longer call `len()` on a Page and expect it to return a cached response.
+From now on you need to explicitly call the `count()` class method on a Page. See [PR #202](https://github.com/recurly/recurly-client-python/pull/202) for more information.
+2. For `POST /v2/subscriptions` Sending `None` for `total_billing_cycles` attribute will now override plan `total_billing_cycles` setting and will make subscription renew forever.
+Omitting the attribute will cause the setting to default to the value of plan `total_billing_cycles`.
+
 ## Version 2.4.4 March 23, 2017
 
 - Add API version 2.5 changes

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -21,7 +21,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.4.4'
+__version__ = '2.5.0'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -42,7 +42,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.5'
+API_VERSION = '2.6'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -859,6 +859,7 @@ class Subscription(Resource):
         'shipping_address_id',
         'started_with_gift',
         'converted_at',
+        'no_billing_info_reason',
     )
     sensitive_attributes = ('number', 'verification_value', 'bulk')
 
@@ -1094,6 +1095,7 @@ class Plan(Resource):
         'total_billing_cycles',
         'revenue_schedule_type',
         'setup_fee_revenue_schedule_type',
+        'trial_requires_billing_info',
     )
 
     def get_add_on(self, add_on_code):

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -405,6 +405,10 @@ class Resource(object):
 
         attr_type = elem.attrib.get('type')
         log.debug("Converting %r element with type %r", elem.tag, attr_type)
+        # TODO this trial_requires_billing_info check can be removed when
+        # the server starts sending the correct type
+        if elem.tag == 'trial_requires_billing_info':
+            return elem.text.strip() == 'true'
         if attr_type == 'integer':
             return int(elem.text.strip())
         if attr_type == 'float':

--- a/tests/fixtures/pages/count.xml
+++ b/tests/fixtures/pages/count.xml
@@ -1,0 +1,9 @@
+HEAD https://api.recurly.com/v2/accounts?begin_time=2017-05-01T10%3A30%3A01-06%3A00 HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 23

--- a/tests/fixtures/plan/exists.xml
+++ b/tests/fixtures/plan/exists.xml
@@ -28,6 +28,7 @@ Content-Type: application/xml; charset=utf-8
   <trial_interval_unit>days</trial_interval_unit>
   <total_billing_cycles type="integer">10</total_billing_cycles>
   <created_at type="datetime">2011-10-03T22:23:12Z</created_at>
+  <trial_requires_billing_info type="boolean">false</trial_requires_billing_info>
   <unit_amount_in_cents>
   </unit_amount_in_cents>
   <setup_fee_in_cents>

--- a/tests/fixtures/subscription/show.xml
+++ b/tests/fixtures/subscription/show.xml
@@ -32,6 +32,7 @@ Content-Type: application/xml; charset=utf-8
   <trial_ends_at nil="nil"></trial_ends_at>
   <tax_in_cents type="integer">0</tax_in_cents>
   <tax_type>usst</tax_type>
+  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
   <subscription_add_ons type="array">
     <subscription_add_on>
         <add_on_type>usage</add_on_type>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -774,6 +774,15 @@ class TestResources(RecurlyTest):
             with self.mock_request('invoice/account-deleted.xml'):
                 account.delete()
 
+    def test_count(self):
+        try:
+            with self.mock_request('pages/count.xml'):
+                num_accounts = Account.count(begin_time='2017-05-01T10:30:01-06:00')
+
+            self.assertTrue(num_accounts, 23)
+        finally:
+            pass
+
     def test_pages(self):
         account_code = 'pages-%s-%%d' % self.test_id
         all_test_accounts = list()


### PR DESCRIPTION
- Remove parsing of X-Records header [PR](https://github.com/recurly/recurly-client-python/pull/202)
- Cardless Free Trial changes for 2.6 [PR](https://github.com/recurly/recurly-client-python/pull/200)

### Upgrade Notes

This release will upgrade us to API version 2.6. There are two breaking changes:

1. Since the X-Records header was removed in the pagination endpoint, you can no longer call `len()` on a Page and expect it to return a cached response.
From now on you need to explicitly call the `count()` class method on a Page. See [PR #202](https://github.com/recurly/recurly-client-python/pull/202) for more information.
2. For `POST /v2/subscriptions` Sending `None` for `total_billing_cycles` attribute will now override plan `total_billing_cycles` setting and will make subscription renew forever.
Omitting the attribute will cause the setting to default to the value of plan `total_billing_cycles`.
