### PR TITLE
Release version 2.9.9 / API version 2.22

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## Version 2.9.9 – August 21st, 2019 ##
+
+This version brings us up to API version 2.22, but has no breaking changes
+
+- MOTO transactions [PR](https://github.com/recurly/recurly-client-python/pull/307)
+
 ## Version 2.9.8 – June 27th, 2019 ##
 
 This version brings us up to API version 2.21, but has no breaking changes

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -46,7 +46,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.21'
+API_VERSION = '2.22'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -22,7 +22,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.8'
+__version__ = '2.9.9'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {


### PR DESCRIPTION
## Version 2.9.9 – August 21st, 2019 ##

This version brings us up to API version 2.22, but has no breaking changes

- MOTO transactions [PR](https://github.com/recurly/recurly-client-python/pull/307)
