### PR TITLE
Remove trial_requires_billing_info coercion

### DIFF
--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -405,10 +405,7 @@ class Resource(object):
 
         attr_type = elem.attrib.get('type')
         log.debug("Converting %r element with type %r", elem.tag, attr_type)
-        # TODO this trial_requires_billing_info check can be removed when
-        # the server starts sending the correct type
-        if elem.tag == 'trial_requires_billing_info':
-            return elem.text.strip() == 'true'
+
         if attr_type == 'integer':
             return int(elem.text.strip())
         if attr_type == 'float':


### PR DESCRIPTION
This field was coming back without the type="boolean" attribute in the xml. In order to not interrupt our 2.6 release date, I overrode the read accessor to coerce the field into a boolean (if it wasn't already). Now that the API change has been deployed we can safely remove this dead code.

### Testing

```python
plan = recurly.Plan.all()[0]
v = plan.trial_requires_billing_info

if type(v) == bool:
    print("It's a bool as expected")
else:
    print("It's not a bool %s" % v)
```