### PR TITLE
Bump 2.8.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,20 @@
 ## Unreleased
-#
+
+## Version 2.8.4 – June 26th, 2018 ##
+
+This version brings us up API version 2.13 but has no breaking changes.
+
+- Allows programmer to set the gateway for a purchase
+- Subscription Terms
+
 ## Version 2.8.3 – May 15th, 2018 ##
 
 - Implement API version 2.12 changes
 
-## Version 2.8.0 – April 5th, 2018 ##
+## Version 2.8.1 – April 5th, 2018 ##
 
 - Implement API version 2.11 changes
-#
+
 ## Version 2.8.0 – March 26, 2018 ##
 
 - Implement API version 2.10 changes

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -20,7 +20,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.8.3'
+__version__ = '2.8.4'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {


### PR DESCRIPTION
This version brings us up API version 2.13 but has no breaking changes.

- Allows programmer to set the gateway for a purchase
- Subscription Terms