### PR TITLE
BACS patch to support <type>

### DIFF
--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -714,8 +714,9 @@ class Resource(object):
                 value = self.__dict__[attrname]
             except KeyError:
                 continue
-
-            if attrname in self.xml_attribute_attributes:
+            # With one exception, type is an element xml attribute, e.g. <billing info type="credit_card"> or <adjustment type="charge">
+            # For billing_info, type property takes precedence over xml attribute when type = bacs, e.g. <billing info><type>bacs</type></billing_info>. 
+            if attrname in self.xml_attribute_attributes and ((root_name != 'billing_info' and attrname == 'type') or (root_name == 'billing_info' and value != 'bacs')):
                 elem.attrib[attrname] = six.text_type(value)
             else:
                 sub_elem = self.element_for_value(attrname, value)

--- a/tests/fixtures/billing-info/account-bacs-created.xml
+++ b/tests/fixtures/billing-info/account-bacs-created.xml
@@ -8,7 +8,8 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <account>
   <account_code>binfo-mock-5</account_code>
-  <billing_info type="bacs">
+  <billing_info>
+    <type>bacs</type>
     <name_on_account>Account Name</name_on_account>
     <city>London</city>
     <zip>W1K 6AH</zip>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -678,7 +678,7 @@ class TestResources(RecurlyTest):
         logger.removeHandler(log_handler)
         log_content = log_content.getvalue()
         self.assertTrue('<billing_info' in log_content)
-        self.assertTrue('type="bacs"' in log_content)
+        self.assertTrue('<type' in log_content)
         self.assertTrue('<sort_code' in log_content)
 
     def test_charge(self):


### PR DESCRIPTION
Patch ensures that subelement `type` is appended to `billing_info` element and fixes incorrect test.