### PR TITLE
Add payment_method and collected_at as attributes to Transaction

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -1404,6 +1404,8 @@ class Transaction(Resource):
         'origin',
         'message',
         'approval_code',
+        'payment_method',
+        'collected_at'
     )
     xml_attribute_attributes = ('type',)
     sensitive_attributes = ('number', 'verification_value',)

--- a/tests/fixtures/invoice/offline-payment.xml
+++ b/tests/fixtures/invoice/offline-payment.xml
@@ -10,6 +10,7 @@ Content-Type: application/xml; charset=utf-8
   <currency>USD</currency>
   <amount_in_cents type="integer">5000</amount_in_cents>
   <description>Collected externally</description>
+  <payment_method>paypal</payment_method>
 </transaction>
 
 HTTP/1.1 201 Created
@@ -26,7 +27,7 @@ Location: https://api.recurly.com/v2/transactions/46036dcc04137580364f244e959181
   <tax_in_cents type="integer">0</tax_in_cents>
   <currency>USD</currency>
   <status>success</status>
-  <payment_method>credit_card</payment_method>
+  <payment_method>paypal</payment_method>
   <reference nil="nil"></reference>
   <source>transaction</source>
   <recurring type="boolean">false</recurring>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -952,10 +952,11 @@ class TestResources(RecurlyTest):
         self.assertIsInstance(invoice, Invoice)
 
         with self.mock_request('invoice/offline-payment.xml'):
-            transaction = Transaction(amount_in_cents=5000, description="Collected externally")
+            transaction = Transaction(payment_method="paypal", amount_in_cents=5000, description="Collected externally")
             transaction = invoice.enter_offline_payment(transaction)
 
         self.assertIsInstance(transaction, Transaction)
+        self.assertEqual(transaction.payment_method, "paypal")
 
     def test_invoice_create(self):
         # Invoices should not be created with save method


### PR DESCRIPTION
It was found that `payment_method` and `collected_at` were not included in the Transaction POST XML request body and thus defaulted to `credit_card` and current date, respectively, in response. UI reflected this. Adding `payment_method` and `collected_at` to the `Transaction` object addresses this issue.