### PR TITLE
Release 2.9.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## Version 2.9.18 - July 22, 2020 ##
+
+This version brings us up to API version 2.28, but has no breaking changes
+
+- BECS support [PR](https://github.com/recurly/recurly-client-python/pull/415)
+
 ## Version 2.9.17 - June 30, 2020 ##
 
 This version brings us up to API version 2.27, but has no breaking changes

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -416,6 +416,7 @@ class BillingInfo(Resource):
         'transaction_type',
         'iban',
         'sort_code',
+        'bsb_code'
     )
     sensitive_attributes = ('number', 'verification_value', 'account_number', 'iban')
     xml_attribute_attributes = ('type',)

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -22,7 +22,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.17'
+__version__ = '2.9.18'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {
@@ -46,7 +46,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.27'
+API_VERSION = '2.28'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -715,9 +715,12 @@ class Resource(object):
             except KeyError:
                 continue
             # With one exception, type is an element xml attribute, e.g. <billing info type="credit_card"> or <adjustment type="charge">
-            # For billing_info, type property takes precedence over xml attribute when type = bacs, e.g. <billing info><type>bacs</type></billing_info>. 
-            if attrname in self.xml_attribute_attributes and ((root_name != 'billing_info' and attrname == 'type') or (root_name == 'billing_info' and value != 'bacs')):
-                elem.attrib[attrname] = six.text_type(value)
+            # For billing_info, type property takes precedence over xml attribute when type = bacs or becs, e.g. <billing info><type>bacs</type></billing_info>. 
+            if attrname in self.xml_attribute_attributes and (
+              (root_name != 'billing_info' and attrname == 'type') 
+              or (root_name == 'billing_info' and value not in ('bacs', 'becs'))
+            ):
+              elem.attrib[attrname] = six.text_type(value)
             else:
                 sub_elem = self.element_for_value(attrname, value)
                 elem.append(sub_elem)

--- a/tests/fixtures/billing-info/account-becs-created.xml
+++ b/tests/fixtures/billing-info/account-becs-created.xml
@@ -1,0 +1,71 @@
+POST https://api.recurly.com/v2/accounts HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account>
+  <account_code>binfo-mock-6</account_code>
+  <email>verena@example.com</email>
+  <billing_info>
+    <type>becs</type>
+    <name_on_account>BECS Test</name_on_account>
+    <address1>125 Paper Street</address1>
+    <city>Adelaide</city>
+    <zip>123456</zip>
+    <country>AU</country>
+    <phone>213-555-5555</phone>
+    <account_number>123456</account_number>
+    <currency>AUD</currency>
+    <bsb_code>082-082</bsb_code>
+  </billing_info>
+</account>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/accounts/binfo-mock-5
+
+<?xml version="1.0" encoding="UTF-8"?>
+<account href="https://api.recurly.com/v2/accounts/binfo-mock-6">
+  <adjustments href="https://api.recurly.com/v2/accounts/binfo-mock-6/adjustments"/>
+  <account_balance href="https://api.recurly.com/v2/accounts/binfo-mock-6/balance"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/binfo-mock-6/billing_info"/>
+  <invoices href="https://api.recurly.com/v2/accounts/binfo-mock-6/invoices"/>
+  <shipping_addresses href="https://api.recurly.com/v2/accounts/binfo-mock-6/shipping_addresses"/>
+  <subscriptions href="https://api.recurly.com/v2/accounts/binfo-mock-6/subscriptions"/>
+  <transactions href="https://api.recurly.com/v2/accounts/binfo-mock-6/transactions"/>
+  <notes href="https://api.recurly.com/v2/accounts/binfo-mock-6/notes"/>
+  <account_code>binfo-mock-6</account_code>
+  <state>active</state>
+  <username nil="nil"></username>
+  <email>verena@example.com</email>
+  <cc_emails nil="nil"></cc_emails>
+  <first_name nil="nil"></first_name>
+  <last_name nil="nil"></last_name>
+  <company_name nil="nil"></company_name>
+  <vat_number nil="nil"></vat_number>
+  <preferred_locale nil="nil"></preferred_locale>
+  <address>
+    <address1 nil="nil"></address1>
+    <address2 nil="nil"></address2>
+    <city nil="nil"></city>
+    <state nil="nil"></state>
+    <zip nil="nil"></zip>
+    <country nil="nil"></country>
+    <phone nil="nil"></phone>
+  </address>
+  <accept_language nil="nil"></accept_language>
+  <hosted_login_token>TDMzdQZtAzuUBZb3wF9fMTEMCzPbKZnx</hosted_login_token>
+  <created_at type="datetime">2020-07-14T21:30:52Z</created_at>
+  <updated_at type="datetime">2020-07-14T21:30:52Z</updated_at>
+  <closed_at nil="nil"></closed_at>
+  <custom_fields type="array"></custom_fields>
+  <has_live_subscription type="boolean">false</has_live_subscription>
+  <has_active_subscription type="boolean">false</has_active_subscription>
+  <has_future_subscription type="boolean">false</has_future_subscription>
+  <has_canceled_subscription type="boolean">false</has_canceled_subscription>
+  <has_past_due_invoice type="boolean">false</has_past_due_invoice>
+  <has_paused_subscription type="boolean">false</has_paused_subscription>
+</account>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -681,6 +681,39 @@ class TestResources(RecurlyTest):
         self.assertTrue('<type' in log_content)
         self.assertTrue('<sort_code' in log_content)
 
+        # BECS
+        log_content = StringIO()
+        log_handler = logging.StreamHandler(log_content)
+        logger.addHandler(log_handler)
+
+        account = Account(account_code='binfo-%s-6' % self.test_id)
+        account.email = 'verena@example.com'
+        account.billing_info = BillingInfo(
+          name_on_account = 'BECS Test',
+          account_number = '123456',
+          bsb_code = '082-082',
+          address1 = '125 Paper Street',
+          city = 'Adelaide',
+          zip = '123456',
+          country = 'AU',
+          phone = '213-555-5555',
+          type = 'becs',
+          currency = 'AUD'
+        )
+
+        with self.mock_request('billing-info/account-becs-created.xml'):
+          account.save()
+
+        self.assertEqual(account.billing_info.name_on_account, 'BECS Test')
+        self.assertEqual(account.billing_info.bsb_code, '082-082')
+        self.assertEqual(account.billing_info.type, 'becs')
+
+        logger.removeHandler(log_handler)
+        log_content = log_content.getvalue()
+        self.assertTrue('<billing_info' in log_content)
+        self.assertTrue('<type' in log_content)
+        self.assertTrue('<bsb_code' in log_content)
+
     def test_charge(self):
         account = Account(account_code='charge%s' % self.test_id)
         with self.mock_request('adjustment/account-created.xml'):


### PR DESCRIPTION
This version brings us up to API version 2.28, but has no breaking changes

- BECS support https://github.com/recurly/recurly-client-python/pull/415