### PR TITLE
Support multiple suberrors per field in ValidationError

### DIFF
--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -1,7 +1,6 @@
 from xml.etree import ElementTree
 import six
 
-
 class ResponseError(Exception):
 
     """An error received from the Recurly API in response to an HTTP
@@ -240,8 +239,16 @@ class ValidationError(ClientError):
             field = err.attrib['field']
             symbol = err.attrib['symbol']
             message = err.text
+            sub_err = self.Suberror(field, symbol, message)
 
-            suberrors[field] = self.Suberror(field, symbol, message)
+            # If the field exists, we need to turn the suberror
+            # into a list of suberrors
+            if field in suberrors:
+                if type(suberrors[field]) != list:
+                    suberrors[field] = [suberrors[field]]
+                suberrors[field].append(sub_err)
+            else:
+                suberrors[field] = sub_err
 
         self.__dict__['errors'] = suberrors
         return suberrors

--- a/tests/fixtures/subscription/error-subscribe-embedded-account.xml
+++ b/tests/fixtures/subscription/error-subscribe-embedded-account.xml
@@ -1,0 +1,30 @@
+POST https://api.recurly.com/v2/subscriptions HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription>
+  <plan_code>basicplan</plan_code>
+  <currency>USD</currency>
+</subscription>
+
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<errors>
+  <error field="subscription.account.billing_info.address1" symbol="empty">can't be empty</error>
+  <error field="subscription.account.billing_info.city" symbol="empty">can't be empty</error>
+  <error field="subscription.account.billing_info.country" symbol="empty">can't be empty</error>
+  <error field="subscription.account.billing_info.first_name" symbol="blank">can't be blank</error>
+  <error field="subscription.account.billing_info.last_name" symbol="blank">can't be blank</error>
+  <error field="subscription.account.billing_info.number" symbol="required">is required</error>
+  <error field="subscription.account.billing_info.zip" symbol="empty">can't be empty</error>
+  <error field="subscription.account.account_code" symbol="blank">can't be blank</error>
+  <error field="subscription.account.account_code" symbol="invalid">is invalid</error>
+  <error field="subscription.plan_code" symbol="invalid">is invalid</error>
+  <error field="subscription.unit_amount_in_cents" symbol="not_a_number">is not a number</error>
+</errors>


### PR DESCRIPTION
Resolves issue #197

I decided we didn't want to go with defaultdict because we don't want all validation error field-values to be lists. That would break the API contract. Instead I just turn the value into a list if there is more than one for a field.