### PR TITLE
Imported_trial flag on Subscription

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -860,6 +860,7 @@ class Subscription(Resource):
         'started_with_gift',
         'converted_at',
         'no_billing_info_reason',
+        'imported_trial',
     )
     sensitive_attributes = ('number', 'verification_value', 'bulk')
 

--- a/tests/fixtures/subscription/error-no-billing-info.xml
+++ b/tests/fixtures/subscription/error-no-billing-info.xml
@@ -13,6 +13,7 @@ Content-Type: application/xml; charset=utf-8
   <bulk type="boolean">true</bulk>
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
   <customer_notes>Some Customer Notes</customer_notes>
+  <imported_trial type="boolean">true</imported_trial>
 </subscription>
 
 HTTP/1.1 400 Bad Request

--- a/tests/fixtures/subscription/subscribed.xml
+++ b/tests/fixtures/subscription/subscribed.xml
@@ -13,6 +13,7 @@ Content-Type: application/xml; charset=utf-8
   <bulk type="boolean">true</bulk>
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
   <customer_notes>Some Customer Notes</customer_notes>
+  <imported_trial type="boolean">true</imported_trial>
 </subscription>
 
 HTTP/1.1 201 Created
@@ -41,6 +42,7 @@ Location: https://api.recurly.com/v2/subscriptions/12345678901234567890123456789
   <trial_ends_at nil="nil"></trial_ends_at>
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
   <customer_notes>Some Customer Notes</customer_notes>
+  <imported_trial type="boolean">true</imported_trial>
   <subscription_add_ons type="array">
   </subscription_add_ons>
   <a name="cancel" href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/cancel" method="put"/>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -897,7 +897,8 @@ class TestResources(RecurlyTest):
                     unit_amount_in_cents=1000,
                     bulk=True,
                     terms_and_conditions='Some Terms and Conditions',
-                    customer_notes='Some Customer Notes'
+                    customer_notes='Some Customer Notes',
+                    imported_trial=True
                 )
 
                 with self.mock_request('subscription/error-no-billing-info.xml'):
@@ -928,7 +929,9 @@ class TestResources(RecurlyTest):
 
                 with self.mock_request('subscription/subscribed.xml'):
                     account.subscribe(sub)
+
                 self.assertTrue(sub._url)
+                self.assertEquals(sub.imported_trial, True)
 
                 manualsub = Subscription(
                     plan_code='basicplan',


### PR DESCRIPTION
This adds the writeable `imported_trial` flag to `Subscription` for API version 2.8 and is directed at the `api_version_2_8` branch.