### PR TITLE
Bump to version 2.9.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## Version 2.9.6 – April 30th, 2019 ##
+
+- Add product code to Adjustments [PR](https://github.com/recurly/recurly-client-python/pull/286)
+
 ## Version 2.9.5 – March 12th, 2019 ##
 
 This version brings us up to API version 2.19, but has no breaking changes

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -22,7 +22,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.5'
+__version__ = '2.9.6'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {


### PR DESCRIPTION
## Version 2.9.6 – April 30th, 2019 ##

- Add product code to Adjustments [PR](https://github.com/recurly/recurly-client-python/pull/286)