### PR TITLE
Release version 2.9.5 / API version 2.19

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## Version 2.9.5 – March 12th, 2019 ##
+
+This version brings us up to API version 2.19, but has no breaking changes
+
+- Add support for Account Hierarchy [PR](https://github.com/recurly/recurly-client-python/pull/279)
+
 ## Version 2.9.4 – February 19th, 2019 ##
 
 This version brings us up to API version 2.18, but has no breaking changes

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -46,7 +46,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.18'
+API_VERSION = '2.19'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -165,6 +165,7 @@ class Account(Resource):
 
     attributes = (
         'account_code',
+        'parent_account_code',
         'username',
         'email',
         'first_name',

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -22,7 +22,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.4'
+__version__ = '2.9.5'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {

--- a/tests/fixtures/account/child-accounts.xml
+++ b/tests/fixtures/account/child-accounts.xml
@@ -1,0 +1,56 @@
+GET https://api.recurly.com/v2/accounts/parent-account/child_accounts HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<accounts type="array">
+    <account href="https://api.recurly.com/v2/accounts/testmock">
+    <parent_account href="https://api.recurly.com/v2/accounts/parent-account"/>
+    <adjustments href="https://api.recurly.com/v2/accounts/testmock/adjustments"/>
+    <billing_info href="https://api.recurly.com/v2/accounts/testmock/billing_info"/>
+    <invoices href="https://api.recurly.com/v2/accounts/testmock/invoices"/>
+    <redemptions href="https://api.recurly.com/v2/accounts/testmock/redemptions"/>
+    <subscriptions href="https://api.recurly.com/v2/accounts/testmock/subscriptions"/>
+    <shipping_addresses href="https://api.recurly.com/v2/accounts/testmock/shipping_addresses"/>
+    <transactions href="https://api.recurly.com/v2/accounts/testmock/transactions"/>
+    <account_code>testmock</account_code>
+    <parent_account_code>parent-account</parent_account_code>
+    <state>active</state>
+    <username nil="nil"></username>
+    <email nil="nil"></email>
+    <cc_emails nil="nil"></cc_emails>
+    <first_name nil="nil"></first_name>
+    <last_name nil="nil"></last_name>
+    <company_name nil="nil"></company_name>
+    <vat_number nil="nil"></vat_number>
+    <preferred_locale nil="nil"></preferred_locale>
+    <address>
+      <address1 nil="nil"></address1>
+      <address2 nil="nil"></address2>
+      <city nil="nil"></city>
+      <state nil="nil"></state>
+      <zip nil="nil"></zip>
+      <country nil="nil"></country>
+      <phone nil="nil"></phone>
+    </address>
+    <accept_language nil="nil"></accept_language>
+    <created_at type="datetime">2019-01-03T00:11:18Z</created_at>
+    <updated_at type="datetime">2019-01-03T00:33:43Z</updated_at>
+    <closed_at nil="nil"></closed_at>
+    <custom_fields type="array">
+    </custom_fields>
+    <has_live_subscription type="boolean">true</has_live_subscription>
+    <has_active_subscription type="boolean">true</has_active_subscription>
+    <has_future_subscription type="boolean">false</has_future_subscription>
+    <has_canceled_subscription type="boolean">false</has_canceled_subscription>
+    <has_past_due_invoice type="boolean">false</has_past_due_invoice>
+    <has_paused_subscription type="boolean">false</has_paused_subscription>
+    <bill_to>self</bill_to>
+  </account>
+</accounts>

--- a/tests/fixtures/account/created-with-parent.xml
+++ b/tests/fixtures/account/created-with-parent.xml
@@ -1,0 +1,47 @@
+POST https://api.recurly.com/v2/accounts HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account>
+  <account_code>testmock</account_code>
+  <parent_account_code>parent-account</parent_account_code>
+</account>
+
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/testmock
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/testmock">
+  <parent_account href="https://api.recurly.com/v2/accounts/parent-account"/>
+  <adjustments href="https://api.recurly.com/v2/accounts/testmock/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/testmock/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/testmock/invoices"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/testmock/subscriptions"/>
+  <transactions href="https://api.recurly.com/v2/accounts/testmock/transactions"/>
+  <account_code>testmock</account_code>
+  <parent_account_code>parent-account</parent_account_code>
+  <username nil="nil"></username>
+  <email nil="nil"></email>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
+  <company_name nil="nil"></company_name>
+  <vat_number nil="nil"></vat_number>
+  <cc_emails nil="nil"></cc_emails>
+  <address>
+    <address1>123 Main St</address1>
+    <address2 nil="nil"></address2>
+    <city>San Francisco</city>
+    <state>CA</state>
+    <zip>94105</zip>
+    <country>US</country>
+    <phone>8015559876</phone>
+  </address>
+  <accept_language nil="nil"></accept_language>
+  <preferred_locale>en-US</preferred_locale>
+</account>

--- a/tests/fixtures/account/exists-with-child-accounts.xml
+++ b/tests/fixtures/account/exists-with-child-accounts.xml
@@ -1,0 +1,28 @@
+GET https://api.recurly.com/v2/accounts/parent-account HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/parent-account">
+  <child_accounts href="https://api.recurly.com/v2/accounts/parent-account/child_accounts"/>
+  <adjustments href="https://api.recurly.com/v2/accounts/parent-account/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/parent-account/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/parent-account/invoices"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/parent-account/subscriptions"/>
+  <transactions href="https://api.recurly.com/v2/accounts/parent-account/transactions"/>
+  <account_balance href="https://api.recurly.com/v2/accounts/parent-account/balance"/>
+  <account_code>parent-account</account_code>
+  <username nil="nil"></username>
+  <email nil="nil"></email>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
+  <company_name nil="nil"></company_name>
+  <entity_use_code>I</entity_use_code>
+  <accept_language nil="nil"></accept_language>
+</account>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -313,6 +313,27 @@ class TestResources(RecurlyTest):
         self.assertEquals(existing_account.custom_fields[1].name, 'field2')
         self.assertEquals(existing_account.custom_fields[1].value, 'new value2')
 
+    def test_account_hierarchy(self):
+        account_code = 'test%s' % self.test_id
+        """Create an account with a parent"""
+        account = Account(
+            account_code=account_code,
+            parent_account_code="parent-account"
+        )
+        with self.mock_request('account/created-with-parent.xml'):
+            account.save()
+
+        """Get Parent account"""
+        with self.mock_request('account/exists-with-child-accounts.xml'):
+            parent = account.parent_account()
+
+        self.assertEquals(parent.account_code, 'parent-account')
+
+        """Get Child accounts"""
+        with self.mock_request('account/child-accounts.xml'):
+            for acct in parent.child_accounts():
+                self.assertEquals(acct.account_code, 'test%s' % self.test_id)
+
     def test_account_acquisition(self):
         account_code = 'test%s' % self.test_id
 


### PR DESCRIPTION
## Version 2.9.5 – March 12th, 2019 ##

This version brings us up to API version 2.19, but has no breaking changes

- Add support for Account Hierarchy [PR](https://github.com/recurly/recurly-client-python/pull/279)