### PR TITLE
Add support for shipping fees

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -968,6 +968,7 @@ class Purchase(Resource):
         'terms_and_conditions',
         'vat_reverse_charge_notes',
         'shipping_address_id',
+        'shipping_fees',
         'gateway_code',
         'collection_method',
     )
@@ -1040,6 +1041,37 @@ class Purchase(Resource):
         invoice_collection = InvoiceCollection.from_element(elem)
         return invoice_collection
 
+class ShippingFee(Resource):
+
+    """A one time shipping fee on a Purchase"""
+
+    nodename = 'shipping_fee'
+
+    attributes = (
+        'shipping_method_code',
+        'shipping_amount_in_cents',
+        'shipping_address',
+        'shipping_address_id',
+    )
+
+class ShippingMethod(Resource):
+
+    """A shipping method available on the site"""
+
+    member_path = 'shipping_methods/%s'
+    collection_path = 'shipping_methods'
+
+    nodename = 'shipping_method'
+
+    attributes = (
+      'code',
+      'name',
+      'accounting_code',
+      'tax_code',
+      'created_at',
+      'updated_at',
+    )
+
 class Subscription(Resource):
 
     """A customer account's subscription to your service."""
@@ -1090,6 +1122,8 @@ class Subscription(Resource):
         'gift_card',
         'shipping_address',
         'shipping_address_id',
+        'shipping_method_code',
+        'shipping_amount_in_cents',
         'started_with_gift',
         'converted_at',
         'no_billing_info_reason',


### PR DESCRIPTION
This adds support for shipping fees and the new shipping methods endpoint.

List shipping methods:
```python
page_size = 200
for shipping_method in recurly.ShippingMethod.all(per_page = page_size):
    print(shipping_method.name)
```
Get a shipping method:
```python
# Assumes a shipping method with code 'slow_boat' exists on site
shipping_method = recurly.ShippingMethod.get('slow_boat')
print(shipping_method.name)
```
Purchase with shipping fees (note: either account must have shipping address, or purchase must have shipping_address_id):
```python
# Assumes shipping_method_code 'fast_fast_fast' exists on the site

purchase = recurly.Purchase(
  currency = 'USD',
  po_number = '12321',
  collection_method = 'automatic',
  account = recurly.Account(
    account_code = 'x',
    billing_info = recurly.BillingInfo(
        first_name = 'Benjamin',
        last_name = 'DuMonde',
        number = '4111-1111-1111-1111',
        verification_value = '123',
        month = 11,
        year = 2020,
        address1 = '123 Main St',
        city = 'New Orleans',
        state = 'LA',
        zip = '70114',
        country = 'US',
    )
  ),
  subscriptions = [
    recurly.Subscription(
      plan_code = 'gold'
    )
  ],
  shipping_fees = [
    recurly.ShippingFee(
      shipping_method_code = 'fast_fast_fast',
      shipping_amount_in_cents = 999,
      shipping_address = recurly.ShippingAddress(
        first_name = 'Lon',
        last_name = 'Dorner',
        address1 = '400 Alabama St',
        city = 'San Francisco',
        state = 'CA',
        zip = '94110',
        country = 'US',
        nickname = 'home'
      )
    )
  ]
)

collection = purchase.invoice()
print(collection.credit_invoices)
```

Create/preview subscription (Must either have a shipping address id or a shipping address in the account object):
```python
# Assumes account code 'x' exists on the site
# Assumes plan code 'gold' exists on the site
# Assumes shipping_address_id 2740995644961737721 exists on the account
# Assumes shipping_method_code 'slow_boat' exists on the site

subscription = recurly.Subscription()
subscription.plan_code = 'gold'

subscription.account = recurly.Account(account_code='x')

subscription.shipping_method_code = 'slow_boat'
subscription.shipping_amount_in_cents = 999
subscription.shipping_address_id = 2740995644961737721

subscription.save()
```