### PR TITLE
Release 2.9.10

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## Version 2.9.10 – September 13th, 2019 ##
+
+-  PSD2 billing info changes [PR](https://github.com/recurly/recurly-client-python/pull/314)
+
 ## Version 2.9.9 – August 21st, 2019 ##
 
 This version brings us up to API version 2.22, but has no breaking changes

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -22,7 +22,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.9'
+__version__ = '2.9.10'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {


### PR DESCRIPTION
## Version 2.9.10 – September 13th, 2019 ##

-  PSD2 billing info changes [PR](https://github.com/recurly/recurly-client-python/pull/314)