### PR TITLE
Release 2.9.12

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## Version 2.9.12 - November 21, 2019 ##
+
+- Add Item class [PR] (https://github.com/recurly/recurly-client-python/pull/331)
+- Add reactivation functionality to Item class [PR] (https://github.com/recurly/recurly-client-python/pull/335)
+
 ## Version 2.9.11 - October 22, 2019 ##
 
 - Add shipping address to purchase object [PR] (https://github.com/recurly/recurly-client-python/pull/327)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
 
 ## Version 2.9.12 - November 21, 2019 ##
 
+This version brings us up to API version 2.24, but has no breaking changes
+
 - Add Item class [PR] (https://github.com/recurly/recurly-client-python/pull/331)
 - Add reactivation functionality to Item class [PR] (https://github.com/recurly/recurly-client-python/pull/335)
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -22,7 +22,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.11'
+__version__ = '2.9.12'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {


### PR DESCRIPTION
Release 2.9.12

This version brings us up to API version 2.24, but has no breaking changes

- Add Item class [PR] (https://github.com/recurly/recurly-client-python/pull/331)
- Add reactivation functionality to Item class [PR] (https://github.com/recurly/recurly-client-python/pull/335)