### PR TITLE
Use latest official python 3.7 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7-dev"
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
-  - pip install six mock iso8601 backports.ssl-match-hostname
   - python setup.py install
 script:
   - RECURLY_INSECURE_DEBUG=true python -m unittest discover -s tests


### PR DESCRIPTION
Wanted to make sure we are using the latest official 3.7 release and also test removing the manual dep installs.