### PR TITLE
Use an interpolate_path method

### DIFF
--- a/recurly/base_client.py
+++ b/recurly/base_client.py
@@ -62,3 +62,8 @@ class BaseClient:
 
         except socket.error as e:
             raise NetworkError(e)
+
+    def _interpolate_path(self, path, *args):
+        """Encodes components and interpolates path"""
+
+        return path % tuple(map(urllib.parse.quote, args))

--- a/recurly/client.py
+++ b/recurly/client.py
@@ -45,7 +45,7 @@ class Client(BaseClient):
         Pager
             A list of sites.
         """
-        path = "/sites" % ()
+        path = self._interpolate_path("/sites")
         return Pager(self, path, kwargs)
 
     def get_site(self,):
@@ -56,7 +56,7 @@ class Client(BaseClient):
         Site
             A site.
         """
-        path = "/sites/%s" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s", self._site_id)
         return self._make_request("GET", path, None, None)
 
     def list_accounts(self, **kwargs):
@@ -104,7 +104,7 @@ class Client(BaseClient):
         Pager
             A list of the site's accounts.
         """
-        path = "/sites/%s/accounts" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/accounts", self._site_id)
         return Pager(self, path, kwargs)
 
     def create_account(self, body):
@@ -121,7 +121,7 @@ class Client(BaseClient):
         Account
             An account.
         """
-        path = "/sites/%s/accounts" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/accounts", self._site_id)
         return self._make_request("POST", path, body, None)
 
     def get_account(self, account_id):
@@ -138,7 +138,9 @@ class Client(BaseClient):
         Account
             An account.
         """
-        path = "/sites/%s/accounts/%s" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s", self._site_id, account_id
+        )
         return self._make_request("GET", path, None, None)
 
     def update_account(self, account_id, body):
@@ -157,7 +159,9 @@ class Client(BaseClient):
         Account
             An account.
         """
-        path = "/sites/%s/accounts/%s" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s", self._site_id, account_id
+        )
         return self._make_request("PUT", path, body, None)
 
     def deactivate_account(self, account_id):
@@ -174,7 +178,9 @@ class Client(BaseClient):
         Account
             An account.
         """
-        path = "/sites/%s/accounts/%s" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s", self._site_id, account_id
+        )
         return self._make_request("DELETE", path, None, None)
 
     def get_account_acquisition(self, account_id):
@@ -191,7 +197,9 @@ class Client(BaseClient):
         AccountAcquisition
             An account's acquisition data.
         """
-        path = "/sites/%s/accounts/%s/acquisition" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/acquisition", self._site_id, account_id
+        )
         return self._make_request("GET", path, None, None)
 
     def update_account_acquisition(self, account_id, body):
@@ -210,7 +218,9 @@ class Client(BaseClient):
         AccountAcquisition
             An account's updated acquisition data.
         """
-        path = "/sites/%s/accounts/%s/acquisition" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/acquisition", self._site_id, account_id
+        )
         return self._make_request("PUT", path, body, None)
 
     def remove_account_acquisition(self, account_id):
@@ -223,7 +233,9 @@ class Client(BaseClient):
 
 
         """
-        path = "/sites/%s/accounts/%s/acquisition" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/acquisition", self._site_id, account_id
+        )
         return self._make_request("DELETE", path, None, None)
 
     def reactivate_account(self, account_id):
@@ -240,7 +252,9 @@ class Client(BaseClient):
         Account
             An account.
         """
-        path = "/sites/%s/accounts/%s/reactivate" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/reactivate", self._site_id, account_id
+        )
         return self._make_request("PUT", path, None, None)
 
     def get_account_balance(self, account_id):
@@ -257,7 +271,9 @@ class Client(BaseClient):
         AccountBalance
             An account's balance.
         """
-        path = "/sites/%s/accounts/%s/balance" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/balance", self._site_id, account_id
+        )
         return self._make_request("GET", path, None, None)
 
     def get_billing_info(self, account_id):
@@ -274,7 +290,9 @@ class Client(BaseClient):
         BillingInfo
             An account's billing information.
         """
-        path = "/sites/%s/accounts/%s/billing_info" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/billing_info", self._site_id, account_id
+        )
         return self._make_request("GET", path, None, None)
 
     def update_billing_info(self, account_id, body):
@@ -293,7 +311,9 @@ class Client(BaseClient):
         BillingInfo
             Updated billing information.
         """
