### PR TITLE
Ensure that path parameters are not empty strings

### DIFF
--- a/recurly/base_client.py
+++ b/recurly/base_client.py
@@ -61,7 +61,18 @@ class BaseClient:
         except socket.error as e:
             raise NetworkError(e)
 
+    def _validate_path_parameters(self, args):
+        """Checks that path parameters are valid"""
+        # Check that parameters are valid types
+        if any(type(arg) not in [str, int, float] for arg in args):
+            raise ApiError("Invalid parameter type", None)
+
+        # Check that string parameters are not empty
+        if any(isinstance(arg, str) and not bool(arg.strip()) for arg in args):
+            raise ApiError("Parameters cannot be empty strings", None)
+
     def _interpolate_path(self, path, *args):
         """Encodes components and interpolates path"""
+        self._validate_path_parameters(args)
 
         return path % tuple(map(urllib.parse.quote, args))

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -107,6 +107,22 @@ class TestBaseClient(unittest.TestCase):
         client = MockClient("apikey")
         self.assertEqual(client.api_version(), "v2018-08-09")
 
+    def test_pathParameterValidationEmpty(self):
+        with get_resource_client(False) as conn:
+            client = MockClient("apikey")
+            with self.assertRaises(recurly.ApiError) as e:
+                resource = client.get_resource("")
+
+            self.assertEqual("Parameters cannot be empty strings", str(e.exception))
+
+    def test_pathParameterValidationNone(self):
+        with get_resource_client(False) as conn:
+            client = MockClient("apikey")
+            with self.assertRaises(recurly.ApiError) as e:
+                resource = client.get_resource(None)
+
+            self.assertEqual("Invalid parameter type", str(e.exception))
+
     def test_successful_GET_200(self):
         with get_resource_client(True) as conn:
             client = MockClient("apikey")


### PR DESCRIPTION
Adding a validation method that will ensure that path parameters are not empty strings to address issues where a `get_*` operation (`/resources/{resource_id}`) does not get handled by the API as a `list_*` operations (`/resources/`). The validation will also ensure that only approved types are used.