### PR TITLE
Fix list_sites bug

### DIFF
--- a/recurly/client.py
+++ b/recurly/client.py
@@ -45,7 +45,7 @@ class Client(BaseClient):
         Pager
             A list of sites.
         """
-        path = "/sites" % (self._site_id,)
+        path = "/sites" % ()
         return Pager(self, path, kwargs)
 
     def get_site(self,):


### PR DESCRIPTION
Fixes this exception with `client.list_sites`

```
Traceback (most recent call last):
  File "scripts/v2018-08-09/python/list_sites.py", line 6, in <module>
    sites = client.list_sites(limit=200).items()
  File "./clients/python/recurly/client.py", line 48, in list_sites
    path = "/sites" % (self._site_id,)
TypeError: not all arguments converted during string formatting
```