-        path = "/sites/%s/accounts/%s/billing_info" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/billing_info", self._site_id, account_id
+        )
         return self._make_request("PUT", path, body, None)
 
     def remove_billing_info(self, account_id):
@@ -306,7 +326,9 @@ class Client(BaseClient):
 
 
         """
-        path = "/sites/%s/accounts/%s/billing_info" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/billing_info", self._site_id, account_id
+        )
         return self._make_request("DELETE", path, None, None)
 
     def list_account_coupon_redemptions(self, account_id, **kwargs):
@@ -347,7 +369,9 @@ class Client(BaseClient):
         Pager
             A list of the the coupon redemptions on an account.
         """
-        path = "/sites/%s/accounts/%s/coupon_redemptions" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/coupon_redemptions", self._site_id, account_id
+        )
         return Pager(self, path, kwargs)
 
     def get_active_coupon_redemption(self, account_id):
@@ -364,9 +388,8 @@ class Client(BaseClient):
         CouponRedemption
             An active coupon redemption on an account.
         """
-        path = "/sites/%s/accounts/%s/coupon_redemptions/active" % (
-            self._site_id,
-            account_id,
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/coupon_redemptions/active", self._site_id, account_id
         )
         return self._make_request("GET", path, None, None)
 
@@ -386,9 +409,8 @@ class Client(BaseClient):
         CouponRedemption
             Returns the new coupon redemption.
         """
-        path = "/sites/%s/accounts/%s/coupon_redemptions/active" % (
-            self._site_id,
-            account_id,
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/coupon_redemptions/active", self._site_id, account_id
         )
         return self._make_request("POST", path, body, None)
 
@@ -406,9 +428,8 @@ class Client(BaseClient):
         CouponRedemption
             Coupon redemption deleted.
         """
-        path = "/sites/%s/accounts/%s/coupon_redemptions/active" % (
-            self._site_id,
-            account_id,
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/coupon_redemptions/active", self._site_id, account_id
         )
         return self._make_request("DELETE", path, None, None)
 
@@ -442,7 +463,9 @@ class Client(BaseClient):
         Pager
             A list of the account's credit payments.
         """
-        path = "/sites/%s/accounts/%s/credit_payments" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/credit_payments", self._site_id, account_id
+        )
         return Pager(self, path, kwargs)
 
     def list_account_invoices(self, account_id, **kwargs):
@@ -493,7 +516,9 @@ class Client(BaseClient):
         Pager
             A list of the account's invoices.
         """
-        path = "/sites/%s/accounts/%s/invoices" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/invoices", self._site_id, account_id
+        )
         return Pager(self, path, kwargs)
 
     def create_invoice(self, account_id, body):
@@ -512,7 +537,9 @@ class Client(BaseClient):
         InvoiceCollection
             Returns the new invoices.
         """
-        path = "/sites/%s/accounts/%s/invoices" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/invoices", self._site_id, account_id
+        )
         return self._make_request("POST", path, body, None)
 
     def preview_invoice(self, account_id, body):
@@ -531,7 +558,9 @@ class Client(BaseClient):
         InvoiceCollection
             Returns the invoice previews.
         """
-        path = "/sites/%s/accounts/%s/invoices/preview" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/invoices/preview", self._site_id, account_id
+        )
         return self._make_request("POST", path, body, None)
 
     def list_account_line_items(self, account_id, **kwargs):
@@ -582,7 +611,9 @@ class Client(BaseClient):
         Pager
             A list of the account's line items.
         """
-        path = "/sites/%s/accounts/%s/line_items" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/line_items", self._site_id, account_id
+        )
         return Pager(self, path, kwargs)
 
     def create_line_item(self, account_id, body):
@@ -601,7 +632,9 @@ class Client(BaseClient):
         LineItem
             Returns the new line item.
         """
-        path = "/sites/%s/accounts/%s/line_items" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/line_items", self._site_id, account_id
+        )
         return self._make_request("POST", path, body, None)
 
     def list_account_notes(self, account_id, **kwargs):
@@ -632,7 +665,9 @@ class Client(BaseClient):
         Pager
             A list of an account's notes.
         """
-        path = "/sites/%s/accounts/%s/notes" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/notes", self._site_id, account_id
+        )
         return Pager(self, path, kwargs)
 
     def get_account_note(self, account_id, account_note_id):
