### PR TITLE
Bump to version 2.9.1 / API version 2.16

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## Version 2.9.1 – October 30th, 2018 ##
+
+This version brings us up to API version 2.16, but has no breaking changes
+
+- Add a GatewayTimeoutError class [PR](https://github.com/recurly/recurly-client-python/pull/267)
+
 ## Version 2.9.0 – September 25th, 2018 ##
 
 This version brings us up to API version 2.15.

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -21,7 +21,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.0'
+__version__ = '2.9.1'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {
@@ -45,7 +45,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.15'
+API_VERSION = '2.16'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None


### PR DESCRIPTION
## Version 2.9.1 – October 30th, 2018

This version brings us up to API version 2.16, but has no breaking changes

- Add a GatewayTimeoutError class [PR](https://github.com/recurly/recurly-client-python/pull/267)