### PR TITLE
Version 2.9.11

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,12 @@
 ## Unreleased
 
+## Version 2.9.11 - October 22, 2019 ##
+
+- Add shipping address to purchase object [PR] (https://github.com/recurly/recurly-client-python/pull/327)
+
 ## Version 2.9.10 – September 13th, 2019 ##
 
--  PSD2 billing info changes [PR](https://github.com/recurly/recurly-client-python/pull/314)
+- PSD2 billing info changes [PR](https://github.com/recurly/recurly-client-python/pull/314)
 
 ## Version 2.9.9 – August 21st, 2019 ##
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -22,7 +22,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.10'
+__version__ = '2.9.11'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {


### PR DESCRIPTION
- Add shipping address to purchase object [PR] (https://github.com/recurly/recurly-client-python/pull/327)