@@ -651,10 +686,8 @@ class Client(BaseClient):
         AccountNote
             An account note.
         """
-        path = "/sites/%s/accounts/%s/notes/%s" % (
-            self._site_id,
-            account_id,
-            account_note_id,
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/notes/%s", self._site_id, account_id, account_note_id
         )
         return self._make_request("GET", path, None, None)
 
@@ -700,7 +733,9 @@ class Client(BaseClient):
         Pager
             A list of an account's shipping addresses.
         """
-        path = "/sites/%s/accounts/%s/shipping_addresses" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/shipping_addresses", self._site_id, account_id
+        )
         return Pager(self, path, kwargs)
 
     def create_shipping_address(self, account_id, body):
@@ -719,7 +754,9 @@ class Client(BaseClient):
         ShippingAddress
             Returns the new shipping address.
         """
-        path = "/sites/%s/accounts/%s/shipping_addresses" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/shipping_addresses", self._site_id, account_id
+        )
         return self._make_request("POST", path, body, None)
 
     def get_shipping_address(self, account_id, shipping_address_id):
@@ -738,7 +775,8 @@ class Client(BaseClient):
         ShippingAddress
             A shipping address.
         """
-        path = "/sites/%s/accounts/%s/shipping_addresses/%s" % (
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/shipping_addresses/%s",
             self._site_id,
             account_id,
             shipping_address_id,
@@ -763,7 +801,8 @@ class Client(BaseClient):
         ShippingAddress
             The updated shipping address.
         """
-        path = "/sites/%s/accounts/%s/shipping_addresses/%s" % (
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/shipping_addresses/%s",
             self._site_id,
             account_id,
             shipping_address_id,
@@ -782,7 +821,8 @@ class Client(BaseClient):
 
 
         """
-        path = "/sites/%s/accounts/%s/shipping_addresses/%s" % (
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/shipping_addresses/%s",
             self._site_id,
             account_id,
             shipping_address_id,
@@ -837,7 +877,9 @@ class Client(BaseClient):
         Pager
             A list of the account's subscriptions.
         """
-        path = "/sites/%s/accounts/%s/subscriptions" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/subscriptions", self._site_id, account_id
+        )
         return Pager(self, path, kwargs)
 
     def list_account_transactions(self, account_id, **kwargs):
@@ -886,7 +928,9 @@ class Client(BaseClient):
         Pager
             A list of the account's transactions.
         """
-        path = "/sites/%s/accounts/%s/transactions" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/transactions", self._site_id, account_id
+        )
         return Pager(self, path, kwargs)
 
     def list_child_accounts(self, account_id, **kwargs):
@@ -936,7 +980,9 @@ class Client(BaseClient):
         Pager
             A list of an account's child accounts.
         """
-        path = "/sites/%s/accounts/%s/accounts" % (self._site_id, account_id)
+        path = self._interpolate_path(
+            "/sites/%s/accounts/%s/accounts", self._site_id, account_id
+        )
         return Pager(self, path, kwargs)
 
     def list_account_acquisition(self, **kwargs):
@@ -979,7 +1025,7 @@ class Client(BaseClient):
         Pager
             A list of the site's account acquisition data.
         """
-        path = "/sites/%s/acquisitions" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/acquisitions", self._site_id)
         return Pager(self, path, kwargs)
 
     def list_coupons(self, **kwargs):
@@ -1022,7 +1068,7 @@ class Client(BaseClient):
         Pager
             A list of the site's coupons.
         """
-        path = "/sites/%s/coupons" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/coupons", self._site_id)
         return Pager(self, path, kwargs)
 
     def create_coupon(self, body):
@@ -1039,7 +1085,7 @@ class Client(BaseClient):
         Coupon
             A new coupon.
         """
-        path = "/sites/%s/coupons" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/coupons", self._site_id)
         return self._make_request("POST", path, body, None)
 
     def get_coupon(self, coupon_id):
@@ -1056,7 +1102,7 @@ class Client(BaseClient):
         Coupon
             A coupon.
         """
-        path = "/sites/%s/coupons/%s" % (self._site_id, coupon_id)
+        path = self._interpolate_path("/sites/%s/coupons/%s", self._site_id, coupon_id)
         return self._make_request("GET", path, None, None)
 
     def update_coupon(self, coupon_id, body):
@@ -1075,7 +1121,7 @@ class Client(BaseClient):
         Coupon
             The updated coupon.
         """
-        path = "/sites/%s/coupons/%s" % (self._site_id, coupon_id)
+        path = self._interpolate_path("/sites/%s/coupons/%s", self._site_id, coupon_id)
         return self._make_request("PUT", path, body, None)
 
     def list_unique_coupon_codes(self, coupon_id, **kwargs):
@@ -1120,7 +1166,9 @@ class Client(BaseClient):
         Pager
             A list of unique coupon codes that were generated
         """
-        path = "/sites/%s/coupons/%s/unique_coupon_codes" % (self._site_id, coupon_id)
+        path = self._interpolate_path(
+            "/sites/%s/coupons/%s/unique_coupon_codes", self._site_id, coupon_id
+        )
         return Pager(self, path, kwargs)
 
     def list_credit_payments(self, **kwargs):
@@ -1151,7 +1199,7 @@ class Client(BaseClient):
         Pager
             A list of the site's credit payments.
         """
-        path = "/sites/%s/credit_payments" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/credit_payments", self._site_id)
         return Pager(self, path, kwargs)
 
     def get_credit_payment(self, credit_payment_id):
@@ -1168,7 +1216,9 @@ class Client(BaseClient):
         CreditPayment
             A credit payment.
         """
-        path = "/sites/%s/credit_payments/%s" % (self._site_id, credit_payment_id)
+        path = self._interpolate_path(
+            "/sites/%s/credit_payments/%s", self._site_id, credit_payment_id
+        )
         return self._make_request("GET", path, None, None)
 
     def list_custom_field_definitions(self, **kwargs):
@@ -1211,7 +1261,9 @@ class Client(BaseClient):
         Pager
             A list of the site's custom field definitions.
         """
-        path = "/sites/%s/custom_field_definitions" % (self._site_id,)
+        path = self._interpolate_path(
+            "/sites/%s/custom_field_definitions", self._site_id
+        )
         return Pager(self, path, kwargs)
 
     def get_custom_field_definition(self, custom_field_definition_id):
@@ -1228,7 +1280,8 @@ class Client(BaseClient):
         CustomFieldDefinition
             An custom field definition.
         """
-        path = "/sites/%s/custom_field_definitions/%s" % (
+        path = self._interpolate_path(
+            "/sites/%s/custom_field_definitions/%s",
             self._site_id,
             custom_field_definition_id,
         )
@@ -1280,7 +1333,7 @@ class Client(BaseClient):
         Pager
             A list of the site's invoices.
         """
-        path = "/sites/%s/invoices" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/invoices", self._site_id)
         return Pager(self, path, kwargs)
 
     def get_invoice(self, invoice_id):
@@ -1297,7 +1350,9 @@ class Client(BaseClient):
         Invoice
             An invoice.
         """
-        path = "/sites/%s/invoices/%s" % (self._site_id, invoice_id)
+        path = self._interpolate_path(
+            "/sites/%s/invoices/%s", self._site_id, invoice_id
+        )
         return self._make_request("GET", path, None, None)
 
     def put_invoice(self, invoice_id, body):
@@ -1316,7 +1371,9 @@ class Client(BaseClient):
         Invoice
             An invoice.
         """
-        path = "/sites/%s/invoices/%s" % (self._site_id, invoice_id)
+        path = self._interpolate_path(
+            "/sites/%s/invoices/%s", self._site_id, invoice_id
+        )
         return self._make_request("PUT", path, body, None)
 
     def collect_invoice(self, invoice_id):
@@ -1333,7 +1390,9 @@ class Client(BaseClient):
         Invoice
             The updated invoice.
         """
-        path = "/sites/%s/invoices/%s/collect" % (self._site_id, invoice_id)
+        path = self._interpolate_path(
+            "/sites/%s/invoices/%s/collect", self._site_id, invoice_id
+        )
         return self._make_request("PUT", path, None, None)
 
     def fail_invoice(self, invoice_id):
@@ -1350,7 +1409,9 @@ class Client(BaseClient):
         Invoice
             The updated invoice.
         """
-        path = "/sites/%s/invoices/%s/mark_failed" % (self._site_id, invoice_id)
+        path = self._interpolate_path(
+            "/sites/%s/invoices/%s/mark_failed", self._site_id, invoice_id
+        )
         return self._make_request("PUT", path, None, None)
 
     def mark_invoice_successful(self, invoice_id):
@@ -1367,7 +1428,9 @@ class Client(BaseClient):
         Invoice
             The updated invoice.
         """
-        path = "/sites/%s/invoices/%s/mark_successful" % (self._site_id, invoice_id)
+        path = self._interpolate_path(
+            "/sites/%s/invoices/%s/mark_successful", self._site_id, invoice_id
+        )
         return self._make_request("PUT", path, None, None)
 
     def reopen_invoice(self, invoice_id):
@@ -1384,7 +1447,9 @@ class Client(BaseClient):
         Invoice
             The updated invoice.
         """
-        path = "/sites/%s/invoices/%s/reopen" % (self._site_id, invoice_id)
+        path = self._interpolate_path(
+            "/sites/%s/invoices/%s/reopen", self._site_id, invoice_id
+        )
         return self._make_request("PUT", path, None, None)
 
     def list_invoice_line_items(self, invoice_id, **kwargs):
@@ -1435,7 +1500,9 @@ class Client(BaseClient):
         Pager
             A list of the invoice's line items.
         """
-        path = "/sites/%s/invoices/%s/line_items" % (self._site_id, invoice_id)
+        path = self._interpolate_path(
+            "/sites/%s/invoices/%s/line_items", self._site_id, invoice_id
+        )
         return Pager(self, path, kwargs)
 
     def list_invoice_coupon_redemptions(self, invoice_id, **kwargs):
@@ -1476,7 +1543,9 @@ class Client(BaseClient):
         Pager
             A list of the the coupon redemptions associated with the invoice.
         """
-        path = "/sites/%s/invoices/%s/coupon_redemptions" % (self._site_id, invoice_id)
+        path = self._interpolate_path(
+            "/sites/%s/invoices/%s/coupon_redemptions", self._site_id, invoice_id
+        )
         return Pager(self, path, kwargs)
 
     def list_related_invoices(self, invoice_id, **kwargs):
@@ -1493,7 +1562,9 @@ class Client(BaseClient):
         Pager
             A list of the credit or charge invoices associated with the invoice.
         """
-        path = "/sites/%s/invoices/%s/related_invoices" % (self._site_id, invoice_id)
+        path = self._interpolate_path(
+            "/sites/%s/invoices/%s/related_invoices", self._site_id, invoice_id
+        )
         return Pager(self, path, kwargs)
 
     def refund_invoice(self, invoice_id, body):
@@ -1512,7 +1583,9 @@ class Client(BaseClient):
         Invoice
             Returns the new credit invoice.
         """
-        path = "/sites/%s/invoices/%s/refund" % (self._site_id, invoice_id)
+        path = self._interpolate_path(
+            "/sites/%s/invoices/%s/refund", self._site_id, invoice_id
+        )
         return self._make_request("POST", path, body, None)
 
     def list_line_items(self, **kwargs):
@@ -1561,7 +1634,7 @@ class Client(BaseClient):
         Pager
             A list of the site's line items.
         """
-        path = "/sites/%s/line_items" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/line_items", self._site_id)
         return Pager(self, path, kwargs)
 
     def get_line_item(self, line_item_id):
@@ -1578,7 +1651,9 @@ class Client(BaseClient):
         LineItem
             A line item.
         """
-        path = "/sites/%s/line_items/%s" % (self._site_id, line_item_id)
+        path = self._interpolate_path(
+            "/sites/%s/line_items/%s", self._site_id, line_item_id
+        )
         return self._make_request("GET", path, None, None)
 
     def remove_line_item(self, line_item_id):
@@ -1591,7 +1666,9 @@ class Client(BaseClient):
 
 
         """
-        path = "/sites/%s/line_items/%s" % (self._site_id, line_item_id)
+        path = self._interpolate_path(
+            "/sites/%s/line_items/%s", self._site_id, line_item_id
+        )
         return self._make_request("DELETE", path, None, None)
 
     def list_plans(self, **kwargs):
@@ -1636,7 +1713,7 @@ class Client(BaseClient):
         Pager
             A list of plans.
         """
-        path = "/sites/%s/plans" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/plans", self._site_id)
         return Pager(self, path, kwargs)
 
     def create_plan(self, body):
@@ -1653,7 +1730,7 @@ class Client(BaseClient):
         Plan
             A plan.
         """
-        path = "/sites/%s/plans" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/plans", self._site_id)
         return self._make_request("POST", path, body, None)
 
     def get_plan(self, plan_id):
@@ -1670,7 +1747,7 @@ class Client(BaseClient):
         Plan
             A plan.
         """
-        path = "/sites/%s/plans/%s" % (self._site_id, plan_id)
+        path = self._interpolate_path("/sites/%s/plans/%s", self._site_id, plan_id)
         return self._make_request("GET", path, None, None)
 
     def update_plan(self, plan_id, body):
@@ -1689,7 +1766,7 @@ class Client(BaseClient):
         Plan
             A plan.
         """
-        path = "/sites/%s/plans/%s" % (self._site_id, plan_id)
+        path = self._interpolate_path("/sites/%s/plans/%s", self._site_id, plan_id)
         return self._make_request("PUT", path, body, None)
 
     def remove_plan(self, plan_id):
@@ -1706,7 +1783,7 @@ class Client(BaseClient):
         Plan
             Plan deleted
         """
-        path = "/sites/%s/plans/%s" % (self._site_id, plan_id)
+        path = self._interpolate_path("/sites/%s/plans/%s", self._site_id, plan_id)
         return self._make_request("DELETE", path, None, None)
 
     def list_plan_add_ons(self, plan_id, **kwargs):
@@ -1753,7 +1830,9 @@ class Client(BaseClient):
         Pager
             A list of add-ons.
         """
-        path = "/sites/%s/plans/%s/add_ons" % (self._site_id, plan_id)
+        path = self._interpolate_path(
+            "/sites/%s/plans/%s/add_ons", self._site_id, plan_id
+        )
         return Pager(self, path, kwargs)
 
     def create_plan_add_on(self, plan_id, body):
@@ -1772,7 +1851,9 @@ class Client(BaseClient):
         AddOn
             An add-on.
         """
-        path = "/sites/%s/plans/%s/add_ons" % (self._site_id, plan_id)
+        path = self._interpolate_path(
+            "/sites/%s/plans/%s/add_ons", self._site_id, plan_id
+        )
         return self._make_request("POST", path, body, None)
 
     def get_plan_add_on(self, plan_id, add_on_id):
@@ -1791,7 +1872,9 @@ class Client(BaseClient):
         AddOn
             An add-on.
         """
-        path = "/sites/%s/plans/%s/add_ons/%s" % (self._site_id, plan_id, add_on_id)
+        path = self._interpolate_path(
+            "/sites/%s/plans/%s/add_ons/%s", self._site_id, plan_id, add_on_id
+        )
         return self._make_request("GET", path, None, None)
 
     def update_plan_add_on(self, plan_id, add_on_id, body):
@@ -1812,7 +1895,9 @@ class Client(BaseClient):
         AddOn
             An add-on.
         """
-        path = "/sites/%s/plans/%s/add_ons/%s" % (self._site_id, plan_id, add_on_id)
+        path = self._interpolate_path(
+            "/sites/%s/plans/%s/add_ons/%s", self._site_id, plan_id, add_on_id
+        )
         return self._make_request("PUT", path, body, None)
 
     def remove_plan_add_on(self, plan_id, add_on_id):
@@ -1831,7 +1916,9 @@ class Client(BaseClient):
         AddOn
             Add-on deleted
         """
-        path = "/sites/%s/plans/%s/add_ons/%s" % (self._site_id, plan_id, add_on_id)
+        path = self._interpolate_path(
+            "/sites/%s/plans/%s/add_ons/%s", self._site_id, plan_id, add_on_id
+        )
         return self._make_request("DELETE", path, None, None)
 
     def list_add_ons(self, **kwargs):
@@ -1876,7 +1963,7 @@ class Client(BaseClient):
         Pager
             A list of add-ons.
         """
-        path = "/sites/%s/add_ons" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/add_ons", self._site_id)
         return Pager(self, path, kwargs)
 
     def get_add_on(self, add_on_id):
@@ -1893,7 +1980,7 @@ class Client(BaseClient):
         AddOn
             An add-on.
         """
-        path = "/sites/%s/add_ons/%s" % (self._site_id, add_on_id)
+        path = self._interpolate_path("/sites/%s/add_ons/%s", self._site_id, add_on_id)
         return self._make_request("GET", path, None, None)
 
     def list_subscriptions(self, **kwargs):
@@ -1942,7 +2029,7 @@ class Client(BaseClient):
         Pager
             A list of the site's subscriptions.
         """
-        path = "/sites/%s/subscriptions" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/subscriptions", self._site_id)
         return Pager(self, path, kwargs)
 
     def create_subscription(self, body):
@@ -1959,7 +2046,7 @@ class Client(BaseClient):
         Subscription
             A subscription.
         """
-        path = "/sites/%s/subscriptions" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/subscriptions", self._site_id)
         return self._make_request("POST", path, body, None)
 
     def get_subscription(self, subscription_id):
@@ -1976,7 +2063,9 @@ class Client(BaseClient):
         Subscription
             A subscription.
         """
-        path = "/sites/%s/subscriptions/%s" % (self._site_id, subscription_id)
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s", self._site_id, subscription_id
+        )
         return self._make_request("GET", path, None, None)
 
     def modify_subscription(self, subscription_id, body):
