### PR TITLE
Add tiers attribute to sub add-on

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -1611,6 +1611,7 @@ class SubscriptionAddOn(Resource):
         'unit_amount_in_cents',
         'address',
         'add_on_source',
+        'tiers'
     )
 
 class Tier(Resource):

--- a/tests/fixtures/subscribe-add-on/subscribed.xml
+++ b/tests/fixtures/subscribe-add-on/subscribed.xml
@@ -19,7 +19,10 @@ Content-Type: application/xml; charset=utf-8
     <subscription_add_on>
       <add_on_code>itemmock</add_on_code>
       <unit_amount_in_cents type="integer">200</unit_amount_in_cents>
-      <add_on_source>type</add_on_source>
+      <add_on_source>item</add_on_source>
+    </subscription_add_on>
+    <subscription_add_on>
+      <add_on_code>tiered_add_on</add_on_code>
     </subscription_add_on>
   </subscription_add_ons>
   <account>
@@ -84,6 +87,23 @@ Location: https://api.recurly.com/v2/subscriptions/12345678901234567890123456789
       <quantity type="integer">1</quantity>
       <add_on_source>item</add_on_source>
     </subscription_add_on>
+    <subscription_add_on>
+      <add_on_type>fixed</add_on_type>
+      <add_on_code>tiered_add_on</add_on_code>
+      <quantity type="integer">1</quantity>
+      <revenue_schedule_type>evenly</revenue_schedule_type>
+      <tier_type>tiered</tier_type>
+      <tiers type="array">
+        <tier>
+          <ending_quantity type="integer">2000</ending_quantity>
+          <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+        </tier>
+        <tier>
+          <ending_quantity type="integer">999999999</ending_quantity>
+          <unit_amount_in_cents type="integer">800</unit_amount_in_cents>
+        </tier>
+      </tiers>
+      </subscription_add_on>
   </subscription_add_ons>
   <a name="cancel" href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/cancel" method="put"/>
   <a name="terminate" href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/terminate" method="put"/>

--- a/tests/fixtures/subscribe-add-on/tiered-add-on-created.xml
+++ b/tests/fixtures/subscribe-add-on/tiered-add-on-created.xml
@@ -1,0 +1,57 @@
+POST https://api.recurly.com/v2/plans/basicplan/add_ons HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<add_on>
+  <add_on_code>tiered_add_on</add_on_code>
+  <name>Quantity-Based Pricing Add-On</name>
+  <display_quantity_on_hosted_page>true</display_quantity_on_hosted_page>
+  <tier_type>tiered</tier_type>
+  <tiers>
+    <tier>
+      <ending_quantity type="integer">2000</ending_quantity>
+      <unit_amount_in_cents><USD type="integer">1000</USD></unit_amount_in_cents>
+    </tier>
+    <tier>
+      <unit_amount_in_cents><USD type="integer">800</USD></unit_amount_in_cents>
+    </tier>
+  </tiers>
+</add_on>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/plans/basicplan/add_ons/tiered_add_on
+
+<?xml version="1.0" encoding="UTF-8"?>
+<add_on href="https://api.recurly.com/v2/plans/basicplan/add_ons/tiered_add_on">
+  <plan href="https://api.recurly.com/v2/plans/basicplan"/>
+  <add_on_code>tiered_add_on</add_on_code>
+  <name>Quantity-Based Pricing Add-On</name>
+  <default_quantity type="integer">1</default_quantity>
+  <display_quantity_on_hosted_page type="boolean">true</display_quantity_on_hosted_page>
+  <tiers type="array">
+    <tier>
+      <ending_quantity type="integer">2000</ending_quantity>
+      <unit_amount_in_cents>
+        <USD type="integer">1000</USD>
+      </unit_amount_in_cents>
+    </tier>
+    <tier>
+      <ending_quantity type="integer">999999999</ending_quantity>
+      <unit_amount_in_cents>
+        <USD type="integer">800</USD>
+      </unit_amount_in_cents>
+    </tier>
+  </tiers>
+  <accounting_code nil="nil"></accounting_code>
+  <add_on_type>fixed</add_on_type>
+  <optional type="boolean">true</optional>
+  <revenue_schedule_type>evenly</revenue_schedule_type>
+  <tier_type>tiered</tier_type>
+  <created_at type="datetime">2020-07-29T18:45:04Z</created_at>
+  <updated_at type="datetime">2020-07-29T18:45:04Z</updated_at>
+</add_on> 


### PR DESCRIPTION
Adding `tiers` to `SubscriptionAddOn` class will enable updating `unit_amount_in_cents` and `ending_quantity` attributes for the following endpoint: https://dev.recurly.com/docs/update-subscription-with-add-ons 

```python
subscription = Subscription.get('insert-uuid')
add_on = subscription.subscription_add_ons[0]

subscription_add_ons = [
  recurly.SubscriptionAddOn(
    add_on_code=add_on.add_on_code,
    quantity=5,
    tiers=[
        recurly.Tier(
          ending_quantity=5999, 
          unit_amount_in_cents=111
        ),
        recurly.Tier(
          unit_amount_in_cents=99
        ),
    ],
  )
]
subscription.subscription_add_ons = subscription_add_ons
subscription.timeframe = "now"
subscription.save()
```

Not directly related, but I also included tests for creating tiered subscription add-ons.