### PR TITLE
Properly encode boolean query params

### DIFF
--- a/recurly/base_client.py
+++ b/recurly/base_client.py
@@ -9,6 +9,7 @@ from .response import Response
 from recurly import USER_AGENT, ApiError, NetworkError
 from pydoc import locate
 import urllib.parse
+from datetime import datetime
 
 PORT = 443
 HOST = "v3.recurly.com"
@@ -88,6 +89,9 @@ class BaseClient:
             # booleans need to be downcased
             elif isinstance(v, bool):
                 r_params[k] = "true" if v else "false"
+            # datetimes should be iso8601 strings
+            elif isinstance(v, datetime):
+                r_params[k] = v.isoformat()
             else:
                 r_params[k] = v
 

--- a/recurly/base_client.py
+++ b/recurly/base_client.py
@@ -34,7 +34,7 @@ class BaseClient:
                 body = json.dumps(body)
 
             if params:
-                path += "?" + urllib.parse.urlencode(params)
+                path += "?" + self._url_encode(params)
 
             self.__conn.request(method, path, body, headers=headers)
             request = Request(method, path, body)
@@ -76,3 +76,19 @@ class BaseClient:
         self._validate_path_parameters(args)
 
         return path % tuple(map(lambda arg: urllib.parse.quote(arg, safe=""), args))
+
+    def _url_encode(self, params):
+        """Encode query params for URL. We need to customize this to conform to Recurly's API"""
+        r_params = {}
+
+        for k, v in params.items():
+            # join lists w/ a comma (CSV encoding)
+            if isinstance(v, list) or isinstance(v, tuple):
+                r_params[k] = ",".join(v)
+            # booleans need to be downcased
+            elif isinstance(v, bool):
+                r_params[k] = "true" if v else "false"
+            else:
+                r_params[k] = v
+
+        return urllib.parse.urlencode(r_params)

--- a/recurly/pager.py
+++ b/recurly/pager.py
@@ -54,7 +54,7 @@ class Pager:
     def __init__(self, client, path, params):
         self.__client = client
         self.__path = path
-        self.__params = self.__map_array_params(params)
+        self.__params = params
 
     def pages(self):
         """An iterator that enumerates each page of results."""
@@ -83,10 +83,3 @@ class Pager:
         """
         resource = self.__client._make_request("HEAD", self.__path, None, self.__params)
         return resource.get_response().total_records
-
-    def __map_array_params(self, params):
-        """Converts array parameters to CSV strings to maintain consistency with
-        how the server expects the request to be formatted while providing the
-        developer with an array type to maintain developer happiness!
-        """
-        return {k: ",".join(v) if isinstance(v, list) else v for k, v in params.items()}


### PR DESCRIPTION
* Refactored all query param handling to exist in BaseClient
* Added support for csv encoding tuples and not just lists
* Added support for datetime query params
* Changed boolean encoding to the correct casing (was resulting in a 400
  Bad Request)
* Fixed the request assertion tests