@@ -1995,7 +2084,9 @@ class Client(BaseClient):
         Subscription
             A subscription.
         """
-        path = "/sites/%s/subscriptions/%s" % (self._site_id, subscription_id)
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s", self._site_id, subscription_id
+        )
         return self._make_request("PUT", path, body, None)
 
     def terminate_subscription(self, subscription_id, **kwargs):
@@ -2024,7 +2115,9 @@ class Client(BaseClient):
         Subscription
             An expired subscription.
         """
-        path = "/sites/%s/subscriptions/%s" % (self._site_id, subscription_id)
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s", self._site_id, subscription_id
+        )
         return self._make_request("DELETE", path, None, kwargs)
 
     def cancel_subscription(self, subscription_id):
@@ -2041,7 +2134,9 @@ class Client(BaseClient):
         Subscription
             A canceled or failed subscription.
         """
-        path = "/sites/%s/subscriptions/%s/cancel" % (self._site_id, subscription_id)
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s/cancel", self._site_id, subscription_id
+        )
         return self._make_request("PUT", path, None, None)
 
     def reactivate_subscription(self, subscription_id):
@@ -2058,9 +2153,8 @@ class Client(BaseClient):
         Subscription
             An active subscription.
         """
-        path = "/sites/%s/subscriptions/%s/reactivate" % (
-            self._site_id,
-            subscription_id,
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s/reactivate", self._site_id, subscription_id
         )
         return self._make_request("PUT", path, None, None)
 
