### PR TITLE
Convert Array params to CSV strings

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0
+current_version = 3.3.1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -6,7 +6,7 @@ import glob
 import ssl
 import sys
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 __python_version__ = ".".join(map(str, sys.version_info[:3]))
 
 USER_AGENT = "recurly-python/%s; python %s; %s" % (

--- a/recurly/pager.py
+++ b/recurly/pager.py
@@ -54,7 +54,7 @@ class Pager:
     def __init__(self, client, path, params):
         self.__client = client
         self.__path = path
-        self.__params = params
+        self.__params = self.__map_array_params(params)
 
     def pages(self):
         """An iterator that enumerates each page of results."""
@@ -65,3 +65,10 @@ class Pager:
         under the hood.
         """
         return ItemIterator(self.__client, self.__path, self.__params)
+
+    def __map_array_params(self, params):
+        """Converts array parameters to CSV strings to maintain consistency with
+        how the server expects the request to be formatted while providing the
+        developer with an array type to maintain developer happiness!
+        """
+        return {k: ",".join(v) if isinstance(v, list) else v for k, v in params.items()}


### PR DESCRIPTION
Fixes an issue with requesting a list of resources with specific `ids`. The server expects a CSV string of ids, but the api spec specifies that the `ids` should be specified as a list. 

This fix maintains developer happiness by maintaining the ability to specify a list of ids that are transformed to a CSV string when the request is sent to the server.