### PR TITLE
Add mandate_reference attribute to BillingInfo

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -378,6 +378,7 @@ class BillingInfo(Resource):
         'name_on_account',
         'first_name',
         'last_name',
+        'mandate_reference',
         'number',
         'verification_value',
         'year',

--- a/tests/fixtures/billing-info/created.xml
+++ b/tests/fixtures/billing-info/created.xml
@@ -31,6 +31,7 @@ Location: https://api.recurly.com/v2/accounts/binfomock/billing_info
 <billing_info url="https://api.recurly.com/v2/accounts/binfomock/billing_info" type="credit_card">
   <first_name>Verena</first_name>
   <last_name>Example</last_name>
+  <mandate_reference>ref-126</mandate_reference>
   <address1>123 Main St</address1>
   <city>San José</city>
   <state>CA</state>


### PR DESCRIPTION
A mandate reference is a specific ID used in a payment system to show that an agreement was made between the customer and the merchant. It is often required for compliance reasons to display when a billing info is created or a payment is created.