### PR TITLE
Implementing __repr__() to make Resource object pretty printable

### DIFF
--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -99,6 +99,9 @@ class Resource:
 
         return resource
 
+    def __repr__(self):
+        return str(vars(self))
+
     def get_response(self):
         """
         Returns

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -111,3 +111,10 @@ class TestResource(unittest.TestCase):
         self.assertEqual(obj.my_sub_resource.my_string, "string")
         self.assertEqual(obj.my_sub_resources[0].my_string, "string1")
         self.assertEqual(obj.my_sub_resources[1].my_string, "string2")
+
+    def test_repr_str(self):
+        resource = cast({"object": "my_resource", "my_string": "kmxu3f3qof17"})
+        # Should return the string version of vars(resource)
+        self.assertEqual(repr(resource), "{'my_string': 'kmxu3f3qof17'}")
+        # str() should default to __repr__() implementation
+        self.assertEqual(str(resource), "{'my_string': 'kmxu3f3qof17'}")


### PR DESCRIPTION
Add implementation of the `__repr__` method to allow for pretty printing of `Resource` objects.

The, not defined, `__str__` method will default to using the implementation of the `__repr__` method as [detailed in the docs](https://docs.python.org/3/reference/datamodel.html#object.__str__). 

```
└[$]› python3
Python 3.7.4 (default, Oct 12 2019, 18:55:28) 
[Clang 11.0.0 (clang-1100.0.33.8)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> class ReprTest():
...     def __repr__(self):
...             return "__repr__ implementation"
... 
>>> str(ReprTest())
'__repr__ implementation'
>>> repr(ReprTest())
'__repr__ implementation'
>>> ReprTest()
__repr__ implementation
```

Python 3 docs linked, but 2.7 behaves the same way (though not explicitly called out in the docs):
```
└[$]› python2.7
Python 2.7.10 (default, Feb 22 2019, 21:55:15) 
[GCC 4.2.1 Compatible Apple LLVM 10.0.1 (clang-1001.0.37.14)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> class ReprTest():
...     def __repr__(self):
...             return "__repr__ implementation"
... 
>>> str(ReprTest())
'__repr__ implementation'
>>> repr(ReprTest())
'__repr__ implementation'
>>> ReprTest()
__repr__ implementation
```