### PR TITLE
Release 3.6.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.5.1
+current_version = 3.6.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
@@ -11,3 +11,4 @@ serialize =
 [bumpversion:file:docs/README.md]
 parse = (?P<major>\d+)\.(?P<minor>\d+)
 serialize = {major}.{minor}
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This library is the official python client for Recurly's V3 API.
 
 We recommend specifying this dependency in your requirements.txt:
 ```
-recurly~=3.5
+recurly~=3.6
 ```
 
 Or installing via the command line:

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -6,7 +6,7 @@ import glob
 import ssl
 import sys
 
-__version__ = "3.5.1"
+__version__ = "3.6.0"
 __python_version__ = ".".join(map(str, sys.version_info[:3]))
 
 USER_AGENT = "Recurly/{}; python {}; {}".format(


### PR DESCRIPTION
[Full Changelog](https://github.com/recurly/recurly-client-python/compare/3.5.1...HEAD)

**Implemented enhancements:**

- Latest Features [\#403](https://github.com/recurly/recurly-client-python/pull/403) ([bhelx](https://github.com/bhelx))
- Updating error hierarchy and providing error handling for non-json error responses [\#401](https://github.com/recurly/recurly-client-python/pull/401) ([douglasmiller](https://github.com/douglasmiller))

**Fixed bugs:**

- Properly encode boolean query params [\#397](https://github.com/recurly/recurly-client-python/pull/397) ([bhelx](https://github.com/bhelx))

**Merged pull requests:**

- Convert datetimes objects in request bodies [\#400](https://github.com/recurly/recurly-client-python/pull/400) ([bhelx](https://github.com/bhelx))
- README: Use 3.5 install instr, remove link formatting [\#399](https://github.com/recurly/recurly-client-python/pull/399) ([bhelx](https://github.com/bhelx))
- Small changes to readme [\#398](https://github.com/recurly/recurly-client-python/pull/398) ([bhelx](https://github.com/bhelx))
- Implement Pager\#take [\#396](https://github.com/recurly/recurly-client-python/pull/396) ([bhelx](https://github.com/bhelx))
- Updating path parameter encoding to include forward slashes [\#393](https://github.com/recurly/recurly-client-python/pull/393) ([douglasmiller](https://github.com/douglasmiller))
- Ensure that path parameters are not empty strings [\#390](https://github.com/recurly/recurly-client-python/pull/390) ([douglasmiller](https://github.com/douglasmiller))