### PR TITLE
Add convert_trial() to Subscription

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -46,7 +46,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.24'
+API_VERSION = '2.25'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None
@@ -1249,6 +1249,44 @@ class Subscription(Resource):
         """Resume a subscription"""
         url = urljoin(self._url, '/resume')
         self.put(url)
+
+    def convert_trial_moto(self):
+        """Convert trial to paid subscription when transaction_type == 'moto'"""
+        url = urljoin(self._url, '/convert_trial')
+
+        request = ElementTreeBuilder.Element('subscription')
+        transaction_type = ElementTreeBuilder.SubElement(request, 'transaction_type')
+        transaction_type.text = "moto"
+        body = ElementTree.tostring(request, encoding='UTF-8')
+        
+        response = self.http_request(url, 'PUT', body, { 'Content-Type':
+            'application/xml; charset=utf-8' })
+
+        if response.status not in (200, 201, 204):
+            self.raise_http_error(response)
+
+        self.update_from_element(ElementTree.fromstring(response.read()))
+
+    def convert_trial(self, three_d_secure_action_result_token_id = None):
+        """Convert trial to paid subscription"""
+        url = urljoin(self._url, '/convert_trial')
+
+        if not three_d_secure_action_result_token_id == None:
+            request = ElementTreeBuilder.Element('subscription')
+            account = ElementTreeBuilder.SubElement(request, 'account')
+            billing_info = ElementTreeBuilder.SubElement(account, 'billing_info')
+            token = ElementTreeBuilder.SubElement(billing_info, 'three_d_secure_action_result_token_id')
+            token.text = three_d_secure_action_result_token_id
+            body = ElementTree.tostring(request, encoding='UTF-8')
+            response = self.http_request(url, 'PUT', body, { 'Content-Type':
+                'application/xml; charset=utf-8' })
+        else:
+            response = self.http_request(url, 'PUT')
+
+        if response.status not in (200, 201, 204):
+            self.raise_http_error(response)
+
+        self.update_from_element(ElementTree.fromstring(response.read()))
 
     def _update(self):
         if not hasattr(self, 'timeframe'):

--- a/tests/fixtures/subscription/convert-trial-3ds.xml
+++ b/tests/fixtures/subscription/convert-trial-3ds.xml
@@ -1,0 +1,58 @@
+PUT https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/convert_trial HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version='1.0' encoding='UTF-8'?>
+<subscription>
+  <account>
+    <billing_info>
+      <three_d_secure_action_result_token_id>token</three_d_secure_action_result_token_id>
+    </billing_info>
+  </account>
+</subscription>
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription
+    href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab">
+  <redemptions href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/redemptions" />
+  <uuid>123456789012345678901234567890ab</uuid>
+  <account href="https://api.recurly.com/v2/accounts/subscribemock"/>
+  <plan href="https://api.recurly.com/v2/plans/basicplan">
+    <plan_code>basicplan</plan_code>
+    <name>Basic Plan</name>
+  </plan>
+  <state>active</state>
+  <quantity type="integer">1</quantity>
+  <currency>EUR</currency>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <activated_at type="datetime">2011-05-27T07:00:00Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <current_period_started_at type="datetime">2020-02-10T20:38:21Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2020-03-10T20:38:21Z</current_period_ends_at>
+  <trial_started_at type="datetime">2020-02-10T20:38:17Z</trial_started_at>
+  <trial_ends_at type="datetime">2020-02-10T20:38:21Z</trial_ends_at>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <tax_type>usst</tax_type>
+  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
+  <gateway_code>A gateway code</gateway_code>
+  <subscription_add_ons type="array">
+    <subscription_add_on>
+        <add_on_type>usage</add_on_type>
+        <measured_unit href="https://api.recurly.com/v2/measured_units/123456"/>
+        <usage href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/add_ons/marketing_emails/usage"/>
+        <add_on_code>marketing_emails</add_on_code>
+        <unit_amount_in_cents type="integer">5</unit_amount_in_cents>
+        <quantity type="integer">1</quantity>
+        <usage_type>price</usage_type>
+        <usage_percentage nil="nil"/>
+    </subscription_add_on>
+  </subscription_add_ons>
+</subscription>

--- a/tests/fixtures/subscription/convert-trial-moto.xml
+++ b/tests/fixtures/subscription/convert-trial-moto.xml
@@ -1,0 +1,54 @@
+PUT https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/convert_trial HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version='1.0' encoding='UTF-8'?>
+<subscription>
+  <transaction_type>moto</transaction_type>
+</subscription>
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription
+    href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab">
+  <redemptions href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/redemptions" />
+  <uuid>123456789012345678901234567890ab</uuid>
+  <account href="https://api.recurly.com/v2/accounts/subscribemock"/>
+  <plan href="https://api.recurly.com/v2/plans/basicplan">
+    <plan_code>basicplan</plan_code>
+    <name>Basic Plan</name>
+  </plan>
+  <state>active</state>
+  <quantity type="integer">1</quantity>
+  <currency>EUR</currency>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <activated_at type="datetime">2011-05-27T07:00:00Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <current_period_started_at type="datetime">2020-02-10T20:38:21Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2020-03-10T20:38:21Z</current_period_ends_at>
+  <trial_started_at type="datetime">2020-02-10T20:38:17Z</trial_started_at>
+  <trial_ends_at type="datetime">2020-02-10T20:38:21Z</trial_ends_at>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <tax_type>usst</tax_type>
+  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
+  <gateway_code>A gateway code</gateway_code>
+  <subscription_add_ons type="array">
+    <subscription_add_on>
+        <add_on_type>usage</add_on_type>
+        <measured_unit href="https://api.recurly.com/v2/measured_units/123456"/>
+        <usage href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/add_ons/marketing_emails/usage"/>
+        <add_on_code>marketing_emails</add_on_code>
+        <unit_amount_in_cents type="integer">5</unit_amount_in_cents>
+        <quantity type="integer">1</quantity>
+        <usage_type>price</usage_type>
+        <usage_percentage nil="nil"/>
+    </subscription_add_on>
+  </subscription_add_ons>
+</subscription>

