### PR TITLE
API Version 2.12

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -41,7 +41,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.11'
+API_VERSION = '2.12'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -909,6 +909,17 @@ class Purchase(Resource):
         url = recurly.base_uri() + self.collection_path + '/authorize'
         return self.__invoice(url)
 
+    def pending(self):
+        """
+        Use for Adyen HPP transaction requests. Runs validations
+        but does not run any transactions.
+
+        Returns:
+            InvoiceCollection: The authorized collection of invoices
+        """
+        url = recurly.base_uri() + self.collection_path + '/pending'
+        return self.__invoice(url)
+
     def __invoice(self, url):
         # We must null out currency in subscriptions and adjustments
         # TODO we should deprecate and remove default currency support

--- a/tests/fixtures/purchase/pending.xml
+++ b/tests/fixtures/purchase/pending.xml
@@ -1,0 +1,166 @@
+POST https://api.recurly.com/v2/purchases/pending HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<purchase>
+  <account>
+    <account_code>testmock</account_code>
+    <email>benjamin.dumonde@example.com</email>
+    <shipping_addresses>
+      <shipping_address>
+        <address1>123 Main St</address1>
+        <city>New Orleans</city>
+        <country>US</country>
+        <first_name>Verena</first_name>
+        <last_name>Example</last_name>
+        <nickname>Work</nickname>
+        <state>LA</state>
+        <zip>70114</zip>
+      </shipping_address>
+    </shipping_addresses>
+    <billing_info>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <number>4111-1111-1111-1111</number>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <month type="integer">11</month>
+      <address1>123 Main St</address1>
+      <city>New Orleans</city>
+      <state>LA</state>
+      <zip>70114</zip>
+      <country>US</country>
+      <currency>USD</currency>
+      <external_hpp_type>adyen</external_hpp_type>
+    </billing_info>
+  </account>
+  <adjustments>
+    <adjustment>
+      <description>Item 1</description>
+      <quantity type="integer">1</quantity>
+      <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+    </adjustment>
+    <adjustment>
+      <description>Item 2</description>
+      <quantity type="integer">2</quantity>
+      <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+    </adjustment>
+  </adjustments>
+  <currency>USD</currency>
+  <subscriptions>
+    <subscription>
+      <plan_code>gold</plan_code>
+    </subscription>
+  </subscriptions>
+</purchase>
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/1021
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice_collection>
+    <charge_invoice href="">
+      <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+      <address>
+        <address1>123 Main St</address1>
+        <address2 nil="nil"></address2>
+        <city>New Orleans</city>
+        <state>LA</state>
+        <zip>70114</zip>
+        <country>US</country>
+        <phone nil="nil"></phone>
+      </address>
+      <uuid>40625fd700c1c2d90060744092b4a1b1</uuid>
+      <state>pending</state>
+      <invoice_number_prefix></invoice_number_prefix>
+      <invoice_number nil="nil"></invoice_number>
+      <po_number nil="nil"></po_number>
+      <vat_number nil="nil"></vat_number>
+      <subtotal_in_cents type="integer">6000</subtotal_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <total_in_cents type="integer">6000</total_in_cents>
+      <subtotal_after_discount_in_cents type="integer">6000</subtotal_after_discount_in_cents>
+      <currency>USD</currency>
+      <created_at nil="nil"></created_at>
+      <updated_at nil="nil"></updated_at>
+      <attempt_next_collection_at type="datetime">2017-10-06T21:25:55Z</attempt_next_collection_at>
+      <closed_at nil="nil"></closed_at>
+      <terms_and_conditions nil="nil"></terms_and_conditions>
+      <customer_notes nil="nil"></customer_notes>
+      <recovery_reason nil="nil"></recovery_reason>
+      <net_terms type="integer">0</net_terms>
+      <collection_method>automatic</collection_method>
+      <line_items type="array">
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6fc46181e2f15044db38c1c82</uuid>
+          <state>pending</state>
+          <description>gold</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code>gold</product_code>
+          <origin>plan</origin>
+          <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+          <quantity type="integer">1</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">1000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date type="datetime">2017-11-06T21:25:55Z</end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type>evenly</revenue_schedule_type>
+        </adjustment>
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6e6a5817b59a2174b72a92fea</uuid>
+          <state>pending</state>
+          <description>Item 1</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code nil="nil"></product_code>
+          <origin>debit</origin>
+          <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+          <quantity type="integer">1</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">1000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date nil="nil"></end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type></revenue_schedule_type>
+        </adjustment>
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6e9096c9922b52646e29f6d5e</uuid>
+          <state>pending</state>
+          <description>Item 2</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code nil="nil"></product_code>
+          <origin>debit</origin>
+          <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+          <quantity type="integer">2</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">4000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date nil="nil"></end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type></revenue_schedule_type>
+        </adjustment>
+      </line_items>
+      <transactions type="array">
+      </transactions>
+    </charge_invoice>
+</invoice_collection>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -121,6 +121,12 @@ class TestResources(RecurlyTest):
             collection = purchase.authorize()
             self.assertIsInstance(collection, InvoiceCollection)
             self.assertIsInstance(collection.charge_invoice, Invoice)
+        with self.mock_request('purchase/pending.xml'):
+            purchase.account.email = 'benjamin.dumonde@example.com'
+            purchase.account.billing_info.external_hpp_type = 'adyen'
+            collection = purchase.pending()
+            self.assertIsInstance(collection, InvoiceCollection)
+            self.assertIsInstance(collection.charge_invoice, Invoice)
 
     def test_account(self):
         account_code = 'test%s' % self.test_id


### PR DESCRIPTION
This bumps us to API version 2.12 and adds the new features.

* Support for `Purchase#pending` endpoint
* Support for `redemption_invoice` and `purchase_invoice` on `GiftCard` (links generated at runtime)