### PR TITLE
Bump to version 2.9.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## Version 2.9.3 - January 17th, 2019 ##
+
+- Add UnexpectedClientError and UnexpectedServerError classes [PR](https://github.com/recurly/recurly-client-python/pull/277)
+
 ## Version 2.9.2 – December 11th, 2018 ##
 
 This version brings us up to API version 2.17, but has no breaking changes

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -21,7 +21,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.2'
+__version__ = '2.9.3'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {


### PR DESCRIPTION
## Version 2.9.3 - January 17th, 2019 ##

- Add UnexpectedClientError and UnexpectedServerError classes [PR](https://github.com/recurly/recurly-client-python/pull/277)