### PR TITLE
Add `vat_number` to ShippingAddress resource

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -436,6 +436,7 @@ class ShippingAddress(Resource):
         'nickname',
         'phone',
         'state',
+        'vat_number',
         'zip',
     )
 


### PR DESCRIPTION
This is a supported attribute according to https://dev.recurly.com/docs/create-shipping-address-on-an-account.

Without this, setting the shipping address when creating it has not effect.

I have no idea if this is a sufficient change, but it does seem to make the attribute be added when testing it.