### PR TITLE
Fix python3 deprecation warnings

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -9,10 +9,8 @@ import sys
 __version__ = "3.5.0"
 __python_version__ = ".".join(map(str, sys.version_info[:3]))
 
-USER_AGENT = "Recurly/%s; python %s; %s" % (
-    __version__,
-    __python_version__,
-    ssl.OPENSSL_VERSION,
+USER_AGENT = "Recurly/{}; python {}; {}".format(
+    __version__, __python_version__, ssl.OPENSSL_VERSION
 )
 
 # Running in strict mode will throw exceptions

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,4 +5,4 @@ from recurly import Client
 class TestClient(unittest.TestCase):
     def test_api_version(self):
         client = Client("apikey")
-        self.assertRegex(client.api_version(), "v\d{4}-\d{2}-\d{2}")
+        self.assertRegex(client.api_version(), r"v\d{4}-\d{2}-\d{2}")


### PR DESCRIPTION
Resolves #391

Ran [pyupgrade](https://github.com/asottile/pyupgrade/) to look for deprecated patterns. I verified that behavior for both changes remained the same.