### PR TITLE
Adding #first and #count methods to Pager

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,8 @@ There are 2 methods for pagination:
 *Warning: These are being worked on and will likely change*
 
 All `client.*_list` methods return a `Pager`. On the pager, `pages()` returns a `PageIterator` and `items()`
-returns an `ItemIterator`.
+returns an `ItemIterator`. The `first()` method will return only the first item from the API. The `count()`
+method will return the total number of records available from the API.
 
 #### per-page
 ```python
@@ -78,6 +79,35 @@ for page in pages:
 #### per-item
 ```python
 accounts = client.list_accounts(limit=200).items()
+for account in accounts:
+    print(account.code)
+```
+
+### Additional Pager Methods
+
+In addition to the methods to facilitate pagination, the Pager class provides 2 helper methods:
+
+1. first 
+2. count
+
+#### First
+
+The Pager's `first` method can be used to fetch only the first resource from the endpoint.
+
+```python
+accounts = client.list_accounts()
+account = accounts.first()
+print(account.code)
+```
+
+#### Count
+
+The Pager's `count` method will return the total number of resources that are available at the requested endpoint.
+
+```python
+accounts = client.list_accounts()
+total = accounts.count()
+print("There are %s accounts in total." % total)
 for account in accounts:
     print(account.code)
 ```

--- a/recurly/pager.py
+++ b/recurly/pager.py
@@ -66,6 +66,24 @@ class Pager:
         """
         return ItemIterator(self.__client, self.__path, self.__params)
 
+    def first(self):
+        """Performs a request with the pager `limit` set to 1 and only returns the
+        first result in the response.
+        """
+        params = self.__params.copy()
+        params.update({"limit": 1})
+        items = ItemIterator(self.__client, self.__path, params)
+        try:
+            return next(items)
+        except StopIteration:
+            return None
+
+    def count(self):
+        """Makes a HEAD request to the API to determine how many total records exist.
+        """
+        resource = self.__client._make_request("HEAD", self.__path, None, self.__params)
+        return int(resource.get_response().total_records)
+
     def __map_array_params(self, params):
         """Converts array parameters to CSV strings to maintain consistency with
         how the server expects the request to be formatted while providing the

--- a/recurly/response.py
+++ b/recurly/response.py
@@ -27,6 +27,7 @@ class Response:
                 "server": self.__headers.get("Server"),
                 "cf-ray": self.__headers.get("CF-RAY"),
             }
+            self.total_records = self.__headers.get("recurly-total-records")
             if http_body and len(http_body) > 0:
                 self.body = http_body
         except:


### PR DESCRIPTION
Adds the `first` and `count` methods to the `Pager` class.

The `first` method will perform a request to the API with the `limit` set to 1 and will only return the first result from the server.

The `count` method will perform a `HEAD` request to the API for the appropriate endpoint. The value of the response header, `recurly-total-records`, will be returned. This is the total number of records that will be returned by the pager.