### PR TITLE
Handle case in which request_id is None

### DIFF
--- a/recurly/base_client.py
+++ b/recurly/base_client.py
@@ -45,7 +45,8 @@ class BaseClient:
                     raise Resource.cast_error(resp)
                 else:
                     raise ApiError(
-                        "Unknown Error. Recurly Request Id: " + resp.request_id, None
+                        "Unknown Error. Recurly Request Id: " + str(resp.request_id),
+                        None,
                     )
 
             if resp.body:


### PR DESCRIPTION
Resolves #358

Let's call `str()` on the request_id in case it's None (we never got one
from the server).