### PR TITLE
Add python 3.8 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ matrix:
     - python: 3.5
     - python: 3.6
     - python: 3.7
+    - python: 3.8
       dist: xenial
       sudo: true
 install:


### PR DESCRIPTION
Was reminded in #360 that some customers are using 3.8