### PR TITLE
Add create_billing_info via HTTP POST

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -340,6 +340,22 @@ class Account(Resource):
         url = urljoin(self._url, '/subscriptions')
         return subscription.post(url)
 
+    def create_billing_info(self, billing_info):
+        """Change this account's billing information to the given `BillingInfo` via POST"""
+        url = urljoin(self._url, '/billing_info')
+        response = billing_info.http_request(url, 'POST', billing_info,
+            {'Content-Type': 'application/xml; charset=utf-8'})
+        if response.status == 200:
+            pass
+        elif response.status == 201:
+            billing_info._url = response.getheader('Location')
+        else:
+            billing_info.raise_http_error(response)
+
+        response_xml = response.read()
+        logging.getLogger('recurly.http.response').debug(response_xml)
+        billing_info.update_from_element(ElementTree.fromstring(response_xml))
+
     def update_billing_info(self, billing_info):
         """Change this account's billing information to the given `BillingInfo`."""
         url = urljoin(self._url, '/billing_info')


### PR DESCRIPTION
It is impossible to create billing info via a POST call without this change.

Playground script:

```python
# Assumes account "x" exists on this site
# Assumes gateway_code "jhpqd551excn" is the code for vantiv on this site

from stub import recurly

account = recurly.Account.get('x')
billing_info = recurly.BillingInfo()

billing_info.first_name         = 'John'
billing_info.last_name          = 'Smith'
billing_info.address1           = '125 Paper Street'
billing_info.city               = 'Los Angeles'
billing_info.state              = 'CA'
billing_info.zip                = '95312'
billing_info.country            = 'US'
billing_info.phone              = '213-555-5555'
billing_info.vat_number         = '54321'
billing_info.gateway_token      = '4111115851581111'
billing_info.gateway_code       = 'jhpqd551excn'
billing_info.card_type          = 'visa'
billing_info.month              = '10'
billing_info.year               = '2020'


account.create_billing_info(billing_info)
```