### PR TITLE
Add IBAN attribute to BillingInfo

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -46,7 +46,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.25'
+API_VERSION = '2.26'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None
@@ -413,8 +413,9 @@ class BillingInfo(Resource):
         'gateway_code',
         'three_d_secure_action_result_token_id',
         'transaction_type',
+        'iban'
     )
-    sensitive_attributes = ('number', 'verification_value', 'account_number')
+    sensitive_attributes = ('number', 'verification_value', 'account_number', 'iban')
     xml_attribute_attributes = ('type',)
 
 class ShippingAddress(Resource):

--- a/tests/fixtures/billing-info/account-iban-created.xml
+++ b/tests/fixtures/billing-info/account-iban-created.xml
@@ -1,0 +1,35 @@
+POST https://api.recurly.com/v2/accounts HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account>
+  <account_code>binfo-mock-4</account_code>
+  <billing_info>
+    <name_on_account>Account Name</name_on_account>
+    <currency>USD</currency>
+    <iban>FR1420041010050500013M02606</iban>
+  </billing_info>
+</account>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/binfo-mock-4
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/binfo-mock-3">
+  <adjustments href="https://api.recurly.com/v2/accounts/binfo-mock-3/adjustments"/>
+  <invoices href="https://api.recurly.com/v2/accounts/binfo-mock-3/invoices"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/binfo-mock-3/subscriptions"/>
+  <transactions href="https://api.recurly.com/v2/accounts/binfo-mock-3/transactions"/>
+  <account_code>binfo-mock-4</account_code>
+  <username nil="nil"></username>
+  <email nil="nil"></email>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
+  <company_name nil="nil"></company_name>
+  <accept_language nil="nil"></accept_language>
+</account>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -561,6 +561,26 @@ class TestResources(RecurlyTest):
         self.assertTrue('<billing_info' in log_content)
         self.assertTrue('<token_id' in log_content)
 
+        # IBAN
+        log_content = StringIO()
+        log_handler = logging.StreamHandler(log_content)
+        logger.addHandler(log_handler)
+
+        account = Account(account_code='binfo-%s-4' % self.test_id)
+        account.billing_info = BillingInfo(
+            name_on_account='Account Name',
+            iban='FR1420041010050500013M02606',
+        )
+        with self.mock_request('billing-info/account-iban-created.xml'):
+            account.save()
+
+        self.assertEqual(account.billing_info.name_on_account, 'Account Name')
+
+        logger.removeHandler(log_handler)
+        log_content = log_content.getvalue()
+        self.assertTrue('<billing_info' in log_content)
+        self.assertTrue('<iban' in log_content)
+
     def test_charge(self):
         account = Account(account_code='charge%s' % self.test_id)
         with self.mock_request('adjustment/account-created.xml'):


### PR DESCRIPTION
This feature is to allow support of the IBAN field in our V2 API for the applicable endpoints. This field is most similar to banking account information or credit card information, and is used to make payments for SEPA transactions.

IBAN numbers can be set in all endpoints that support BillingInfo:

PUT "/v2/accounts/{account_id}/billing_info"
PUT "/v2/accounts/{account_id}"
POST "/v2/accounts"
POST "/v2/subscriptions"
POST "/v2/purchases"
POST "/v2/purchases/preview"

A sample request payload is provided below:

```
<billing_info>
  <iban>IBANNUMBERHERE</iban>
  <name_on_account>Verena Example</name_on_account>
  <!-- address fields... ->
</billing_info>
```