### PR TITLE
Updating error hierarchy and providing error handling for non-json error responses

### DIFF
--- a/docs/source/recurly.rst
+++ b/docs/source/recurly.rst
@@ -12,6 +12,14 @@ recurly.base\_client module
     :undoc-members:
     :show-inheritance:
 
+recurly.base\_errors module
+---------------------------
+
+.. automodule:: recurly.base_errors
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 recurly.client module
 ---------------------
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -21,20 +21,7 @@ USER_AGENT = "Recurly/{}; python {}; {}".format(
 STRICT_MODE = os.getenv("RECURLY_STRICT_MODE", "FALSE").upper() == "TRUE"
 
 
-class RecurlyError(Exception):
-    pass
-
-
-class ApiError(RecurlyError):
-    def __init__(self, message, error):
-        super(ApiError, self).__init__(message)
-        self.error = error
-
-
-class NetworkError(RecurlyError):
-    pass
-
-
+from .base_errors import RecurlyError, ApiError, NetworkError
 from . import errors
 from .client import Client
 from .resource import Resource

--- a/recurly/base_errors.py
+++ b/recurly/base_errors.py
@@ -1,0 +1,20 @@
+import recurly
+
+
+class RecurlyError(Exception):
+    @classmethod
+    def error_from_status(cls, status):
+        if status in recurly.errors.ERROR_MAP:
+            return recurly.errors.ERROR_MAP[status]
+        else:
+            return ""
+
+
+class ApiError(RecurlyError):
+    def __init__(self, message, error):
+        super(ApiError, self).__init__(message)
+        self.error = error
+
+
+class NetworkError(RecurlyError):
+    pass

--- a/recurly/base_errors.py
+++ b/recurly/base_errors.py
@@ -4,10 +4,7 @@ import recurly
 class RecurlyError(Exception):
     @classmethod
     def error_from_status(cls, status):
-        if status in recurly.errors.ERROR_MAP:
-            return recurly.errors.ERROR_MAP[status]
-        else:
-            return ""
+        return recurly.errors.ERROR_MAP.get(status, "")
 
 
 class ApiError(RecurlyError):

--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -5,25 +5,26 @@
 # need and we will usher them to the appropriate places.
 import recurly
 
+ERROR_MAP = {
+    500: "InternalServerError",
+    502: "BadGatewayError",
+    503: "ServiceUnavailableError",
+    304: "NotModifiedError",
+    400: "BadRequestError",
+    401: "UnauthorizedError",
+    402: "PaymentRequiredError",
+    403: "ForbiddenError",
+    404: "NotFoundError",
+    406: "NotAcceptableError",
+    412: "PreconditionFailedError",
+    422: "UnprocessableEntityError",
+    429: "TooManyRequestsError",
+}
+
 
 def error_from_status(status):
-    error_map = {
-        500: "InternalServerError",
-        502: "BadGatewayError",
-        503: "ServiceUnavailableError",
-        304: "NotModifiedError",
-        400: "BadRequestError",
-        401: "UnauthorizedError",
-        402: "PaymentRequiredError",
-        403: "ForbiddenError",
-        404: "NotFoundError",
-        406: "NotAcceptableError",
-        412: "PreconditionFailedError",
-        422: "UnprocessableEntityError",
-        429: "TooManyRequestsError",
-    }
-    if status in error_map:
-        return error_map[status]
+    if status in ERROR_MAP:
+        return ERROR_MAP[status]
     else:
         return ""
 

--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -6,69 +6,143 @@
 import recurly
 
 
-class BadRequestError(recurly.ApiError):
+def error_from_status(status):
+    error_map = {
+        500: "InternalServerError",
+        502: "BadGatewayError",
+        503: "ServiceUnavailableError",
+        304: "NotModifiedError",
+        400: "BadRequestError",
+        401: "UnauthorizedError",
+        402: "PaymentRequiredError",
+        403: "ForbiddenError",
+        404: "NotFoundError",
+        406: "NotAcceptableError",
+        412: "PreconditionFailedError",
+        422: "UnprocessableEntityError",
+        429: "TooManyRequestsError",
+    }
+    if status in error_map:
+        return error_map[status]
+    else:
+        return ""
+
+
+class ResponseError(recurly.ApiError):
     pass
 
 
-class InternalServerError(recurly.ApiError):
+class ServerError(ResponseError):
     pass
 
 
-class ImmutableSubscriptionError(recurly.ApiError):
+class InternalServerError(ServerError):
     pass
 
 
-class InvalidApiKeyError(recurly.ApiError):
+class BadGatewayError(ServerError):
     pass
 
 
-class InvalidApiVersionError(recurly.ApiError):
+class ServiceUnavailableError(ServerError):
     pass
 
 
-class InvalidContentTypeError(recurly.ApiError):
+class RedirectionError(ResponseError):
     pass
 
 
-class InvalidPermissionsError(recurly.ApiError):
+class NotModifiedError(ResponseError):
     pass
 
 
-class InvalidTokenError(recurly.ApiError):
+class ClientError(recurly.ApiError):
     pass
 
 
-class NotFoundError(recurly.ApiError):
+class BadRequestError(ClientError):
     pass
 
 
-class SimultaneousRequestError(recurly.ApiError):
+class InvalidContentTypeError(BadRequestError):
     pass
 
 
-class TransactionError(recurly.ApiError):
+class UnauthorizedError(ClientError):
     pass
 
 
-class UnauthorizedError(recurly.ApiError):
+class PaymentRequiredError(ClientError):
     pass
 
 
-class UnavailableInApiVersionError(recurly.ApiError):
+class ForbiddenError(ClientError):
     pass
 
 
-class UnknownApiVersionError(recurly.ApiError):
+class InvalidApiKeyError(ForbiddenError):
     pass
 
 
-class ValidationError(recurly.ApiError):
+class InvalidPermissionsError(ForbiddenError):
     pass
 
 
-class MissingFeatureError(recurly.ApiError):
+class NotFoundError(ClientError):
     pass
 
 
-class RateLimitedError(recurly.ApiError):
+class NotAcceptableError(ClientError):
+    pass
+
+
+class UnknownApiVersionError(NotAcceptableError):
+    pass
+
+
+class UnavailableInApiVersionError(NotAcceptableError):
+    pass
+
+
+class InvalidApiVersionError(NotAcceptableError):
+    pass
+
+
+class PreconditionFailedError(ClientError):
+    pass
+
+
+class UnprocessableEntityError(ClientError):
+    pass
+
+
+class ValidationError(UnprocessableEntityError):
+    pass
+
+
+class MissingFeatureError(UnprocessableEntityError):
+    pass
+
+
+class TransactionError(UnprocessableEntityError):
+    pass
+
+
+class SimultaneousRequestError(UnprocessableEntityError):
+    pass
+
+
+class ImmutableSubscriptionError(UnprocessableEntityError):
+    pass
+
+
+class InvalidTokenError(UnprocessableEntityError):
+    pass
+
+
+class TooManyRequestsError(ClientError):
+    pass
+
+
+class RateLimitedError(TooManyRequestsError):
     pass

--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -22,13 +22,6 @@ ERROR_MAP = {
 }
 
 
-def error_from_status(status):
-    if status in ERROR_MAP:
-        return ERROR_MAP[status]
-    else:
-        return ""
-
-
 class ResponseError(recurly.ApiError):
     pass
 

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -42,7 +42,7 @@ class Resource:
             class_name = "".join(x.title() for x in name_parts)
             msg = error.message + ". Recurly Request Id: " + response.request_id
         else:
-            class_name = recurly.errors.error_from_status(response.status)
+            class_name = recurly.RecurlyError.error_from_status(response.status)
             error = None
             msg = "Unexpected %i Error. Recurly Request Id: %s" % (
                 response.status,

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -31,18 +31,26 @@ class Resource:
 
     @classmethod
     def cast_error(cls, response):
-        json_body = json.loads(response.body.decode("utf-8"))
+        if response.content_type == "application/json":
+            json_body = json.loads(response.body.decode("utf-8"))
 
-        error_json = json_body["error"]
-        error_json["object"] = "error"
-        error = cls.cast_json(error_json, response=response)
-        error_type = error.type
-        name_parts = error_type.split("_")
-        class_name = "".join(x.title() for x in name_parts)
+            error_json = json_body["error"]
+            error_json["object"] = "error"
+            error = cls.cast_json(error_json, response=response)
+            error_type = error.type
+            name_parts = error_type.split("_")
+            class_name = "".join(x.title() for x in name_parts)
+            msg = error.message + ". Recurly Request Id: " + response.request_id
+        else:
+            class_name = recurly.errors.error_from_status(response.status)
+            error = None
+            msg = "Unexpected %i Error. Recurly Request Id: %s" % (
+                response.status,
+                response.request_id,
+            )
         if not class_name.endswith("Error"):
             class_name += "Error"
         klass = locate("recurly.errors.%s" % class_name)
-        msg = error.message + ". Recurly Request Id: " + response.request_id
         # Use a specific error class if we can find one, else
         # fall back to a generic ApiError
         if klass:

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -29,6 +29,10 @@ def update_resource_client(success, request):
     response = MagicMock()
     if success:
         response.status = 201
+        response.headers = {
+            "Content-Type": "application/json",
+            "X-Request-Id": "request-id",
+        }
         response.read.return_value = bytes(
             """
             {
@@ -39,6 +43,10 @@ def update_resource_client(success, request):
         )
     else:
         response.status = 422
+        response.headers = {
+            "Content-Type": "application/json",
+            "X-Request-Id": "request-id",
+        }
         response.read.return_value = bytes(
             """
             {
@@ -70,6 +78,10 @@ def get_resource_client(success, request):
     response = MagicMock()
     if success:
         response.status = 200
+        response.headers = {
+            "Content-Type": "application/json",
+            "X-Request-Id": "request-id",
+        }
         response.read.return_value = bytes(
             """
             {
@@ -80,6 +92,10 @@ def get_resource_client(success, request):
         )
     else:
         response.status = 404
+        response.headers = {
+            "Content-Type": "application/json",
+            "X-Request-Id": "request-id",
+        }
         response.read.return_value = bytes(
             """
             {


### PR DESCRIPTION
Non-breaking update to error classes to give them a hierarchical structure. This will facilitate differentiating between a `ClientError` and a `ServerError` for example.

New error classes have also been added to be parent classes for some existing errors (e.g. `ForbiddenError` is a new class and both `InvalidApiKeyError` and `InvalidPermissionsError` extend it)

Most importantly, this update allows the client library to gracefully handle non-json errors in the rare occasions when they occur. These errors will be based on the HTTP status code of the response and will fall back to the existing `ApiError` if there is not a defined mapping.