@@ -2080,7 +2174,9 @@ class Client(BaseClient):
         Subscription
             A subscription.
         """
-        path = "/sites/%s/subscriptions/%s/pause" % (self._site_id, subscription_id)
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s/pause", self._site_id, subscription_id
+        )
         return self._make_request("PUT", path, body, None)
 
     def resume_subscription(self, subscription_id):
@@ -2097,7 +2193,9 @@ class Client(BaseClient):
         Subscription
             A subscription.
         """
-        path = "/sites/%s/subscriptions/%s/resume" % (self._site_id, subscription_id)
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s/resume", self._site_id, subscription_id
+        )
         return self._make_request("PUT", path, None, None)
 
     def get_subscription_change(self, subscription_id):
@@ -2114,7 +2212,9 @@ class Client(BaseClient):
         SubscriptionChange
             A subscription's pending change.
         """
-        path = "/sites/%s/subscriptions/%s/change" % (self._site_id, subscription_id)
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s/change", self._site_id, subscription_id
+        )
         return self._make_request("GET", path, None, None)
 
     def create_subscription_change(self, subscription_id, body):
@@ -2133,7 +2233,9 @@ class Client(BaseClient):
         SubscriptionChange
             A subscription change.
         """
-        path = "/sites/%s/subscriptions/%s/change" % (self._site_id, subscription_id)
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s/change", self._site_id, subscription_id
+        )
         return self._make_request("POST", path, body, None)
 
     def remove_subscription_change(self, subscription_id):
