### PR TITLE
Add custom fields to Account and Subscription

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -127,6 +127,27 @@ class AccountAcquisition(Resource):
         'updated_at',
     )
 
+class CustomField(Resource):
+
+    """A field to store extra data on the account or subscription."""
+
+    nodename = 'custom_field'
+
+    attributes = (
+        'name',
+        'value',
+    )
+
+    def to_element(self, root_name=None):
+        # Include the field name/value pair when the value changed
+        if 'value' in self.__dict__:
+            try:
+                self.name = self.name # forces name into __dict__
+            except AttributeError:
+                pass
+
+        return super(CustomField, self).to_element(root_name)
+
 class Account(Resource):
 
     """A customer account."""
@@ -160,9 +181,10 @@ class Account(Resource):
         'has_paused_subscription',
         'has_past_due_invoice',
         'preferred_locale',
+        'custom_fields',
     )
 
-    _classes_for_nodename = { 'address': Address }
+    _classes_for_nodename = { 'address': Address, 'custom_field': CustomField }
 
     sensitive_attributes = ('number', 'verification_value',)
 
@@ -1016,6 +1038,7 @@ class Subscription(Resource):
         'next_bill_date',
         'current_term_started_at',
         'current_term_ends_at',
+        'custom_fields',
     )
     sensitive_attributes = ('number', 'verification_value', 'bulk')
 

--- a/tests/fixtures/account/created-with-custom-fields.xml
+++ b/tests/fixtures/account/created-with-custom-fields.xml
@@ -1,0 +1,45 @@
+POST https://api.recurly.com/v2/accounts HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account>
+  <account_code>testmock</account_code>
+  <custom_fields>
+    <custom_field>
+      <name>field_1</name>
+      <value>my field value</value>
+    </custom_field>
+  </custom_fields>
+</account>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/testmock
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/testmock">
+  <adjustments href="https://api.recurly.com/v2/accounts/testmock/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/testmock/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/testmock/invoices"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/testmock/shipping_addresses"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/testmock/subscriptions"/>
+  <transactions href="https://api.recurly.com/v2/accounts/testmock/transactions"/>
+  <account_code>testmock</account_code>
+  <username nil="nil"></username>
+  <email nil="nil"></email>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
+  <company_name nil="nil"></company_name>
+  <vat_number nil="nil"></vat_number>
+  <accept_language nil="nil"></accept_language>
+  <custom_fields type="array">
+    <custom_field>
+      <name>field_1</name>
+      <value>my field value</value>
+    </custom_field>
+  </custom_fields>
+</account>

--- a/tests/fixtures/account/exists-custom-fields.xml
+++ b/tests/fixtures/account/exists-custom-fields.xml
@@ -1,0 +1,37 @@
+GET https://api.recurly.com/v2/accounts/testmock HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/testmock">
+  <adjustments href="https://api.recurly.com/v2/accounts/testmock/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/testmock/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/testmock/invoices"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/testmock/subscriptions"/>
+  <transactions href="https://api.recurly.com/v2/accounts/testmock/transactions"/>
+  <account_balance href="https://api.recurly.com/v2/accounts/testmock/balance"/>
+  <account_code>testmock</account_code>
+  <username nil="nil"></username>
+  <email nil="nil"></email>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
+  <company_name nil="nil"></company_name>
+  <entity_use_code>I</entity_use_code>
+  <accept_language nil="nil"></accept_language>
+  <custom_fields type="array">
+    <custom_field>
+      <name>field1</name>
+      <value>original value1</value>
+    </custom_field>
+    <custom_field>
+      <name>field2</name>
+      <value>original value2</value>
+    </custom_field>
+  </custom_fields>
+</account>

