### PR TITLE
Fixes #219: Add Delivery class in nodename of Gift card

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -438,7 +438,7 @@ class GiftCard(Resource):
         'unit_amount_in_cents',
     )
     _classes_for_nodename = {'recipient_account': Account,'gifter_account':
-            Account}
+            Account, 'delivery': Delivery}
 
     def preview(self):
         """Preview the purchase of this gift card"""

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1545,6 +1545,7 @@ class TestResources(RecurlyTest):
             gift_card.save()
 
         self.assertTrue(gift_card._url is not None)
+        self.assertTrue(gift_card.delivery is not None)
         self.assertTrue(gift_card.canceled_at is None)
 
     def test_gift_cards_preview(self):


### PR DESCRIPTION
Fixes #219 

What this PR will do ?

* Add delivery class in the _classes_for_nodename attribute of GiftCard object

# Examples Code
(using the methods from testcase)

**Before**

```py
gift_card = self._build_gift_card()
gift_card.save()
# Result : ValueError: Could not determine resource class for array member with tag 'delivery'
```

**After**
```py
gift_card = self._build_gift_card()
gift_card.save()
# No problem
```


