### PR TITLE
Update refund methods for credit invoices

### DIFF
--- a/tests/fixtures/invoice/line-item-refunded.xml
+++ b/tests/fixtures/invoice/line-item-refunded.xml
@@ -7,7 +7,6 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <invoice>
-    <refund_method>credit_first</refund_method>
     <line_items>
         <adjustment>
             <uuid>2bc3cf4cb513049c6aec1b419c97b508</uuid>
@@ -15,6 +14,9 @@ Content-Type: application/xml; charset=utf-8
             <prorate type="boolean">false</prorate>
         </adjustment>
     </line_items>
+    <credit_customer_notes>Credit Customer Notes</credit_customer_notes>
+    <description>Description</description>
+    <refund_method>credit_first</refund_method>
 </invoice>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/invoice/refunded.xml
+++ b/tests/fixtures/invoice/refunded.xml
@@ -7,8 +7,10 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <invoice>
-    <refund_method>credit_first</refund_method>
     <amount_in_cents type="integer">1000</amount_in_cents>
+    <credit_customer_notes>Credit Customer Notes</credit_customer_notes>
+    <description>Description</description>
+    <refund_method>credit_first</refund_method>
 </invoice>
 
 HTTP/1.1 201 Created

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -832,7 +832,12 @@ class TestResources(RecurlyTest):
             invoice = account.invoice().charge_invoice
 
         with self.mock_request('invoice/refunded.xml'):
-            refund_invoice = invoice.refund_amount(1000)
+            options = {
+                'refund_method': 'credit_first',
+                'credit_customer_notes': 'Credit Customer Notes',
+                'description': 'Description'
+            }
+            refund_invoice = invoice.refund_amount(1000, options)
         self.assertEqual(refund_invoice.subtotal_in_cents, -1000)
 
     def test_invoice_refund(self):
@@ -846,7 +851,12 @@ class TestResources(RecurlyTest):
         with self.mock_request('invoice/line-item-refunded.xml'):
             line_items = [{ 'adjustment': invoice.line_items[0], 'quantity': 1,
                 'prorate': False }]
-            refund_invoice = invoice.refund(line_items)
+            options = {
+                'refund_method': 'credit_first',
+                'credit_customer_notes': 'Credit Customer Notes',
+                'description': 'Description'
+            }
+            refund_invoice = invoice.refund(line_items, options)
         self.assertEqual(refund_invoice.subtotal_in_cents, -1000)
 
     def test_invoice_with_optionals(self):


### PR DESCRIPTION
Adjusting the refund methods to support new credit invoice options. Still a WIP. Will add testing info and scripts soon.

# Testing

```python
invoice = recurly.Invoice.get('1101')
line_items = list({'adjustment' : adjustment, 'quantity' : 1, 'prorate' : False} for adjustment in invoice.line_items)

# These two calls should generate the same xml
ref = invoice.refund(line_items, 'credit_first')                     # old
ref = invoice.refund(line_items, {'refund_method': 'credit_first'})  # new

# These two calls should generate the same xml
ref = invoice.refund_amount(100, 'credit_first')                     # old
ref = invoice.refund_amount(100, {'refund_method': 'credit_first'})  # new
```