### PR TITLE
Expose response metadata

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -150,3 +150,37 @@ except recurly.NetworkError as e:
     print("Something happened with the network connection.")
     print(e)
 ```
+
+### HTTP Metadata
+
+Sometimes you might want to get some additional information about the underlying HTTP request and response. Instead of
+returning this information directly and forcing the programmer to unwrap it, we inject this metadata into the top level
+resource that was returned. You can access the [Response](recurly.html?highlight=response#recurly.response.Response) by
+calling `get_response()` on any Resource.
+
+**Warning**: Do not log or render whole requests or responses as they may contain PII or sensitive data.
+
+
+```python
+account = client.get_account("code-benjamin")
+response = account.get_response()
+response.rate_limit_remaining #=> 1985
+response.request_id #=> "0av50sm5l2n2gkf88ehg"
+response.request.path #=> "/sites/subdomain-mysite/accounts/code-benjamin"
+response.request.body #=> None
+```
+
+This also works on [Empty](recurly.html?highlight=empty#recurly.resource.Empty) responses:
+
+```python
+response = client.remove_line_item("a959576b2b10b012").get_response()
+```
+And it can be captured on exceptions through the [Error](recurly.html?highlight=error#recurly.resources.Error) object:
+
+```python
+try:
+    account = client.get_account(account_id)
+except recurly.errors.NotFoundError as e:
+    response = e.error.get_response()
+    print("Give this request id to Recurly Support: " + response.request_id)
+```

--- a/docs/source/recurly.rst
+++ b/docs/source/recurly.rst
@@ -36,6 +36,14 @@ recurly.pager module
     :undoc-members:
     :show-inheritance:
 
+recurly.request module
+----------------------
+
+.. automodule:: recurly.request
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 recurly.resource module
 -----------------------
 
@@ -48,6 +56,14 @@ recurly.resources module
 ------------------------
 
 .. automodule:: recurly.resources
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+recurly.response module
+-----------------------
+
+.. automodule:: recurly.response
     :members:
     :undoc-members:
     :show-inheritance:

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -40,3 +40,5 @@ class NetworkError(RecurlyError):
 from . import errors
 from .client import Client
 from .resource import Resource
+from .response import Response
+from .request import Request

--- a/recurly/client.py
+++ b/recurly/client.py
@@ -94,7 +94,7 @@ class Client(BaseClient):
             Filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
         subscriber : str
-            Filter accounts accounts with or without a subscription in the `active`,
+            Filter accounts with or without a subscription in the `active`,
             `canceled`, or `future` state.
         past_due : str
             Filter for accounts with an invoice in the `past_due` state.
@@ -232,6 +232,10 @@ class Client(BaseClient):
             Account ID or code (use prefix: `code-`, e.g. `code-bob`).
 
 
+        Returns
+        -------
+        Empty
+            An Empty Response.
         """
         path = self._interpolate_path(
             "/sites/%s/accounts/%s/acquisition", self._site_id, account_id
@@ -325,6 +329,10 @@ class Client(BaseClient):
             Account ID or code (use prefix: `code-`, e.g. `code-bob`).
 
 
+        Returns
+        -------
+        Empty
+            An Empty Response.
         """
         path = self._interpolate_path(
             "/sites/%s/accounts/%s/billing_info", self._site_id, account_id
@@ -820,6 +828,10 @@ class Client(BaseClient):
             Shipping Address ID.
 
 
+        Returns
+        -------
+        Empty
+            An Empty Response.
         """
         path = self._interpolate_path(
             "/sites/%s/accounts/%s/shipping_addresses/%s",
@@ -970,7 +982,7 @@ class Client(BaseClient):
             Filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
         subscriber : str
-            Filter accounts accounts with or without a subscription in the `active`,
+            Filter accounts with or without a subscription in the `active`,
             `canceled`, or `future` state.
         past_due : str
             Filter for accounts with an invoice in the `past_due` state.
@@ -1665,6 +1677,10 @@ class Client(BaseClient):
             Line Item ID.
 
 
+        Returns
+        -------
+        Empty
+            An Empty Response.
         """
         path = self._interpolate_path(
             "/sites/%s/line_items/%s", self._site_id, line_item_id
@@ -2247,6 +2263,10 @@ class Client(BaseClient):
             Subscription ID or UUID (use prefix: `uuid-`, e.g. `uuid-123457890`).
 
 
+        Returns
+        -------
+        Empty
+            An Empty Response.
         """
         path = self._interpolate_path(
             "/sites/%s/subscriptions/%s/change", self._site_id, subscription_id

--- a/recurly/request.py
+++ b/recurly/request.py
@@ -1,0 +1,7 @@
+class Request:
+    """Class representing a request to Recurly"""
+
+    def __init__(self, method, path, body=None):
+        self.method = method
+        self.path = path
+        self.body = body

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -251,6 +251,7 @@ class BillingInfo(Resource):
         When the billing information was created.
     first_name : str
     fraud : FraudInfo
+        Most recent fraud result.
     id : str
     last_name : str
     payment_method : BillingInfoPaymentMethod
@@ -341,6 +342,7 @@ class ErrorMayHaveTransaction(Resource):
     params : :obj:`list` of :obj:`dict`
         Parameter specific errors
     transaction_error : TransactionError
+        This is only included on errors with `type=transaction`.
     type : str
         Type
     """
@@ -627,6 +629,7 @@ class CouponDiscount(Resource):
     percent : int
         This is only present when `type=percent`.
     trial : CouponDiscountTrial
+        This is only present when `type=free_trial`.
     type : str
     """
 

--- a/recurly/response.py
+++ b/recurly/response.py
@@ -1,0 +1,38 @@
+import sys, traceback
+from datetime import datetime
+import recurly
+import json
+
+
+class Response:
+    """Class representing a response from Recurly"""
+
+    def __init__(self, response, request):
+        self.request = request
+        self.status = response.status
+        http_body = response.read()
+        self.body = None
+        if http_body and len(http_body) > 0:
+            self.body = json.loads(http_body.decode("utf-8"))
+
+        try:
+            self.__headers = response.headers
+            self.request_id = self.__headers.get("X-Request-Id")
+            self.rate_limit = int(self.__headers.get("X-RateLimit-Limit"))
+            self.rate_limit_remaining = int(self.__headers.get("X-RateLimit-Remaining"))
+            self.rate_limit_reset = datetime.utcfromtimestamp(
+                int(self.__headers.get("X-RateLimit-Reset"))
+            )
+            self.date = self.__headers.get("Date")
+            self.proxy_metadata = {
+                "server": self.__headers.get("Server"),
+                "cf-ray": self.__headers.get("CF-RAY"),
+            }
+        except:
+            # Re-raise the exception in strict-mode
+            if recurly.STRICT_MODE:
+                raise
+            # Log and ignore it in production, we don't want this to kill the whole request
+            else:
+                print("[WARNING][Recurly] Unexpected error parsing response metadata")
+                traceback.print_exc(file=sys.stdout)

--- a/tests/mock_resources.py
+++ b/tests/mock_resources.py
@@ -20,3 +20,7 @@ class MySubResource(Resource):
 
 class Error(Resource):
     schema = {"message": str, "params": list, "type": str}
+
+
+class Empty(Resource):
+    schema = {}

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -2,6 +2,7 @@ import unittest
 import recurly
 import socket
 from recurly import Resource
+from recurly.resource import Empty
 from .mock_resources import MyResource, MySubResource
 from .mock_client import MockClient
 import unittest.mock as mock
@@ -165,7 +166,7 @@ class TestBaseClient(unittest.TestCase):
             #     None,
             #     headers=expected_headers,
             # )
-            self.assertEqual(resource, None)
+            self.assertIsInstance(resource, Empty)
 
     def test_failure_socket_error(self):
         with get_socket_error_client() as conn:

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,13 +1,14 @@
 import unittest
 import recurly
 from datetime import datetime
-from recurly import Resource
+from recurly import Resource, Response, Request
 from pydoc import locate
 from .mock_resources import MyResource, MySubResource
+from unittest.mock import Mock, MagicMock
 
 
-def cast(obj):
-    return Resource.cast(obj)
+def cast(obj, class_name=None, resp=None):
+    return Resource.cast(obj, class_name, resp)
 
 
 class TestResource(unittest.TestCase):
@@ -17,6 +18,46 @@ class TestResource(unittest.TestCase):
         # TODO test non-strict-mode behavior
         with self.assertRaises(ValueError):
             self.assertEqual(cast(obj), obj)
+
+    def test_cast_from_response(self):
+        resp = MagicMock()
+        resp.headers = {
+            "X-Request-Id": "0av50sm5l2n2gkf88ehg",
+            "X-RateLimit-Limit": "2000",
+            "X-RateLimit-Remaining": "1985",
+            "X-RateLimit-Reset": "1564624560",
+            "Date": "Thu, 01 Aug 2019 01:26:44 GMT",
+            "Server": "cloudflare",
+            "CF-RAY": "4ff4b71268424738-EWR",
+        }
+
+        request = Request("GET", "/sites", {})
+        empty = cast({}, "Empty", Response(resp, request))
+        response = empty.get_response()
+
+        self.assertEqual(type(response), Response)
+        self.assertEqual(response.request_id, "0av50sm5l2n2gkf88ehg")
+        self.assertEqual(response.rate_limit, 2000)
+        self.assertEqual(response.rate_limit_remaining, 1985)
+        self.assertEqual(response.rate_limit_reset, datetime(2019, 8, 1, 1, 56))
+        self.assertEqual(response.date, "Thu, 01 Aug 2019 01:26:44 GMT")
+        self.assertEqual(response.proxy_metadata["server"], "cloudflare")
+        self.assertEqual(response.proxy_metadata["cf-ray"], "4ff4b71268424738-EWR")
+        self.assertEqual(response.request.method, "GET")
+        self.assertEqual(response.request.path, "/sites")
+        self.assertEqual(response.request.body, {})
+
+        resp = MagicMock()
+        resp.headers = {
+            "X-Request-Id": "abcd123",
+            "X-RateLimit-Limit": "invalid2000",
+            "X-RateLimit-Remaining": "1985",
+            "X-RateLimit-Reset": "1564624560",
+            "Date": "Thu, 01 Aug 2019 01:26:44 GMT",
+        }
+
+        with self.assertRaises(ValueError):
+            cast({}, "Empty", Response(resp, request))
 
     def test_cast_page(self):
         # should return a page of cast data


### PR DESCRIPTION
Provide an interface for exposing http request and response metadata.

Technically has breaking changes as previously void methods now return instances of Empty.

<img width="804" alt="Screen Shot 2019-07-31 at 11 57 40 PM" src="https://user-images.githubusercontent.com/185919/62266708-055c4700-b3ef-11e9-87a5-1787a4b21824.png">
