### PR TITLE
Add item_code attribute to AddOn

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -1566,6 +1566,7 @@ class AddOn(Resource):
 
     attributes = (
         'add_on_code',
+        'item_code',
         'name',
         'display_quantity_on_hosted_page',
         'display_quantity',

--- a/tests/fixtures/add-on/created-item-backed.xml
+++ b/tests/fixtures/add-on/created-item-backed.xml
@@ -1,0 +1,35 @@
+POST https://api.recurly.com/v2/plans/planmock/add_ons HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<add_on>
+  <item_code>itemmock</item_code>
+  <unit_amount_in_cents>
+    <USD type="integer">500</USD>
+  </unit_amount_in_cents>
+</add_on>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/plans/planmock/add_ons/addonmock
+
+<?xml version="1.0" encoding="UTF-8"?>
+<add_on href="https://api.recurly.com/v2/plans/planmock/add_ons/addonmock">
+  <plan href="https://api.recurly.com/v2/plans/planmock"/>
+  <add_on_code>itemmock</add_on_code>
+  <name>Mock Add-On</name>
+  <display_quantity type="boolean">false</display_quantity>
+  <default_quantity nil="nil"></default_quantity>
+  <unit_amount_in_cents>
+    <USD type="integer">500</USD>
+  </unit_amount_in_cents>
+  <add_on_type>usage</add_on_type>
+  <optional>true</optional>
+  <usage_type>price</usage_type>
+  <measured_unit_id type="integer">123456</measured_unit_id>
+  <created_at type="datetime">2011-06-28T12:34:56Z</created_at>
+</add_on>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -439,6 +439,32 @@ class TestResources(RecurlyTest):
             with self.mock_request('add-on/plan-deleted.xml'):
                 plan.delete()
 
+    def test_item_backed_add_on(self):
+        plan_code = 'plan%s' % self.test_id
+        item_code = 'item%s' % self.test_id
+
+        plan = Plan(
+            plan_code=plan_code,
+            name='Mock Plan',
+            setup_fee_in_cents=Money(0),
+            unit_amount_in_cents=Money(1000),
+        )
+        with self.mock_request('add-on/plan-created.xml'):
+            plan.save()
+
+        try:
+            add_on = AddOn(
+                item_code= item_code,
+                unit_amount_in_cents = Money(500)
+            )
+
+            with self.mock_request('add-on/created-item-backed.xml'):
+                plan.create_add_on(add_on)
+            self.assertEqual(add_on.add_on_code, item_code)
+        finally:
+            with self.mock_request('add-on/plan-deleted.xml'):
+                plan.delete()
+
     def test_billing_info(self):
         logging.basicConfig(level=logging.DEBUG)  # make sure it's init'ed
         logger = logging.getLogger('recurly.http.request')


### PR DESCRIPTION
To create item-backed add-on:
```python
addon = recurly.AddOn(
  item_code = item.item_code,
  unit_amount_in_cents = recurly.Money(USD=500)
)
plan.create_add_on(addon)
```

To get an item-backed-add-on:
```python
plan.get_add_on(item.item_code)
```

To update item-backed add-on:
```python
add_on.unit_amount_in_cents = recurly.Money(USD=200)
add_on.save()
```

When add-on has an associated item, only the following attributes are updatable:
```python
unit_amount_in_cents
default_quantity
display_quantity_on_hosted_page
optional
```