--- a/tests/fixtures/subscription/convert-trial.xml
+++ b/tests/fixtures/subscription/convert-trial.xml
@@ -1,0 +1,50 @@
+PUT https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/convert_trial HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Length: 0
+
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription
+    href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab">
+  <redemptions href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/redemptions" />
+  <uuid>123456789012345678901234567890ab</uuid>
+  <account href="https://api.recurly.com/v2/accounts/subscribemock"/>
+  <plan href="https://api.recurly.com/v2/plans/basicplan">
+    <plan_code>basicplan</plan_code>
+    <name>Basic Plan</name>
+  </plan>
+  <state>active</state>
+  <quantity type="integer">1</quantity>
+  <currency>EUR</currency>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <activated_at type="datetime">2011-05-27T07:00:00Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <current_period_started_at type="datetime">2020-02-10T20:38:24Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2020-03-10T20:38:24Z</current_period_ends_at>
+  <trial_started_at type="datetime">2020-02-10T20:38:21Z</trial_started_at>
+  <trial_ends_at type="datetime">2020-02-10T20:38:24Z</trial_ends_at>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <tax_type>usst</tax_type>
+  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
+  <gateway_code>A gateway code</gateway_code>
+  <subscription_add_ons type="array">
+    <subscription_add_on>
+        <add_on_type>usage</add_on_type>
+        <measured_unit href="https://api.recurly.com/v2/measured_units/123456"/>
+        <usage href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/add_ons/marketing_emails/usage"/>
+        <add_on_code>marketing_emails</add_on_code>
+        <unit_amount_in_cents type="integer">5</unit_amount_in_cents>
+        <quantity type="integer">1</quantity>
+        <usage_type>price</usage_type>
+        <usage_percentage nil="nil"/>
+    </subscription_add_on>
+  </subscription_add_ons>
+</subscription>

--- a/tests/fixtures/subscription/show-trial.xml
+++ b/tests/fixtures/subscription/show-trial.xml
@@ -1,0 +1,49 @@
+GET https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription
+    href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab">
+  <redemptions href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/redemptions" />
+  <uuid>123456789012345678901234567890ab</uuid>
+  <account href="https://api.recurly.com/v2/accounts/subscribemock"/>
+  <plan href="https://api.recurly.com/v2/plans/basicplan">
+    <plan_code>basicplan</plan_code>
+    <name>Basic Plan</name>
+  </plan>
+  <state>active</state>
+  <quantity type="integer">1</quantity>
+  <currency>EUR</currency>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <activated_at type="datetime">2011-05-27T07:00:00Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <current_period_started_at type="datetime">2020-02-10T20:38:21Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2020-03-10T20:38:21Z</current_period_ends_at>
+  <trial_started_at type="datetime">2020-02-10T20:38:21Z</trial_started_at>
+  <trial_ends_at type="datetime">2020-03-10T20:38:21Z</trial_ends_at>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <tax_type>usst</tax_type>
+  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
+  <gateway_code>A gateway code</gateway_code>
+  <subscription_add_ons type="array">
+    <subscription_add_on>
+        <add_on_type>usage</add_on_type>
+        <measured_unit href="https://api.recurly.com/v2/measured_units/123456"/>
+        <usage href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/add_ons/marketing_emails/usage"/>
+        <add_on_code>marketing_emails</add_on_code>
+        <unit_amount_in_cents type="integer">5</unit_amount_in_cents>
+        <quantity type="integer">1</quantity>
+        <usage_type>price</usage_type>
+        <usage_percentage nil="nil"/>
+    </subscription_add_on>
+  </subscription_add_ons>
+</subscription>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1383,6 +1383,22 @@ class TestResources(RecurlyTest):
         with self.mock_request('subscription/resume.xml'):
             sub.resume()
 
+    def test_subscription_convert_trial(self):
+        with self.mock_request('subscription/show-trial.xml'):
+            sub = Subscription.get('123456789012345678901234567890ab')
+        
+        with self.mock_request('subscription/convert-trial.xml'):
+            sub.convert_trial()
+        self.assertEqual(sub.trial_ends_at, sub.current_period_started_at)   
+
+        with self.mock_request('subscription/convert-trial-3ds.xml'):
+            sub.convert_trial("token")
+        self.assertEqual(sub.trial_ends_at, sub.current_period_started_at)   
+
+        with self.mock_request('subscription/convert-trial-moto.xml'):
+            sub.convert_trial_moto()
+        self.assertEqual(sub.trial_ends_at, sub.current_period_started_at)            
+
     def test_usage(self):
         usage = Usage()
         usage.amount = 100 # record 100 emails


### PR DESCRIPTION
To convert trial to paid subscription with 3d secure action result token id:
```python
subscription.convert_trial(token)
```

To convert trial for non-3ds where subscription has billing info:
```python
subscription.convert_trial()
```

To convert trial to paid subscription with transaction type:
```python
subscription.convert_trial_moto()
```

