### PR TITLE
BACS support

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -416,7 +416,6 @@ class BillingInfo(Resource):
         'transaction_type',
         'iban',
         'sort_code',
-        'type'
     )
     sensitive_attributes = ('number', 'verification_value', 'account_number', 'iban')
     xml_attribute_attributes = ('type',)

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -46,7 +46,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.26'
+API_VERSION = '2.27'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None
@@ -414,7 +414,9 @@ class BillingInfo(Resource):
         'gateway_code',
         'three_d_secure_action_result_token_id',
         'transaction_type',
-        'iban'
+        'iban',
+        'sort_code',
+        'type'
     )
     sensitive_attributes = ('number', 'verification_value', 'account_number', 'iban')
     xml_attribute_attributes = ('type',)

--- a/tests/fixtures/billing-info/account-bacs-created.xml
+++ b/tests/fixtures/billing-info/account-bacs-created.xml
@@ -13,7 +13,7 @@ Content-Type: application/xml; charset=utf-8
     <city>London</city>
     <zip>W1K 6AH</zip>
     <country>GB</country>
-    <account_number>55779911</account_number>
+    <account_number>12345678</account_number>
     <currency>USD</currency>
     <sort_code>200000</sort_code>
   </billing_info>

--- a/tests/fixtures/billing-info/account-bacs-created.xml
+++ b/tests/fixtures/billing-info/account-bacs-created.xml
@@ -1,0 +1,39 @@
+POST https://api.recurly.com/v2/accounts HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account>
+  <account_code>binfo-mock-5</account_code>
+  <billing_info type="bacs">
+    <name_on_account>Account Name</name_on_account>
+    <city>London</city>
+    <zip>W1K 6AH</zip>
+    <country>GB</country>
+    <account_number>55779911</account_number>
+    <currency>USD</currency>
+    <sort_code>200000</sort_code>
+  </billing_info>
+</account>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/binfo-mock-5
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/binfo-mock-5">
+  <adjustments href="https://api.recurly.com/v2/accounts/binfo-mock-5/adjustments"/>
+  <invoices href="https://api.recurly.com/v2/accounts/binfo-mock-5/invoices"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/binfo-mock-5/subscriptions"/>
+  <transactions href="https://api.recurly.com/v2/accounts/binfo-mock-5/transactions"/>
+  <account_code>binfo-mock-5</account_code>
+  <username nil="nil"></username>
+  <email nil="nil"></email>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
+  <company_name nil="nil"></company_name>
+  <accept_language nil="nil"></accept_language>
+</account>

--- a/tests/fixtures/billing-info/account-iban-created.xml
+++ b/tests/fixtures/billing-info/account-iban-created.xml
@@ -20,11 +20,11 @@ Content-Type: application/xml; charset=utf-8
 Location: https://api.recurly.com/v2/accounts/binfo-mock-4
 
 <?xml version="1.0" encoding="UTF-8"?>
-<account href="https://api.recurly.com/v2/accounts/binfo-mock-3">
-  <adjustments href="https://api.recurly.com/v2/accounts/binfo-mock-3/adjustments"/>
-  <invoices href="https://api.recurly.com/v2/accounts/binfo-mock-3/invoices"/>
-  <subscriptions href="https://api.recurly.com/v2/accounts/binfo-mock-3/subscriptions"/>
-  <transactions href="https://api.recurly.com/v2/accounts/binfo-mock-3/transactions"/>
+<account href="https://api.recurly.com/v2/accounts/binfo-mock-4">
+  <adjustments href="https://api.recurly.com/v2/accounts/binfo-mock-4/adjustments"/>
+  <invoices href="https://api.recurly.com/v2/accounts/binfo-mock-4/invoices"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/binfo-mock-4/subscriptions"/>
+  <transactions href="https://api.recurly.com/v2/accounts/binfo-mock-4/transactions"/>
   <account_code>binfo-mock-4</account_code>
   <username nil="nil"></username>
   <email nil="nil"></email>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -652,6 +652,35 @@ class TestResources(RecurlyTest):
         self.assertTrue('<billing_info' in log_content)
         self.assertTrue('<iban' in log_content)
 
+        # BACS
+        log_content = StringIO()
+        log_handler = logging.StreamHandler(log_content)
+        logger.addHandler(log_handler)
+
+        account = Account(account_code='binfo-%s-5' % self.test_id)
+        account.billing_info = BillingInfo(
+          name_on_account = 'Account Name',
+          account_number = '55779911',
+          sort_code = '200000',
+          city = 'London',
+          zip = 'W1K 6AH',
+          country = 'GB',
+          type = 'bacs'
+        )
+
+        with self.mock_request('billing-info/account-bacs-created.xml'):
+          account.save()
+
+        self.assertEqual(account.billing_info.name_on_account, 'Account Name')
+        self.assertEqual(account.billing_info.sort_code, '200000')
+        self.assertEqual(account.billing_info.type, 'bacs')
+
+        logger.removeHandler(log_handler)
+        log_content = log_content.getvalue()
+        self.assertTrue('<billing_info' in log_content)
+        self.assertTrue('type="bacs"' in log_content)
+        self.assertTrue('<sort_code' in log_content)
+
     def test_charge(self):
         account = Account(account_code='charge%s' % self.test_id)
         with self.mock_request('adjustment/account-created.xml'):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -660,7 +660,7 @@ class TestResources(RecurlyTest):
         account = Account(account_code='binfo-%s-5' % self.test_id)
         account.billing_info = BillingInfo(
           name_on_account = 'Account Name',
-          account_number = '55779911',
+          account_number = '12345678',
           sort_code = '200000',
           city = 'London',
           zip = 'W1K 6AH',


### PR DESCRIPTION
Added `sort_code` and `type` fields to support BACS payment type.