### PR TITLE
Add recurly-style User-Agent

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ This library is published on pypi as a pre-release. We recommend targeting a spe
 in your requirements.txt or setup.py:
 
 ```
-recurly==3.0b2
+recurly==3.0b3
 ```
 
 Until we reach GA with version `3.0.0`, we will bump the beta level on each release `3.0bX` by 1.

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -3,6 +3,17 @@ name = "recurly"
 import os
 from os.path import dirname, basename, isfile
 import glob
+import ssl
+import sys
+
+__version__ = "3.0b3"
+__python_version__ = ".".join(map(str, sys.version_info[:3]))
+
+USER_AGENT = "recurly-python/%s; python %s; %s" % (
+    __version__,
+    __python_version__,
+    ssl.OPENSSL_VERSION,
+)
 
 # Running in strict mode will throw exceptions
 # when API responses don't line up with the client's expectations.

--- a/recurly/base_client.py
+++ b/recurly/base_client.py
@@ -4,7 +4,7 @@ from base64 import b64encode
 import json
 from . import resources
 from .resource import Resource
-from recurly import ApiError, NetworkError
+from recurly import USER_AGENT, ApiError, NetworkError
 from pydoc import locate
 import urllib.parse
 
@@ -22,6 +22,7 @@ class BaseClient:
         try:
             basic_auth = b64encode(bytes(self.__api_key + ":", "ascii")).decode("ascii")
             headers = {
+                "User-Agent": USER_AGENT,
                 "Authorization": "Basic %s" % basic_auth,
                 "Accept": "application/vnd.recurly.%s" % self.api_version(),
                 "Content-Type": "application/json",

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,19 @@
 import setuptools
+import re
+import os.path
+
+# get version from top level __init__ file
+VERSION_RE = re.compile('^__version__ = "(.+)"$', flags=re.MULTILINE)
+with open(os.path.join(os.path.dirname(__file__), "recurly", "__init__.py")) as PACKAGE:
+    VERSION = VERSION_RE.search(PACKAGE.read()).group(1)
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="recurly",
-    version="3.0b2",
+    # version managed in recurly/__init__.py
+    version=VERSION,
     author="Benjamin Eckel",
     author_email="ben@recurly.com",
     description="Recurly v3",


### PR DESCRIPTION
Adds a recurly-style user agent.

User agent should look something like this:

`recurly-python/3.0b3; python 3.7.3; OpenSSL 1.1.0j 20 Nov 2018`

* Also bumps to 3.0b3