### PR TITLE
Support items on subscriptions

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -46,7 +46,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.26'
+API_VERSION = '2.27'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None
@@ -1510,6 +1510,7 @@ class Plan(Resource):
         'setup_fee_revenue_schedule_type',
         'trial_requires_billing_info',
         'auto_renew',
+        'allow_any_item_on_subscriptions',
     )
 
     def get_add_on(self, add_on_code):
@@ -1607,6 +1608,7 @@ class SubscriptionAddOn(Resource):
         'quantity',
         'unit_amount_in_cents',
         'address',
+        'add_on_source',
     )
 
 class Tier(Resource):

--- a/tests/fixtures/subscribe-add-on/item-created.xml
+++ b/tests/fixtures/subscribe-add-on/item-created.xml
@@ -1,0 +1,37 @@
+POST https://api.recurly.com/v2/items HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<item>
+  <item_code>itemmock</item_code>
+  <name>Mock Item</name>
+  <description>An item of the mocked variety</description>
+</item>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/items/itemmock
+
+<?xml version="1.0" encoding="UTF-8"?>
+<item href="https://api.recurly.com/v2/items/itemmock">
+  <item_code>itemmock</item_code>
+  <name>Mock Item</name>
+  <external_sku>handcrafted-plastic-soap</external_sku>
+  <description>An item of the mocked variety</description>
+  <tax_exempt>true</tax_exempt>
+  <accounting_code>1569273867</accounting_code>
+  <revenue_schedule_type>never</revenue_schedule_type>
+  <custom_fields>
+    <custom_field>
+        <name>color</name>
+        <value>blue</value>
+    </custom_field>
+  </custom_fields>
+  <created_at type="datetime">2019-09-23T21:25:45Z</created_at>
+  <updated_at type="datetime">2019-09-23T21:25:45Z</updated_at>
+  <deleted_at nil="nil"/>
+</item>

--- a/tests/fixtures/subscribe-add-on/subscribed.xml
+++ b/tests/fixtures/subscribe-add-on/subscribed.xml
@@ -16,6 +16,11 @@ Content-Type: application/xml; charset=utf-8
     <subscription_add_on>
       <add_on_code>second_add_on</add_on_code>
     </subscription_add_on>
+    <subscription_add_on>
+      <add_on_code>itemmock</add_on_code>
+      <unit_amount_in_cents type="integer">200</unit_amount_in_cents>
+      <add_on_source>type</add_on_source>
+    </subscription_add_on>
   </subscription_add_ons>
   <account>
     <account_code>sad-on-mock</account_code>
@@ -65,11 +70,19 @@ Location: https://api.recurly.com/v2/subscriptions/12345678901234567890123456789
       <add_on_code>mock_add_on</add_on_code>
       <unit_amount_in_cents type="integer">100</unit_amount_in_cents>
       <quantity type="integer">1</quantity>
+      <add_on_source>plan_add_on</add_on_source>
     </subscription_add_on>
     <subscription_add_on>
       <add_on_code>second_add_on</add_on_code>
       <unit_amount_in_cents type="integer">50</unit_amount_in_cents>
       <quantity type="integer">1</quantity>
+      <add_on_source>plan_add_on</add_on_source>
+    </subscription_add_on>
+    <subscription_add_on>
+      <add_on_code>itemmock</add_on_code>
+      <unit_amount_in_cents type="integer">200</unit_amount_in_cents>
+      <quantity type="integer">1</quantity>
+      <add_on_source>item</add_on_source>
     </subscription_add_on>
   </subscription_add_ons>
   <a name="cancel" href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/cancel" method="put"/>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1539,6 +1539,15 @@ class TestResources(RecurlyTest):
         with self.mock_request('subscribe-add-on/plan-created.xml'):
             plan.save()
 
+        item_code = 'item%s' % self.test_id
+        item = Item(
+            item_code=item_code,
+            name='Mock Item',
+            description='An item of the mocked variety'
+        )
+        with self.mock_request('subscribe-add-on/item-created.xml'):
+            item.save()
+
         try:
 
             add_on = AddOn(
@@ -1567,6 +1576,11 @@ class TestResources(RecurlyTest):
                     SubscriptionAddOn(
                         add_on_code='second_add_on',
                     ),
+                    SubscriptionAddOn(
+                        add_on_code=item.item_code,
+                        unit_amount_in_cents=200,
+                        add_on_source='type'
+                    )
                 ],
                 currency='USD',
                 account=Account(
@@ -1595,11 +1609,15 @@ class TestResources(RecurlyTest):
             self.assertEqual(sub_amount, 1000)
 
             # Test that the add-ons' amounts aren't real Money instances either.
-            add_on_1, add_on_2 = sub.subscription_add_ons
+            add_on_1, add_on_2, add_on_3 = sub.subscription_add_ons
             self.assertIsInstance(add_on_1, SubscriptionAddOn)
             amount_1 = add_on_1.unit_amount_in_cents
             self.assertTrue(not isinstance(amount_1, Money))
             self.assertEqual(amount_1, 100)
+
+            # Items can be used for subscription add-ons
+            add_on_source = add_on_3.add_on_source
+            self.assertEqual(add_on_source, "item")
 
             with self.mock_request('subscribe-add-on/account-exists.xml'):
                 account = Account.get(account_code)


### PR DESCRIPTION
This PR adds support for items on subscriptions, where merchants may now associate a subscription add-on with an item in their catalog.

`allow_any_item_on_subscriptions` has been added to the `Plan` class. It is used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used.

`add_on_source`, added to the `SubscriptionAddOn` class, is used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add-on data will be pulled from the plan's add-ons. If the associated  `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog.

Code example:
```python

# create sub add-on with item 
add_on_1 = recurly.SubscriptionAddOn()
add_on_1.add_on_code = item.item_code
add_on_1.unit_amount_in_cents = 299
add_on_1.add_on_source = "item"

# create sub add-on with existing add-on
add_on_2 = recurly.SubscriptionAddOn()
add_on_2.add_on_code = addon2.add_on_code

# create subscription
subscription = recurly.Subscription()
subscription.plan_code = plan.plan_code
subscription.account = account
subscription.subscription_add_ons = [add_on_1, add_on_2]
subscription.save()
```