### PR TITLE
Add more pythons to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7-dev"
 install:
   - pip install six mock iso8601 backports.ssl-match-hostname
   - python setup.py install


### PR DESCRIPTION
Adding python `3.6` and `3.7` to travis CI build.