### PR TITLE
Release version 2.9.2 / API version 2.17

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## Version 2.9.2 – December 11th, 2018 ##
+
+This version brings us up to API version 2.17, but has no breaking changes
+
+- Add `gateway_code` to Subscription and Invoice objects [PR](https://github.com/recurly/recurly-client-python/pull/271)
+- Add `exemption_certificate` to Account object [PR](https://github.com/recurly/recurly-client-python/pull/272)
+- Add OpenSSL version to user agent [PR](https://github.com/recurly/recurly-client-python/pull/274)
+
 ## Version 2.9.1 – October 30th, 2018 ##
 
 This version brings us up to API version 2.16, but has no breaking changes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## Version 2.9.1 – October 30th, 2018 ##
+
+This version brings us up to API version 2.16, but has no breaking changes
+
+- Add a GatewayTimeoutError class [PR](https://github.com/recurly/recurly-client-python/pull/267)
+
 ## Version 2.9.0 – September 25th, 2018 ##
 
 This version brings us up to API version 2.15.

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -21,7 +21,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.0'
+__version__ = '2.9.1'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {
@@ -45,7 +45,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.15'
+API_VERSION = '2.16'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -171,6 +171,7 @@ class Account(Resource):
         'company_name',
         'vat_number',
         'tax_exempt',
+        'exemption_certificate',
         'entity_use_code',
         'accept_language',
         'cc_emails',

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -21,7 +21,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.1'
+__version__ = '2.9.2'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -45,7 +45,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.16'
+API_VERSION = '2.17'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -751,6 +751,7 @@ class Invoice(Resource):
         'type',
         'origin',
         'credit_customer_notes',
+        'gateway_code'
     )
 
     blacklist_attributes = (
@@ -1069,6 +1070,7 @@ class Subscription(Resource):
         'current_term_started_at',
         'current_term_ends_at',
         'custom_fields',
+        'gateway_code',
     )
     sensitive_attributes = ('number', 'verification_value', 'bulk')
 

--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -299,6 +299,16 @@ class ServiceUnavailableError(ServerError):
     pass
 
 
+class GatewayTimeoutError(ServerError):
+    """An error indicating the service is temporarily unavailable.
+
+    This error results from an HTTP ``504 Gateway Timeout``
+    response. Try the request again.
+
+    """
+    pass
+
+
 class UnexpectedStatusError(ResponseError):
 
     """An error resulting from an unexpected status code returned by
@@ -325,6 +335,7 @@ error_classes = {
     500: InternalServerError,
     502: BadGatewayError,
     503: ServiceUnavailableError,
+    504: GatewayTimeoutError,
 }
 
 

--- a/tests/fixtures/account/show-taxed.xml
+++ b/tests/fixtures/account/show-taxed.xml
@@ -23,4 +23,5 @@ Content-Type: application/xml; charset=utf-8
   <company_name nil="nil"></company_name>
   <accept_language nil="nil"></accept_language>
   <tax_exempt type="boolean">true</tax_exempt>
+  <exemption_certificate>Some Certificate</exemption_certificate>
 </account>

--- a/tests/fixtures/invoice/update-invoice.xml
+++ b/tests/fixtures/invoice/update-invoice.xml
@@ -25,6 +25,7 @@ Content-Type: application/xml; charset=utf-8
      <phone>781-452-4077</phone>
    </address>
    <net_terms type="integer">1</net_terms>
+   <gateway_code>A new gateway code</gateway_code>
 </invoice>
 
 
@@ -74,6 +75,7 @@ Content-Type: application/xml; charset=utf-8
   <credit_payments type="array">
   </credit_payments>
   <net_terms type="integer">1</net_terms>
+  <gateway_code>A new gateway code</gateway_code>
   <collection_method>manual</collection_method>
   <po_number>1234</po_number>
   <terms_and_conditions>School staff is not responsible for items left at Hogwarts School of Witchcraft and Wizardry.</terms_and_conditions>

--- a/tests/fixtures/subscription/subscribe-notes.xml
+++ b/tests/fixtures/subscription/subscribe-notes.xml
@@ -1,20 +1,27 @@
-GET https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab HTTP/1.1
+PUT https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/notes HTTP/1.1
 X-Api-Version: {api-version}
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}
-
-
-HTTP/1.1 200 OK
-X-Records: 1
 Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription>
+  <terms_and_conditions>Some terms and conditions</terms_and_conditions>
+  <customer_notes>Some customer notes</customer_notes>
+  <vat_reverse_charge_notes>Some vat reverse charge notes</vat_reverse_charge_notes>
+  <gateway_code>A new gateway code</gateway_code>
+</subscription>
+
+HTTP/1.1 200 OK 
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/plans/basicplan
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription
     href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab">
-  <redemptions href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/redemptions" />
   <uuid>123456789012345678901234567890ab</uuid>
-  <account href="https://api.recurly.com/v2/accounts/subscribemock"/>
+  <account href="https://api.recurly.com/v2/accounts/subscribe-mock-2"/>
   <plan href="https://api.recurly.com/v2/plans/basicplan">
     <plan_code>basicplan</plan_code>
     <name>Basic Plan</name>
@@ -30,20 +37,10 @@ Content-Type: application/xml; charset=utf-8
   <current_period_ends_at type="datetime">2010-07-27T07:00:00Z</current_period_ends_at>
   <trial_started_at nil="nil"></trial_started_at>
   <trial_ends_at nil="nil"></trial_ends_at>
-  <tax_in_cents type="integer">0</tax_in_cents>
-  <tax_type>usst</tax_type>
-  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
-  <gateway_code>A gateway code</gateway_code>
+  <terms_and_conditions>Some terms and conditions</terms_and_conditions>
+  <customer_notes>Some customer notes</customer_notes>
+  <vat_reverse_charge_notes>Some vat reverse charge notes</vat_reverse_charge_notes>
+  <gateway_code>A new gateway code</gateway_code>
   <subscription_add_ons type="array">
-    <subscription_add_on>
-        <add_on_type>usage</add_on_type>
-        <measured_unit href="https://api.recurly.com/v2/measured_units/123456"/>
-        <usage href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/add_ons/marketing_emails/usage"/>
-        <add_on_code>marketing_emails</add_on_code>
-        <unit_amount_in_cents type="integer">5</unit_amount_in_cents>
-        <quantity type="integer">1</quantity>
-        <usage_type>price</usage_type>
-        <usage_percentage nil="nil"/>
-    </subscription_add_on>
   </subscription_add_ons>
 </subscription>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -234,6 +234,7 @@ class TestResources(RecurlyTest):
         with self.mock_request('account/show-taxed.xml'):
             account = Account.get(account_code)
             self.assertTrue(account.tax_exempt)
+            self.assertEqual(account.exemption_certificate, 'Some Certificate')
 
     def test_account_addresses(self):
         account_code = 'test%s' % self.test_id

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -909,6 +909,7 @@ class TestResources(RecurlyTest):
             invoice.customer_notes = "It's levi-O-sa, not levio-SA!"
             invoice.vat_reverse_charge_notes = "can't be changed when invoice was not a reverse charge"
             invoice.net_terms = 1
+            invoice.gateway_code = 'A new gateway code'
             invoice.save()
 
         self.assertEqual(invoice.address.first_name, 'Harry')
@@ -927,6 +928,7 @@ class TestResources(RecurlyTest):
         self.assertEqual(invoice.customer_notes, "It's levi-O-sa, not levio-SA!")
         self.assertEqual(invoice.vat_reverse_charge_notes, "can't be changed when invoice was not a reverse charge")
         self.assertEqual(invoice.net_terms, 1)
+        self.assertEqual(invoice.gateway_code, 'A new gateway code')
 
     def test_build_invoice(self):
         account = Account(account_code='invoice%s' % self.test_id)
@@ -1416,6 +1418,19 @@ class TestResources(RecurlyTest):
         finally:
             with self.mock_request('subscribe-add-on/plan-deleted.xml'):
                 plan.delete()
+
+    def test_subscription_notes(self):
+        with self.mock_request('subscription/show.xml'):
+            sub = Subscription.get('123456789012345678901234567890ab')
+
+        with self.mock_request('subscription/subscribe-notes.xml'):
+            sub.terms_and_conditions = "Some terms and conditions"
+            sub.customer_notes = "Some customer notes"
+            sub.vat_reverse_charge_notes = "Some vat reverse charge notes"
+            sub.gateway_code = 'A new gateway code'
+            sub.update_notes()
+
+        self.assertEquals(sub.gateway_code, 'A new gateway code')
 
     def test_subscription_custom_fields(self):
         account_code = 'subscribe-%s-2' % self.test_id


### PR DESCRIPTION
## Version 2.9.2 – December 11th, 2018 ##

This version brings us up to API version 2.17, but has no breaking changes

- Add `gateway_code` to Subscription and Invoice objects [PR](https://github.com/recurly/recurly-client-python/pull/271)
- Add `exemption_certificate` to Account object [PR](https://github.com/recurly/recurly-client-python/pull/272)
- Add OpenSSL version to user agent [PR](https://github.com/recurly/recurly-client-python/pull/274)