### PR TITLE
MOTO transactions

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -190,6 +190,7 @@ class Account(Resource):
         'has_past_due_invoice',
         'preferred_locale',
         'custom_fields',
+        'transaction_type',
     )
 
     _classes_for_nodename = { 'address': Address, 'custom_field': CustomField }
@@ -411,6 +412,7 @@ class BillingInfo(Resource):
         'gateway_token',
         'gateway_code',
         'three_d_secure_action_result_token_id',
+        'transaction_type',
     )
     sensitive_attributes = ('number', 'verification_value', 'account_number')
     xml_attribute_attributes = ('type',)
@@ -972,6 +974,7 @@ class Purchase(Resource):
         'shipping_fees',
         'gateway_code',
         'collection_method',
+        'transaction_type',
     )
 
     def invoice(self):
@@ -1140,6 +1143,7 @@ class Subscription(Resource):
         'current_term_ends_at',
         'custom_fields',
         'gateway_code',
+        'transaction_type',
     )
     sensitive_attributes = ('number', 'verification_value', 'bulk')
 


### PR DESCRIPTION
As a part of PSD2, there is an exemption to exclude MOTO transactions from SCA scope.
In order to pass this indicator to the gateways, merchants need a mechanism via API
to inform Recurly of these transactions. These transactions will be initiated from
within a merchants customer service / support admin portal UI, where the customer
is not authenticated to be able to complete an SCA flow.

This is exposed to the programmer as `transaction_type` on many of the resources. Set the value to `moto` to mark the transaction as MOTO. Ex use with purchases:

```python
purchase = recurly.Purchase(
  currency = 'USD',
  transaction_type = 'moto',
  account = recurly.Account(
    account_code = 'account-code-123',
  ),
  subscriptions = [
    recurly.Subscription(plan_code = 'gold')
  ],
)

collection = purchase.invoice()
print(collection)
```