### PR TITLE
Release 3.5.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.5.0
+current_version = 3.5.1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -6,7 +6,7 @@ import glob
 import ssl
 import sys
 
-__version__ = "3.5.0"
+__version__ = "3.5.1"
 __python_version__ = ".".join(map(str, sys.version_info[:3]))
 
 USER_AGENT = "Recurly/{}; python {}; {}".format(


### PR DESCRIPTION
[Full Changelog](https://github.com/recurly/recurly-client-python/compare/3.5.0...HEAD)

**Implemented enhancements:**

- Deprecation warning due to invalid escape sequences [\#391](https://github.com/recurly/recurly-client-python/issues/391)

**Fixed bugs:**

- RateLimiter Exception  [\#388](https://github.com/recurly/recurly-client-python/issues/388)

**Merged pull requests:**

- Fix python3 deprecation warnings [\#392](https://github.com/recurly/recurly-client-python/pull/392) ([bhelx](https://github.com/bhelx))
- More defensive parsing of Response headers [\#389](https://github.com/recurly/recurly-client-python/pull/389) ([bhelx](https://github.com/bhelx))