### PR TITLE
Add UnexpectedClientError and UnexpectedServerError classes

### DIFF
--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -322,6 +322,23 @@ class UnexpectedStatusError(ResponseError):
         return six.text_type(self.status)
 
 
+class UnexpectedClientError(UnexpectedStatusError):
+    """An error resulting from an unexpected status code in
+    the range 400-499 of HTTP status codes. This class should
+    not be used for classes mapped in the `error_classes` dict.
+
+    """
+    pass
+
+class UnexpectedServerError(UnexpectedStatusError):
+    """An error resulting from an unexpected status code in
+    the range 500-599 of HTTP status codes. This class should
+    not be used for classes mapped in the `error_classes` dict.
+
+    """
+    pass
+
+
 error_classes = {
     400: BadRequestError,
     401: UnauthorizedError,
@@ -346,6 +363,10 @@ def error_class_for_http_status(status):
         return error_classes[status]
     except KeyError:
         def new_status_error(xml_response):
+            if (status > 400 and status < 500):
+                return UnexpectedClientError(status, xml_response)
+            if (status > 500 and status < 600):
+                return UnexpectedServerError(status, xml_response)
             return UnexpectedStatusError(status, xml_response)
         return new_status_error
 

--- a/tests/fixtures/transaction/error-client.xml
+++ b/tests/fixtures/transaction/error-client.xml
@@ -1,0 +1,23 @@
+POST https://api.recurly.com/v2/transactions HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction>
+  <account>
+    <account_code>transactionmock</account_code>
+  </account>
+  <currency>USD</currency>
+  <amount_in_cents type="integer">1000</amount_in_cents>
+</transaction>
+
+HTTP/1.1 495
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<errors>
+  <error>Method not allowed</error>
+</errors>

--- a/tests/fixtures/transaction/error-server.xml
+++ b/tests/fixtures/transaction/error-server.xml
@@ -1,0 +1,23 @@
+POST https://api.recurly.com/v2/transactions HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction>
+  <account>
+    <account_code>transactionmock</account_code>
+  </account>
+  <currency>USD</currency>
+  <amount_in_cents type="integer">1000</amount_in_cents>
+</transaction>
+
+HTTP/1.1 530 Origin DNS Error
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<errors>
+  <error>Method not allowed</error>
+</errors>

--- a/tests/fixtures/transaction/error-teapot.xml
+++ b/tests/fixtures/transaction/error-teapot.xml
@@ -1,0 +1,23 @@
+POST https://api.recurly.com/v2/transactions HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction>
+  <account>
+    <account_code>transactionmock</account_code>
+  </account>
+  <currency>USD</currency>
+  <amount_in_cents type="integer">1000</amount_in_cents>
+</transaction>
+
+HTTP/1.1 418 I'm a teapot
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<errors>
+  <error>Method not allowed</error>
+</errors>


### PR DESCRIPTION
Fixes #276.

This should NOT be a breaking change because these two new classes inherit from `UnexpectedStatusError` so any current `except` blocks will continue to catch these errors all the same (see unit tests). The logic to throw these errors still happens after the check in the `error_classes` dict, so if the error is defined there, it will throw that more specific error first.

There is no script for this change, just the unit test.