### PR TITLE
Add exemption certificate attribute to Account

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -171,6 +171,7 @@ class Account(Resource):
         'company_name',
         'vat_number',
         'tax_exempt',
+        'exemption_certificate',
         'entity_use_code',
         'accept_language',
         'cc_emails',

--- a/tests/fixtures/account/show-taxed.xml
+++ b/tests/fixtures/account/show-taxed.xml
@@ -23,4 +23,5 @@ Content-Type: application/xml; charset=utf-8
   <company_name nil="nil"></company_name>
   <accept_language nil="nil"></accept_language>
   <tax_exempt type="boolean">true</tax_exempt>
+  <exemption_certificate>Some Certificate</exemption_certificate>
 </account>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -234,6 +234,7 @@ class TestResources(RecurlyTest):
         with self.mock_request('account/show-taxed.xml'):
             account = Account.get(account_code)
             self.assertTrue(account.tax_exempt)
+            self.assertEqual(account.exemption_certificate, 'Some Certificate')
 
     def test_account_addresses(self):
         account_code = 'test%s' % self.test_id


### PR DESCRIPTION
Adds exemption_certificate attribute to the account object.

Script:
```python
account = recurly.Account(account_code='new-account')
account.tax_exempt = True
account.exemption_certificate = 'Some Certificate'
account.save()
```