### PR TITLE
Add amazon_region to Billing Info

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -398,6 +398,7 @@ class BillingInfo(Resource):
         'last_four',
         'paypal_billing_agreement_id',
         'amazon_billing_agreement_id',
+        'amazon_region',
         'token_id',
         'account_type',
         'routing_number',


### PR DESCRIPTION
Adds an additional attribute amazon_region to the billing info object.

```python
account = recurly.Account.get('x')
billing_info = recurly.BillingInfo()

billing_info.first_name         = 'John'
billing_info.last_name          = 'Smith'
billing_info.address1           = '125 Paper Street'
billing_info.city               = 'Los Angeles'
billing_info.state              = 'CA'
billing_info.zip                = '95312'
billing_info.country            = 'US'
billing_info.phone              = '213-555-5555'
billing_info.amazon_billing_agreement_id = 'C02-2000965-4255444'
billing_info.amazon_region      = 'uk'

account.create_billing_info(billing_info)
```