### PR TITLE
Release 2.9.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## Version 2.9.17 - June 30, 2020 ##
+
+This version brings us up to API version 2.27, but has no breaking changes
+
+- BACS support [PR](https://github.com/recurly/recurly-client-python/pull/405)
+- Support items on subscriptions [PR](https://github.com/recurly/recurly-client-python/pull/407)
+- BACS patch [PR](https://github.com/recurly/recurly-client-python/pull/409)
+
 ## Version 2.9.16 - March 26, 2020 ##
 
 This version brings us up to API version 2.26, but has no breaking changes

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -22,7 +22,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.16'
+__version__ = '2.9.17'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {


### PR DESCRIPTION
This version brings us up to API version 2.27, but has no breaking changes

- BACS support https://github.com/recurly/recurly-client-python/pull/405
- Support items on subscriptions https://github.com/recurly/recurly-client-python/pull/407
- BACS patch https://github.com/recurly/recurly-client-python/pull/409