### PR TITLE
Implement bump script

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,18 @@
+[bumpversion]
+current_version = 3.0b5
+parse = (?P<major>\d+)
+        \.(?P<minor>\d+)
+        (?P<release>[a-z])(?P<build>\d+)
+serialize = 
+	{major}.{minor}{release}{build}
+
+[bumpversion:part:release]
+values = 
+	b
+
+[bumpversion:part:build]
+
+[bumpversion:file:recurly/__init__.py]
+
+[bumpversion:file:docs/README.md]
+

--- a/scripts/bump
+++ b/scripts/bump
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+bump2version "$@"


### PR DESCRIPTION
Change from pre-release to normal release semantics after 3.0.0

Allows automation of bumping versions. Will bump the versions for the library as well as any other files that need to be updated (such as READMEs). I still have some work to do on this library but it can be a follow up. Example uses:

```
./scripts/bump patch
./scripts/bump minor
./scripts/bump major
./scripts/bump build
```

Use dry run to dump config and see the plan:

```
current_version=3.0b5
parse=(?P<major>\d+)
\.(?P<minor>\d+)
(?P<release>[a-z])(?P<build>\d+)
serialize=
{major}.{minor}{release}{build}
new_version=3.0b6
```

**Note**: Requires bump2version which will be included in playground image:

```
pip3 install bump2version
```