--- a/tests/fixtures/account/updated-custom-fields.xml
+++ b/tests/fixtures/account/updated-custom-fields.xml
@@ -1,0 +1,37 @@
+PUT https://api.recurly.com/v2/accounts/testmock HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account>
+  <custom_fields>
+    <custom_field />
+    <custom_field>
+      <name>field2</name>
+      <value>new value2</value>
+    </custom_field>
+  </custom_fields>
+  <account_code>testmock</account_code>
+</account>
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/testmock
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/testmock">
+  <account_code>testmock</account_code>
+  <custom_fields type="array">
+    <custom_field>
+      <name>field1</name>
+      <value>original value1</value>
+    </custom_field>
+    <custom_field>
+      <name>field2</name>
+      <value>new value2</value>
+    </custom_field>
+  </custom_fields>
+</account>

--- a/tests/fixtures/subscription/subscribe-custom-fields.xml
+++ b/tests/fixtures/subscription/subscribe-custom-fields.xml
@@ -1,0 +1,75 @@
+POST https://api.recurly.com/v2/subscriptions HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription>
+  <plan_code>basicplan</plan_code>
+  <currency>USD</currency>
+  <account>
+    <account_code>subscribe-mock-2</account_code>
+    <custom_fields>
+      <custom_field>
+        <name>my_account_field</name>
+        <value>here is the account value you seek</value>
+      </custom_field>
+    </custom_fields>
+    <billing_info type="credit_card">
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <number>4111 1111 1111 1111</number>
+      <verification_value>7777</verification_value>
+      <year>2015</year>
+      <month>12</month>
+      <address1>123 Main St</address1>
+      <city>San José</city>
+      <state>CA</state>
+      <zip>94105</zip>
+      <country>US</country>
+      <currency>USD</currency>
+    </billing_info>
+  </account>
+  <custom_fields>
+    <custom_field>
+      <name>my_sub_field</name>
+      <value>definitely sub value</value>
+    </custom_field>
+  </custom_fields>
+</subscription>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/plans/basicplan
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription
+    href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab">
+  <uuid>123456789012345678901234567890ab</uuid>
+  <account href="https://api.recurly.com/v2/accounts/subscribe-mock-2"/>
+  <plan href="https://api.recurly.com/v2/plans/basicplan">
+    <plan_code>basicplan</plan_code>
+    <name>Basic Plan</name>
+  </plan>
+  <state>active</state>
+  <quantity type="integer">1</quantity>
+  <currency>EUR</currency>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <activated_at type="datetime">2011-05-27T07:00:00Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <current_period_started_at type="datetime">2011-06-27T07:00:00Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2010-07-27T07:00:00Z</current_period_ends_at>
+  <trial_started_at nil="nil"></trial_started_at>
+  <trial_ends_at nil="nil"></trial_ends_at>
+  <subscription_add_ons type="array">
+  </subscription_add_ons>
+  <custom_fields type="array">
+    <custom_field>
+      <name>my_sub_field</name>
+      <value>definitely sub value</value>
+    </custom_field>
+  </custom_fields>
+</subscription>


### PR DESCRIPTION
Adds support for Custom Fields at version 2.13 of the API

**Examples**:

```python
# Create an Account with custom fields
account = Account(
    account_code=account_code,
    custom_fields=[
        CustomField(name="field_1", value="my field value")
    ]
)
account.save()

# Access field attributes
account.custom_fields[0].name
=> "field_1"
account.custom_fields[0].value
=> "my field value"

# Update an existing Account's custom fields
account = Account.get(account_code)
cfs = account.custom_fields
cfs[0].value = "new account value" # update the value
cfs[1].value = "" # OR cfs[1].value = None to delete an existing field
account.custom_fields = cfs
account.save()

# Create a Subscription with both Account and Subscription custom fields
sub = Subscription(
    plan_code=plan_code,
    currency='USD',
    custom_fields=[CustomField(name='my_sub_field', value='definitely sub value')],
    account=Account(
        account_code=account_code,
        billing_info=billing_info,
        custom_fields=[CustomField(name='my_account_field', value='here is the account value you seek')],
    ),
)
sub.save()

# Update an existing Subscription's custom fields
sub = Subscription.get(subscription_uuid)
cfs = sub.custom_fields
cfs[0].value = "a new value" # update an existing field
cfs[1].value = "" # OR cfs[1].value = None to delete an existing field
sub.custom_fields = cfs
sub.save()
```