@@ -2146,7 +2248,9 @@ class Client(BaseClient):
 
 
         """
-        path = "/sites/%s/subscriptions/%s/change" % (self._site_id, subscription_id)
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s/change", self._site_id, subscription_id
+        )
         return self._make_request("DELETE", path, None, None)
 
     def list_subscription_invoices(self, subscription_id, **kwargs):
@@ -2197,7 +2301,9 @@ class Client(BaseClient):
         Pager
             A list of the subscription's invoices.
         """
-        path = "/sites/%s/subscriptions/%s/invoices" % (self._site_id, subscription_id)
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s/invoices", self._site_id, subscription_id
+        )
         return Pager(self, path, kwargs)
 
     def list_subscription_line_items(self, subscription_id, **kwargs):
@@ -2248,9 +2354,8 @@ class Client(BaseClient):
         Pager
             A list of the subscription's line items.
         """
-        path = "/sites/%s/subscriptions/%s/line_items" % (
-            self._site_id,
-            subscription_id,
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s/line_items", self._site_id, subscription_id
         )
         return Pager(self, path, kwargs)
 
@@ -2292,7 +2397,8 @@ class Client(BaseClient):
         Pager
             A list of the the coupon redemptions on a subscription.
         """
-        path = "/sites/%s/subscriptions/%s/coupon_redemptions" % (
+        path = self._interpolate_path(
+            "/sites/%s/subscriptions/%s/coupon_redemptions",
             self._site_id,
             subscription_id,
         )
@@ -2342,7 +2448,7 @@ class Client(BaseClient):
         Pager
             A list of the site's transactions.
         """
-        path = "/sites/%s/transactions" % (self._site_id,)
+        path = self._interpolate_path("/sites/%s/transactions", self._site_id)
         return Pager(self, path, kwargs)
 
     def get_transaction(self, transaction_id):
@@ -2359,7 +2465,9 @@ class Client(BaseClient):
         Transaction
             A transaction.
         """
-        path = "/sites/%s/transactions/%s" % (self._site_id, transaction_id)
+        path = self._interpolate_path(
+            "/sites/%s/transactions/%s", self._site_id, transaction_id
+        )
         return self._make_request("GET", path, None, None)
 
     def get_unique_coupon_code(self, unique_coupon_code_id):
@@ -2376,9 +2484,8 @@ class Client(BaseClient):
         UniqueCouponCode
             A unique coupon code.
         """
-        path = "/sites/%s/unique_coupon_codes/%s" % (
-            self._site_id,
-            unique_coupon_code_id,
+        path = self._interpolate_path(
+            "/sites/%s/unique_coupon_codes/%s", self._site_id, unique_coupon_code_id
         )
         return self._make_request("GET", path, None, None)
 
@@ -2396,9 +2503,8 @@ class Client(BaseClient):
         UniqueCouponCode
             A unique coupon code.
         """
-        path = "/sites/%s/unique_coupon_codes/%s" % (
-            self._site_id,
-            unique_coupon_code_id,
+        path = self._interpolate_path(
+            "/sites/%s/unique_coupon_codes/%s", self._site_id, unique_coupon_code_id
         )
         return self._make_request("DELETE", path, None, None)
 
@@ -2416,7 +2522,8 @@ class Client(BaseClient):
         UniqueCouponCode
             A unique coupon code.
         """
-        path = "/sites/%s/unique_coupon_codes/%s/restore" % (
+        path = self._interpolate_path(
+            "/sites/%s/unique_coupon_codes/%s/restore",
             self._site_id,
             unique_coupon_code_id,
         )

--- a/tests/mock_client.py
+++ b/tests/mock_client.py
@@ -11,13 +11,13 @@ class MockClient(BaseClient):
         return Pager(self, path, params)
 
     def get_resource(self, resource_id, params={}):
-        path = "/resources/%s" % (resource_id)
+        path = self._interpolate_path("/resources/%s", resource_id)
         return self._make_request("GET", path, None, params)
 
     def update_resource(self, resource_id, body):
-        path = "/resources/%s" % (resource_id)
+        path = self._interpolate_path("/resources/%s", resource_id)
         return self._make_request("PUT", path, body, None)
 
     def delete_resource(self, resource_id):
-        path = "/resources/%s" % (resource_id)
+        path = self._interpolate_path("/resources/%s", resource_id)
         return self._make_request("DELETE", path, None, None)


### PR DESCRIPTION
Adds an `interpolate_path` method which does the url encoding and the path interpolation. 

### Testing

Create an account with some chars that don't work in a url without encoding. Then fetch that account in debug mode and ensure that the url is encoded and the account can be fetched. Example:

```python
account_code = "benjamin.dumond email@gmail.com" # has space and @
client.get_account("code-%s" % account_code)
```


