### PR TITLE
Add **options kwargs to operations

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -7033,7 +7033,7 @@ paths:
       - lang: Python
         source: |
           params = {"limit": 200}
-          invoices = client.list_invoices(params).items()
+          invoices = client.list_invoices(params=params).items()
           for invoice in invoices:
               print(invoice.number)
       - lang: ".NET"

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -329,7 +329,8 @@ paths:
           }
       - lang: Python
         source: |
-          sites = client.list_sites(limit=200).items()
+          params = {"limit": 200}
+          sites = client.list_sites(params=params).items()
           for site in sites:
               print(site.subdomain)
       - lang: ".NET"
@@ -545,7 +546,8 @@ paths:
           }
       - lang: Python
         source: |
-          accounts = client.list_accounts(limit=200).items()
+          params = {"limit": 200}
+          accounts = client.list_accounts(params=params).items()
           for account in accounts:
               print(account.code)
       - lang: ".NET"
@@ -2304,7 +2306,8 @@ paths:
           }
       - lang: Python
         source: |
-          redemptions = client.list_account_coupon_redemptions(account_id, limit=200).items()
+          params = {"limit": 200}
+          redemptions = client.list_account_coupon_redemptions(account_id, params=params).items()
           for redemption in redemptions:
               print(redemption.id)
       - lang: ".NET"
@@ -2772,7 +2775,8 @@ paths:
           }
       - lang: Python
         source: |
-          payments = client.list_account_credit_payments(account_id, limit=200).items()
+          params = {"limit": 200}
+          payments = client.list_account_credit_payments(account_id, params=params).items()
           for payment in payments:
               print(payment.id)
       - lang: ".NET"
@@ -2877,7 +2881,8 @@ paths:
           }
       - lang: Python
         source: |
-          invoices = client.list_account_invoices(account_id, limit=200).items()
+          params = {"limit": 200}
+          invoices = client.list_account_invoices(account_id, params=params).items()
           for invoice in invoices:
               print(invoice.number)
       - lang: ".NET"
@@ -3325,7 +3330,8 @@ paths:
           }
       - lang: Python
         source: |
-          line_items = client.list_account_line_items(account_id, limit=200).items()
+          params = {"limit": 200}
+          line_items = client.list_account_line_items(account_id, params=params).items()
           for line_item in line_items:
               print(line_item.id)
       - lang: ".NET"
@@ -3587,7 +3593,8 @@ paths:
           }
       - lang: Python
         source: |
-          line_items = client.list_account_line_items(account_id, limit=200).items()
+          params = {"limit": 200}
+          line_items = client.list_account_line_items(account_id, params=params).items()
           for line_item in line_items:
               print(line_item.id)
       - lang: ".NET"
@@ -4507,7 +4514,8 @@ paths:
           }
       - lang: Python
         source: |
-          subscriptions = client.list_account_subscriptions(account.id, limit=200).items()
+          params = {"limit": 200}
+          subscriptions = client.list_account_subscriptions(account.id, params=params).items()
           for subscription in subscriptions:
               print(subscription.uuid)
       - lang: ".NET"
@@ -4612,7 +4620,8 @@ paths:
           }
       - lang: Python
         source: |
-          transactions = client.list_account_transactions(account_id, limit=200).items()
+          params = {"limit": 200}
+          transactions = client.list_account_transactions(account_id, params=params).items()
           for transaction in transactions:
               print("Transaction %s" % transaction.id)
       - lang: ".NET"
@@ -4711,7 +4720,8 @@ paths:
       x-code-samples:
       - lang: Python
         source: |
-          child_accounts = client.list_child_accounts(account_id, limit=200).items()
+          params = {"limit": 200}
+          child_accounts = client.list_child_accounts(account_id, params=params).items()
           for account in child_accounts:
               print("Child Account %s" % account.code)
       - lang: Ruby
@@ -4796,7 +4806,8 @@ paths:
           }
       - lang: Python
         source: |
-          acquisitions = client.list_account_acquisition(limit=200).items()
+          params = {"limit": 200}
+          acquisitions = client.list_account_acquisition(params=params).items()
           for acquisition in acquisitions:
               print(acquisition.id)
       - lang: ".NET"
@@ -4895,7 +4906,8 @@ paths:
           }
       - lang: Python
         source: |
-          coupons = client.list_coupons(limit=200).items()
+          params = {"limit": 200}
+          coupons = client.list_coupons(params=params).items()
           for coupon in coupons:
               print(coupon.code)
       - lang: ".NET"
@@ -5647,7 +5659,8 @@ paths:
           }
       - lang: Python
         source: |
-          payments = client.list_credit_payments(limit=200).items()
+          params = {"limit": 200}
+          payments = client.list_credit_payments(params=params).items()
           for payment in payments:
               print("Credit Payment %s" % payment.id)
       - lang: ".NET"
@@ -5779,7 +5792,8 @@ paths:
           }
       - lang: Python
         source: |
-          custom_fields = client.list_custom_field_definitions(limit=200).items()
+          params = {"limit": 200}
+          custom_fields = client.list_custom_field_definitions(params=params).items()
           for custom_field in custom_fields:
               print(custom_field.name)
       - lang: ".NET"
@@ -5996,7 +6010,8 @@ paths:
           }
       - lang: Python
         source: |
-          items = client.list_items(limit=200).items()
+          params = {"limit": 200}
+          items = client.list_items(params=params).items()
           for item in items:
               print(item.code)
       - lang: ".NET"
@@ -7017,7 +7032,8 @@ paths:
           }
       - lang: Python
         source: |
-          invoices = client.list_invoices(limit=200).items()
+          params = {"limit": 200}
+          invoices = client.list_invoices(params).items()
           for invoice in invoices:
               print(invoice.number)
       - lang: ".NET"
@@ -7786,7 +7802,8 @@ paths:
       - lang: Python
         source: |
           try:
-              invoice = client.mark_invoice_successful(invoice_id)
+              params = {"limit": 200}
+              invoice = client.mark_invoice_successful(invoice_id, params=params)
               print("Marked Invoice successful %s" % invoice)
           except recurly.errors.ValidationError as e:
               # If the request was invalid, you may want to tell your user
@@ -8209,9 +8226,10 @@ paths:
       - lang: Python
         source: |
           try:
-              line_items = client.list_invoice_line_items(invoice_id, limit=200).items()
+              params = {"limit": 200}
+              line_items = client.list_invoice_line_items(invoice_id, params=params).items()
               for item in line_items:
-                print("Invoice Line Items %s" % item.id)
+                  print("Invoice Line Items %s" % item.id)
           except recurly.errors.NotFoundError:
               # If the resource was not found, you may want to alert the user or
               # just return nil
@@ -8307,14 +8325,10 @@ paths:
           }
       - lang: Python
         source: |
-          try:
-              redemptions = client.list_invoice_coupon_redemptions(invoice_id, limit=200).items()
-              for redemption in redemptions:
-                print("Invoice Coupon Redemption %s" % redemption)
-          except recurly.errors.NotFoundError:
-              # If the resource was not found, you may want to alert the user or
-              # just return nil
-              print("Resource Not Found")
+          params = {"limit": 200}
+          redemptions = client.list_invoice_coupon_redemptions(invoice_id, params=params).items()
+          for redemption in redemptions:
+              print("Invoice Coupon Redemption %s" % redemption)
       - lang: ".NET"
         source: |
           var couponRedemptions = client.ListInvoiceCouponRedemptions(invoiceId);
@@ -8408,9 +8422,10 @@ paths:
       - lang: Python
         source: |
           try:
-              related_invoices = client.list_related_invoices(invoice_id, limit=200).items()
+              params = {"limit": 200}
+              related_invoices = client.list_related_invoices(invoice_id, params=params).items()
               for invoice in related_invoices:
-                print("Related invoice %s" % invoice.id)
+                  print("Related invoice %s" % invoice.id)
           except recurly.errors.NotFoundError:
               # If the resource was not found, you may want to alert the user or
               # just return nil
@@ -8674,7 +8689,8 @@ paths:
           }
       - lang: Python
         source: |
-          line_items = client.list_line_items(limit=200).items()
+          params = {"limit": 200}
+          line_items = client.list_line_items(params=params).items()
           for line_item in line_items:
               print(line_item.id)
       - lang: ".NET"
@@ -9009,7 +9025,8 @@ paths:
           }
       - lang: Python
         source: |
-          plans = client.list_plans(limit=200).items()
+          params = {"limit": 200}
+          plans = client.list_plans(params=params).items()
           for plan in plans:
               print(plan.code)
       - lang: ".NET"
@@ -9679,7 +9696,8 @@ paths:
           }
       - lang: Python
         source: |
-          add_ons = client.list_plan_add_ons(plan_id).items()
+          params = {"limit": 200}
+          add_ons = client.list_plan_add_ons(plan_id, params=params).items()
           for add_on in add_ons:
               print(add_on.code)
       - lang: ".NET"
@@ -10351,7 +10369,8 @@ paths:
           }
       - lang: Python
         source: |
-          add_ons = client.list_add_ons().items()
+          params = {"limit": 200}
+          add_ons = client.list_add_ons(params=params).items()
           for add_on in add_ons:
               print("Add-On %s" % add_on.code)
       - lang: ".NET"
@@ -10567,9 +10586,10 @@ paths:
           }
       - lang: Python
         source: |
-          shipping_methods = client.list_shipping_methods(limit=200).items()
+          params = {"limit": 200}
+          shipping_methods = client.list_shipping_methods(params=params).items()
           for shipping_method in shipping_methods:
-            print("Shipping Method %s" % shipping_method.code)
+              print("Shipping Method %s" % shipping_method.code)
       - lang: ".NET"
         source: |
           var shippingMethods = client.ListShippingMethods();
@@ -10819,7 +10839,8 @@ paths:
           }
       - lang: Python
         source: |
-          subscriptions = client.list_subscriptions(limit=200).items()
+          params = {"limit": 200}
+          subscriptions = client.list_subscriptions(params=params).items()
           for subscription in subscriptions:
               print(subscription.uuid)
       - lang: ".NET"
@@ -12563,7 +12584,8 @@ paths:
           }
       - lang: Python
         source: |
-          invoices = client.list_subscription_invoices(subscription_id).items()
+          params = {"limit": 200}
+          invoices = client.list_subscription_invoices(subscription_id, params=params).items()
           for invoice in invoices:
               print(invoice.number)
       - lang: ".NET"
@@ -12669,7 +12691,8 @@ paths:
           }
       - lang: Python
         source: |
-          line_items = client.list_subscription_line_items(subscription_id).items()
+          params = {"limit": 200}
+          line_items = client.list_subscription_line_items(subscription_id, params=params).items()
           for line_item in line_items:
               print(line_item.id)
       - lang: ".NET"
@@ -12765,7 +12788,10 @@ paths:
           }
       - lang: Python
         source: |
-          redemptions = client.list_subscription_coupon_redemptions(subscription_id).items()
+          params = {"limit": 200}
+          redemptions = client.list_subscription_coupon_redemptions(
+              subscription_id, params=params
+          ).items()
           for redemption in redemptions:
               print(redemption.uuid)
       - lang: ".NET"
@@ -13085,7 +13111,8 @@ paths:
           }
       - lang: Python
         source: |
-          transactions = client.list_transactions(limit=200).items()
+          params = {"limit": 200}
+          transactions = client.list_transactions(params=params).items()
           for transaction in transactions:
               print(transaction.uuid)
       - lang: ".NET"

--- a/recurly/base_client.py
+++ b/recurly/base_client.py
@@ -29,7 +29,7 @@ class BaseClient:
         self.__api_key = api_key
         self.__conn = http.client.HTTPSConnection(HOST, PORT)
 
-    def _make_request(self, method, path, body, params):
+    def _make_request(self, method, path, body, **options):
         try:
             basic_auth = b64encode(bytes(self.__api_key + ":", "ascii")).decode("ascii")
             headers = {
@@ -38,11 +38,17 @@ class BaseClient:
                 "Accept": "application/vnd.recurly.%s" % self.api_version(),
                 "Content-Type": "application/json",
             }
+
+            # override headers with custom headers in the options
+            if "headers" in options:
+                for k, v in options["headers"].items():
+                    headers[k] = v
+
             if body:
                 body = json.dumps(body, default=request_converter)
 
-            if params:
-                path += "?" + self._url_encode(params)
+            if "params" in options:
+                path += "?" + self._url_encode(options["params"])
 
             self.__conn.request(method, path, body, headers=headers)
             request = Request(method, path, body)

--- a/recurly/client.py
+++ b/recurly/client.py
@@ -2030,7 +2030,7 @@ class Client(BaseClient):
         Invoice
             The updated invoice.
         """
-        body = kwargs.pop("body", None)
+        body = options.pop("body", None)
         path = self._interpolate_path("/invoices/%s/collect", invoice_id)
         return self._make_request("PUT", path, body, **options)
 
@@ -3121,7 +3121,7 @@ class Client(BaseClient):
         Subscription
             A canceled or failed subscription.
         """
-        body = kwargs.pop("body", None)
+        body = options.pop("body", None)
         path = self._interpolate_path("/subscriptions/%s/cancel", subscription_id)
         return self._make_request("PUT", path, body, **options)
 

--- a/recurly/client.py
+++ b/recurly/client.py
@@ -11,15 +11,17 @@ class Client(BaseClient):
     def api_version(self):
         return "v2020-01-01"
 
-    def list_sites(self, **kwargs):
+    def list_sites(self, **options):
         """List sites
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -31,51 +33,61 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        state : str
+        params.state : str
             Filter by state.
 
         Returns
         -------
+
         Pager
             A list of sites.
         """
         path = self._interpolate_path("/sites")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def get_site(self, site_id):
+    def get_site(self, site_id, **options):
         """Fetch a site
 
         Parameters
         ----------
+
         site_id : str
             Site ID or subdomain. For ID no prefix is used e.g. `e28zov4fw0v2`. For subdomain use prefix `subdomain-`, e.g. `subdomain-recurly`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Site
             A site.
         """
         path = self._interpolate_path("/sites/%s", site_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def list_accounts(self, **kwargs):
+    def list_accounts(self, **options):
         """List a site's accounts
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -87,257 +99,348 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        email : str
+        params.email : str
             Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
-        subscriber : bool
+        params.subscriber : bool
             Filter for accounts with or without a subscription in the `active`,
             `canceled`, or `future` state.
-        past_due : str
+        params.past_due : str
             Filter for accounts with an invoice in the `past_due` state.
 
         Returns
         -------
+
         Pager
             A list of the site's accounts.
         """
         path = self._interpolate_path("/accounts")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def create_account(self, body):
+    def create_account(self, body, **options):
         """Create an account
 
         Parameters
         ----------
-        body
-            The body of the request.
 
+        body : dict
+            The request body. It should follow the schema of AccountCreate.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Account
             An account.
         """
         path = self._interpolate_path("/accounts")
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def get_account(self, account_id):
+    def get_account(self, account_id, **options):
         """Fetch an account
 
         Parameters
         ----------
-        account_id : str
-            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
 
-
-        Returns
-        -------
-        Account
-            An account.
-        """
-        path = self._interpolate_path("/accounts/%s", account_id)
-        return self._make_request("GET", path, None, None)
-
-    def update_account(self, account_id, body):
-        """Modify an account
-
-        Parameters
-        ----------
-        account_id : str
-            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-        body
-            The body of the request.
-
-
-        Returns
-        -------
-        Account
-            An account.
-        """
-        path = self._interpolate_path("/accounts/%s", account_id)
-        return self._make_request("PUT", path, body, None)
-
-    def deactivate_account(self, account_id):
-        """Deactivate an account
-
-        Parameters
-        ----------
-        account_id : str
-            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-
-
-        Returns
-        -------
-        Account
-            An account.
-        """
-        path = self._interpolate_path("/accounts/%s", account_id)
-        return self._make_request("DELETE", path, None, None)
-
-    def get_account_acquisition(self, account_id):
-        """Fetch an account's acquisition data
-
-        Parameters
-        ----------
-        account_id : str
-            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-
-
-        Returns
-        -------
-        AccountAcquisition
-            An account's acquisition data.
-        """
-        path = self._interpolate_path("/accounts/%s/acquisition", account_id)
-        return self._make_request("GET", path, None, None)
-
-    def update_account_acquisition(self, account_id, body):
-        """Update an account's acquisition data
-
-        Parameters
-        ----------
-        account_id : str
-            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-        body
-            The body of the request.
-
-
-        Returns
-        -------
-        AccountAcquisition
-            An account's updated acquisition data.
-        """
-        path = self._interpolate_path("/accounts/%s/acquisition", account_id)
-        return self._make_request("PUT", path, body, None)
-
-    def remove_account_acquisition(self, account_id):
-        """Remove an account's acquisition data
-
-        Parameters
-        ----------
-        account_id : str
-            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-
-
-        Returns
-        -------
-        Empty
-            Acquisition data was succesfully deleted.
-        """
-        path = self._interpolate_path("/accounts/%s/acquisition", account_id)
-        return self._make_request("DELETE", path, None, None)
-
-    def reactivate_account(self, account_id):
-        """Reactivate an inactive account
-
-        Parameters
-        ----------
-        account_id : str
-            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-
-
-        Returns
-        -------
-        Account
-            An account.
-        """
-        path = self._interpolate_path("/accounts/%s/reactivate", account_id)
-        return self._make_request("PUT", path, None, None)
-
-    def get_account_balance(self, account_id):
-        """Fetch an account's balance and past due status
-
-        Parameters
-        ----------
-        account_id : str
-            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-
-
-        Returns
-        -------
-        AccountBalance
-            An account's balance.
-        """
-        path = self._interpolate_path("/accounts/%s/balance", account_id)
-        return self._make_request("GET", path, None, None)
-
-    def get_billing_info(self, account_id):
-        """Fetch an account's billing information
-
-        Parameters
-        ----------
-        account_id : str
-            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-
-
-        Returns
-        -------
-        BillingInfo
-            An account's billing information.
-        """
-        path = self._interpolate_path("/accounts/%s/billing_info", account_id)
-        return self._make_request("GET", path, None, None)
-
-    def update_billing_info(self, account_id, body):
-        """Set an account's billing information
-
-        Parameters
-        ----------
-        account_id : str
-            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-        body
-            The body of the request.
-
-
-        Returns
-        -------
-        BillingInfo
-            Updated billing information.
-        """
-        path = self._interpolate_path("/accounts/%s/billing_info", account_id)
-        return self._make_request("PUT", path, body, None)
-
-    def remove_billing_info(self, account_id):
-        """Remove an account's billing information
-
-        Parameters
-        ----------
-        account_id : str
-            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-
-
-        Returns
-        -------
-        Empty
-            Billing information deleted
-        """
-        path = self._interpolate_path("/accounts/%s/billing_info", account_id)
-        return self._make_request("DELETE", path, None, None)
-
-    def list_account_coupon_redemptions(self, account_id, **kwargs):
-        """Show the coupon redemptions for an account
-
-        Parameters
-        ----------
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        Account
+            An account.
+        """
+        path = self._interpolate_path("/accounts/%s", account_id)
+        return self._make_request("GET", path, None, **options)
+
+    def update_account(self, account_id, body, **options):
+        """Modify an account
+
+        Parameters
+        ----------
+
+        account_id : str
+            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+        body : dict
+            The request body. It should follow the schema of AccountUpdate.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        Account
+            An account.
+        """
+        path = self._interpolate_path("/accounts/%s", account_id)
+        return self._make_request("PUT", path, body, **options)
+
+    def deactivate_account(self, account_id, **options):
+        """Deactivate an account
+
+        Parameters
+        ----------
+
+        account_id : str
+            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        Account
+            An account.
+        """
+        path = self._interpolate_path("/accounts/%s", account_id)
+        return self._make_request("DELETE", path, None, **options)
+
+    def get_account_acquisition(self, account_id, **options):
+        """Fetch an account's acquisition data
+
+        Parameters
+        ----------
+
+        account_id : str
+            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        AccountAcquisition
+            An account's acquisition data.
+        """
+        path = self._interpolate_path("/accounts/%s/acquisition", account_id)
+        return self._make_request("GET", path, None, **options)
+
+    def update_account_acquisition(self, account_id, body, **options):
+        """Update an account's acquisition data
+
+        Parameters
+        ----------
+
+        account_id : str
+            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+        body : dict
+            The request body. It should follow the schema of AccountAcquisitionUpdatable.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        AccountAcquisition
+            An account's updated acquisition data.
+        """
+        path = self._interpolate_path("/accounts/%s/acquisition", account_id)
+        return self._make_request("PUT", path, body, **options)
+
+    def remove_account_acquisition(self, account_id, **options):
+        """Remove an account's acquisition data
+
+        Parameters
+        ----------
+
+        account_id : str
+            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        Empty
+            Acquisition data was succesfully deleted.
+        """
+        path = self._interpolate_path("/accounts/%s/acquisition", account_id)
+        return self._make_request("DELETE", path, None, **options)
+
+    def reactivate_account(self, account_id, **options):
+        """Reactivate an inactive account
+
+        Parameters
+        ----------
+
+        account_id : str
+            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        Account
+            An account.
+        """
+        path = self._interpolate_path("/accounts/%s/reactivate", account_id)
+        return self._make_request("PUT", path, None, **options)
+
+    def get_account_balance(self, account_id, **options):
+        """Fetch an account's balance and past due status
+
+        Parameters
+        ----------
+
+        account_id : str
+            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        AccountBalance
+            An account's balance.
+        """
+        path = self._interpolate_path("/accounts/%s/balance", account_id)
+        return self._make_request("GET", path, None, **options)
+
+    def get_billing_info(self, account_id, **options):
+        """Fetch an account's billing information
+
+        Parameters
+        ----------
+
+        account_id : str
+            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        BillingInfo
+            An account's billing information.
+        """
+        path = self._interpolate_path("/accounts/%s/billing_info", account_id)
+        return self._make_request("GET", path, None, **options)
+
+    def update_billing_info(self, account_id, body, **options):
+        """Set an account's billing information
+
+        Parameters
+        ----------
+
+        account_id : str
+            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+        body : dict
+            The request body. It should follow the schema of BillingInfoCreate.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        BillingInfo
+            Updated billing information.
+        """
+        path = self._interpolate_path("/accounts/%s/billing_info", account_id)
+        return self._make_request("PUT", path, body, **options)
+
+    def remove_billing_info(self, account_id, **options):
+        """Remove an account's billing information
+
+        Parameters
+        ----------
+
+        account_id : str
+            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        Empty
+            Billing information deleted
+        """
+        path = self._interpolate_path("/accounts/%s/billing_info", account_id)
+        return self._make_request("DELETE", path, None, **options)
+
+    def list_account_coupon_redemptions(self, account_id, **options):
+        """Show the coupon redemptions for an account
+
+        Parameters
+        ----------
+
+        account_id : str
+            Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -349,128 +452,163 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 
         Returns
         -------
+
         Pager
             A list of the the coupon redemptions on an account.
         """
         path = self._interpolate_path("/accounts/%s/coupon_redemptions", account_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def get_active_coupon_redemption(self, account_id):
+    def get_active_coupon_redemption(self, account_id, **options):
         """Show the coupon redemption that is active on an account
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         CouponRedemption
             An active coupon redemption on an account.
         """
         path = self._interpolate_path(
             "/accounts/%s/coupon_redemptions/active", account_id
         )
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def create_coupon_redemption(self, account_id, body):
+    def create_coupon_redemption(self, account_id, body, **options):
         """Generate an active coupon redemption on an account
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of CouponRedemptionCreate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         CouponRedemption
             Returns the new coupon redemption.
         """
         path = self._interpolate_path(
             "/accounts/%s/coupon_redemptions/active", account_id
         )
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def remove_coupon_redemption(self, account_id):
+    def remove_coupon_redemption(self, account_id, **options):
         """Delete the active coupon redemption from an account
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         CouponRedemption
             Coupon redemption deleted.
         """
         path = self._interpolate_path(
             "/accounts/%s/coupon_redemptions/active", account_id
         )
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None, **options)
 
-    def list_account_credit_payments(self, account_id, **kwargs):
+    def list_account_credit_payments(self, account_id, **options):
         """List an account's credit payments
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
 
         Keyword Arguments
-        =================
-        limit : int
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 
         Returns
         -------
+
         Pager
             A list of the account's credit payments.
         """
         path = self._interpolate_path("/accounts/%s/credit_payments", account_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def list_account_invoices(self, account_id, **kwargs):
+    def list_account_invoices(self, account_id, **options):
         """List an account's invoices
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -482,21 +620,21 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        type : str
+        params.type : str
             Filter by type when:
             - `type=charge`, only charge invoices will be returned.
             - `type=credit`, only credit invoices will be returned.
@@ -505,61 +643,82 @@ class Client(BaseClient):
 
         Returns
         -------
+
         Pager
             A list of the account's invoices.
         """
         path = self._interpolate_path("/accounts/%s/invoices", account_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def create_invoice(self, account_id, body):
+    def create_invoice(self, account_id, body, **options):
         """Create an invoice for pending line items
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of InvoiceCreate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         InvoiceCollection
             Returns the new invoices.
         """
         path = self._interpolate_path("/accounts/%s/invoices", account_id)
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def preview_invoice(self, account_id, body):
+    def preview_invoice(self, account_id, body, **options):
         """Preview new invoice for pending line items
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of InvoiceCreate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         InvoiceCollection
             Returns the invoice previews.
         """
         path = self._interpolate_path("/accounts/%s/invoices/preview", account_id)
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def list_account_line_items(self, account_id, **kwargs):
+    def list_account_line_items(self, account_id, **options):
         """List an account's line items
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -571,65 +730,79 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        original : str
+        params.original : str
             Filter by original field.
-        state : str
+        params.state : str
             Filter by state field.
-        type : str
+        params.type : str
             Filter by type field.
 
         Returns
         -------
+
         Pager
             A list of the account's line items.
         """
         path = self._interpolate_path("/accounts/%s/line_items", account_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def create_line_item(self, account_id, body):
+    def create_line_item(self, account_id, body, **options):
         """Create a new line item for the account
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of LineItemCreate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         LineItem
             Returns the new line item.
         """
         path = self._interpolate_path("/accounts/%s/line_items", account_id)
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def list_account_notes(self, account_id, **kwargs):
+    def list_account_notes(self, account_id, **options):
         """Fetch a list of an account's notes
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -644,44 +817,58 @@ class Client(BaseClient):
 
         Returns
         -------
+
         Pager
             A list of an account's notes.
         """
         path = self._interpolate_path("/accounts/%s/notes", account_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def get_account_note(self, account_id, account_note_id):
+    def get_account_note(self, account_id, account_note_id, **options):
         """Fetch an account note
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
         account_note_id : str
             Account Note ID.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         AccountNote
             An account note.
         """
         path = self._interpolate_path(
             "/accounts/%s/notes/%s", account_id, account_note_id
         )
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def list_shipping_addresses(self, account_id, **kwargs):
+    def list_shipping_addresses(self, account_id, **options):
         """Fetch a list of an account's shipping addresses
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -693,124 +880,159 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 
         Returns
         -------
+
         Pager
             A list of an account's shipping addresses.
         """
         path = self._interpolate_path("/accounts/%s/shipping_addresses", account_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def create_shipping_address(self, account_id, body):
+    def create_shipping_address(self, account_id, body, **options):
         """Create a new shipping address for the account
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of ShippingAddressCreate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         ShippingAddress
             Returns the new shipping address.
         """
         path = self._interpolate_path("/accounts/%s/shipping_addresses", account_id)
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def get_shipping_address(self, account_id, shipping_address_id):
+    def get_shipping_address(self, account_id, shipping_address_id, **options):
         """Fetch an account's shipping address
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
         shipping_address_id : str
             Shipping Address ID.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         ShippingAddress
             A shipping address.
         """
         path = self._interpolate_path(
             "/accounts/%s/shipping_addresses/%s", account_id, shipping_address_id
         )
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def update_shipping_address(self, account_id, shipping_address_id, body):
+    def update_shipping_address(self, account_id, shipping_address_id, body, **options):
         """Update an account's shipping address
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
         shipping_address_id : str
             Shipping Address ID.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of ShippingAddressUpdate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         ShippingAddress
             The updated shipping address.
         """
         path = self._interpolate_path(
             "/accounts/%s/shipping_addresses/%s", account_id, shipping_address_id
         )
-        return self._make_request("PUT", path, body, None)
+        return self._make_request("PUT", path, body, **options)
 
-    def remove_shipping_address(self, account_id, shipping_address_id):
+    def remove_shipping_address(self, account_id, shipping_address_id, **options):
         """Remove an account's shipping address
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
         shipping_address_id : str
             Shipping Address ID.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Empty
             Shipping address deleted.
         """
         path = self._interpolate_path(
             "/accounts/%s/shipping_addresses/%s", account_id, shipping_address_id
         )
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None, **options)
 
-    def list_account_subscriptions(self, account_id, **kwargs):
+    def list_account_subscriptions(self, account_id, **options):
         """List an account's subscriptions
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -822,21 +1044,21 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        state : str
+        params.state : str
             Filter by state.
 
             - When `state=active`, `state=canceled`, `state=expired`, or `state=future`, subscriptions with states that match the query and only those subscriptions will be returned.
@@ -845,23 +1067,30 @@ class Client(BaseClient):
 
         Returns
         -------
+
         Pager
             A list of the account's subscriptions.
         """
         path = self._interpolate_path("/accounts/%s/subscriptions", account_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def list_account_transactions(self, account_id, **kwargs):
+    def list_account_transactions(self, account_id, **options):
         """List an account's transactions
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -873,44 +1102,51 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        type : str
+        params.type : str
             Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
-        success : str
+        params.success : str
             Filter by success field.
 
         Returns
         -------
+
         Pager
             A list of the account's transactions.
         """
         path = self._interpolate_path("/accounts/%s/transactions", account_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def list_child_accounts(self, account_id, **kwargs):
+    def list_child_accounts(self, account_id, **options):
         """List an account's child accounts
 
         Parameters
         ----------
+
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -922,45 +1158,48 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        email : str
+        params.email : str
             Filter for accounts with this exact email address. A blank value will return accounts with both `null` and `""` email addresses. Note that multiple accounts can share one email address.
-        subscriber : bool
+        params.subscriber : bool
             Filter for accounts with or without a subscription in the `active`,
             `canceled`, or `future` state.
-        past_due : str
+        params.past_due : str
             Filter for accounts with an invoice in the `past_due` state.
 
         Returns
         -------
+
         Pager
             A list of an account's child accounts.
         """
         path = self._interpolate_path("/accounts/%s/accounts", account_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def list_account_acquisition(self, **kwargs):
+    def list_account_acquisition(self, **options):
         """List a site's account acquisition data
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -972,38 +1211,41 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 
         Returns
         -------
+
         Pager
             A list of the site's account acquisition data.
         """
         path = self._interpolate_path("/acquisitions")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def list_coupons(self, **kwargs):
+    def list_coupons(self, **options):
         """List a site's coupons
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -1015,110 +1257,145 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 
         Returns
         -------
+
         Pager
             A list of the site's coupons.
         """
         path = self._interpolate_path("/coupons")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def create_coupon(self, body):
+    def create_coupon(self, body, **options):
         """Create a new coupon
 
         Parameters
         ----------
-        body
-            The body of the request.
 
+        body : dict
+            The request body. It should follow the schema of CouponCreate.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Coupon
             A new coupon.
         """
         path = self._interpolate_path("/coupons")
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def get_coupon(self, coupon_id):
+    def get_coupon(self, coupon_id, **options):
         """Fetch a coupon
 
         Parameters
         ----------
+
         coupon_id : str
             Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Coupon
             A coupon.
         """
         path = self._interpolate_path("/coupons/%s", coupon_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def update_coupon(self, coupon_id, body):
+    def update_coupon(self, coupon_id, body, **options):
         """Update an active coupon
 
         Parameters
         ----------
+
         coupon_id : str
             Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of CouponUpdate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Coupon
             The updated coupon.
         """
         path = self._interpolate_path("/coupons/%s", coupon_id)
-        return self._make_request("PUT", path, body, None)
+        return self._make_request("PUT", path, body, **options)
 
-    def deactivate_coupon(self, coupon_id):
+    def deactivate_coupon(self, coupon_id, **options):
         """Expire a coupon
 
         Parameters
         ----------
+
         coupon_id : str
             Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Coupon
             The expired Coupon
         """
         path = self._interpolate_path("/coupons/%s", coupon_id)
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None, **options)
 
-    def list_unique_coupon_codes(self, coupon_id, **kwargs):
+    def list_unique_coupon_codes(self, coupon_id, **options):
         """List unique coupon codes associated with a bulk coupon
 
         Parameters
         ----------
+
         coupon_id : str
             Coupon ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-10off`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -1130,86 +1407,99 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 
         Returns
         -------
+
         Pager
             A list of unique coupon codes that were generated
         """
         path = self._interpolate_path("/coupons/%s/unique_coupon_codes", coupon_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def list_credit_payments(self, **kwargs):
+    def list_credit_payments(self, **options):
         """List a site's credit payments
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        limit : int
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 
         Returns
         -------
+
         Pager
             A list of the site's credit payments.
         """
         path = self._interpolate_path("/credit_payments")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def get_credit_payment(self, credit_payment_id):
+    def get_credit_payment(self, credit_payment_id, **options):
         """Fetch a credit payment
 
         Parameters
         ----------
+
         credit_payment_id : str
             Credit Payment ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         CreditPayment
             A credit payment.
         """
         path = self._interpolate_path("/credit_payments/%s", credit_payment_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def list_custom_field_definitions(self, **kwargs):
+    def list_custom_field_definitions(self, **options):
         """List a site's custom field definitions
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -1221,59 +1511,69 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        related_type : str
+        params.related_type : str
             Filter by related type.
 
         Returns
         -------
+
         Pager
             A list of the site's custom field definitions.
         """
         path = self._interpolate_path("/custom_field_definitions")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def get_custom_field_definition(self, custom_field_definition_id):
+    def get_custom_field_definition(self, custom_field_definition_id, **options):
         """Fetch an custom field definition
 
         Parameters
         ----------
+
         custom_field_definition_id : str
             Custom Field Definition ID
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         CustomFieldDefinition
             An custom field definition.
         """
         path = self._interpolate_path(
             "/custom_field_definitions/%s", custom_field_definition_id
         )
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def list_items(self, **kwargs):
+    def list_items(self, **options):
         """List a site's items
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -1285,127 +1585,165 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        state : str
+        params.state : str
             Filter by state.
 
         Returns
         -------
+
         Pager
             A list of the site's items.
         """
         path = self._interpolate_path("/items")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def create_item(self, body):
+    def create_item(self, body, **options):
         """Create a new item
 
         Parameters
         ----------
-        body
-            The body of the request.
 
+        body : dict
+            The request body. It should follow the schema of ItemCreate.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Item
             A new item.
         """
         path = self._interpolate_path("/items")
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def get_item(self, item_id):
+    def get_item(self, item_id, **options):
         """Fetch an item
 
         Parameters
         ----------
+
         item_id : str
             Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Item
             An item.
         """
         path = self._interpolate_path("/items/%s", item_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def update_item(self, item_id, body):
+    def update_item(self, item_id, body, **options):
         """Update an active item
 
         Parameters
         ----------
+
         item_id : str
             Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of ItemUpdate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Item
             The updated item.
         """
         path = self._interpolate_path("/items/%s", item_id)
-        return self._make_request("PUT", path, body, None)
+        return self._make_request("PUT", path, body, **options)
 
-    def deactivate_item(self, item_id):
+    def deactivate_item(self, item_id, **options):
         """Deactivate an item
 
         Parameters
         ----------
+
         item_id : str
             Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Item
             An item.
         """
         path = self._interpolate_path("/items/%s", item_id)
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None, **options)
 
-    def reactivate_item(self, item_id):
+    def reactivate_item(self, item_id, **options):
         """Reactivate an inactive item
 
         Parameters
         ----------
+
         item_id : str
             Item ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-red`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Item
             An item.
         """
         path = self._interpolate_path("/items/%s/reactivate", item_id)
-        return self._make_request("PUT", path, None, None)
+        return self._make_request("PUT", path, None, **options)
 
-    def list_measured_unit(self, **kwargs):
+    def list_measured_unit(self, **options):
         """List a site's measured units
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -1417,110 +1755,141 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        state : str
+        params.state : str
             Filter by state.
 
         Returns
         -------
+
         Pager
             A list of the site's measured units.
         """
         path = self._interpolate_path("/measured_units")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def create_measured_unit(self, body):
+    def create_measured_unit(self, body, **options):
         """Create a new measured unit
 
         Parameters
         ----------
-        body
-            The body of the request.
 
+        body : dict
+            The request body. It should follow the schema of MeasuredUnitCreate.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         MeasuredUnit
             A new measured unit.
         """
         path = self._interpolate_path("/measured_units")
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def get_measured_unit(self, measured_unit_id):
+    def get_measured_unit(self, measured_unit_id, **options):
         """Fetch a measured unit
 
         Parameters
         ----------
+
         measured_unit_id : str
             Measured unit ID or name. For ID no prefix is used e.g. `e28zov4fw0v2`. For name use prefix `name-`, e.g. `name-Storage`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         MeasuredUnit
             An item.
         """
         path = self._interpolate_path("/measured_units/%s", measured_unit_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def update_measured_unit(self, measured_unit_id, body):
+    def update_measured_unit(self, measured_unit_id, body, **options):
         """Update a measured unit
 
         Parameters
         ----------
+
         measured_unit_id : str
             Measured unit ID or name. For ID no prefix is used e.g. `e28zov4fw0v2`. For name use prefix `name-`, e.g. `name-Storage`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of MeasuredUnitUpdate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         MeasuredUnit
             The updated measured_unit.
         """
         path = self._interpolate_path("/measured_units/%s", measured_unit_id)
-        return self._make_request("PUT", path, body, None)
+        return self._make_request("PUT", path, body, **options)
 
-    def remove_measured_unit(self, measured_unit_id):
+    def remove_measured_unit(self, measured_unit_id, **options):
         """Remove a measured unit
 
         Parameters
         ----------
+
         measured_unit_id : str
             Measured unit ID or name. For ID no prefix is used e.g. `e28zov4fw0v2`. For name use prefix `name-`, e.g. `name-Storage`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         MeasuredUnit
             A measured unit.
         """
         path = self._interpolate_path("/measured_units/%s", measured_unit_id)
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None, **options)
 
-    def list_invoices(self, **kwargs):
+    def list_invoices(self, **options):
         """List a site's invoices
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -1532,21 +1901,21 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        type : str
+        params.type : str
             Filter by type when:
             - `type=charge`, only charge invoices will be returned.
             - `type=credit`, only credit invoices will be returned.
@@ -1555,185 +1924,255 @@ class Client(BaseClient):
 
         Returns
         -------
+
         Pager
             A list of the site's invoices.
         """
         path = self._interpolate_path("/invoices")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def get_invoice(self, invoice_id):
+    def get_invoice(self, invoice_id, **options):
         """Fetch an invoice
 
         Parameters
         ----------
-        invoice_id : str
-            Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
 
-
-        Returns
-        -------
-        Invoice
-            An invoice.
-        """
-        path = self._interpolate_path("/invoices/%s", invoice_id)
-        return self._make_request("GET", path, None, None)
-
-    def put_invoice(self, invoice_id, body):
-        """Update an invoice
-
-        Parameters
-        ----------
-        invoice_id : str
-            Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-        body
-            The body of the request.
-
-
-        Returns
-        -------
-        Invoice
-            An invoice.
-        """
-        path = self._interpolate_path("/invoices/%s", invoice_id)
-        return self._make_request("PUT", path, body, None)
-
-    def get_invoice_pdf(self, invoice_id):
-        """Fetch an invoice as a PDF
-
-        Parameters
-        ----------
-        invoice_id : str
-            Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-
-
-        Returns
-        -------
-        BinaryFile
-            An invoice as a PDF.
-        """
-        path = self._interpolate_path("/invoices/%s.pdf", invoice_id)
-        return self._make_request("GET", path, None, None)
-
-    def collect_invoice(self, invoice_id, **kwargs):
-        """Collect a pending or past due, automatic invoice
-
-        Parameters
-        ----------
         invoice_id : str
             Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
 
         Keyword Arguments
-        =================
-        body
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        Invoice
+            An invoice.
+        """
+        path = self._interpolate_path("/invoices/%s", invoice_id)
+        return self._make_request("GET", path, None, **options)
+
+    def put_invoice(self, invoice_id, body, **options):
+        """Update an invoice
+
+        Parameters
+        ----------
+
+        invoice_id : str
+            Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+        body : dict
+            The request body. It should follow the schema of InvoiceUpdatable.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        Invoice
+            An invoice.
+        """
+        path = self._interpolate_path("/invoices/%s", invoice_id)
+        return self._make_request("PUT", path, body, **options)
+
+    def get_invoice_pdf(self, invoice_id, **options):
+        """Fetch an invoice as a PDF
+
+        Parameters
+        ----------
+
+        invoice_id : str
+            Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        BinaryFile
+            An invoice as a PDF.
+        """
+        path = self._interpolate_path("/invoices/%s.pdf", invoice_id)
+        return self._make_request("GET", path, None, **options)
+
+    def collect_invoice(self, invoice_id, **options):
+        """Collect a pending or past due, automatic invoice
+
+        Parameters
+        ----------
+
+        invoice_id : str
+            Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.body : InvoiceCollect
             The body of the request.
 
         Returns
         -------
+
         Invoice
             The updated invoice.
         """
         body = kwargs.pop("body", None)
         path = self._interpolate_path("/invoices/%s/collect", invoice_id)
-        return self._make_request("PUT", path, body, kwargs)
+        return self._make_request("PUT", path, body, **options)
 
-    def fail_invoice(self, invoice_id):
+    def fail_invoice(self, invoice_id, **options):
         """Mark an open invoice as failed
 
         Parameters
         ----------
+
         invoice_id : str
             Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Invoice
             The updated invoice.
         """
         path = self._interpolate_path("/invoices/%s/mark_failed", invoice_id)
-        return self._make_request("PUT", path, None, None)
+        return self._make_request("PUT", path, None, **options)
 
-    def mark_invoice_successful(self, invoice_id):
+    def mark_invoice_successful(self, invoice_id, **options):
         """Mark an open invoice as successful
 
         Parameters
         ----------
+
         invoice_id : str
             Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Invoice
             The updated invoice.
         """
         path = self._interpolate_path("/invoices/%s/mark_successful", invoice_id)
-        return self._make_request("PUT", path, None, None)
+        return self._make_request("PUT", path, None, **options)
 
-    def reopen_invoice(self, invoice_id):
+    def reopen_invoice(self, invoice_id, **options):
         """Reopen a closed, manual invoice
 
         Parameters
         ----------
+
         invoice_id : str
             Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Invoice
             The updated invoice.
         """
         path = self._interpolate_path("/invoices/%s/reopen", invoice_id)
-        return self._make_request("PUT", path, None, None)
+        return self._make_request("PUT", path, None, **options)
 
-    def void_invoice(self, invoice_id):
+    def void_invoice(self, invoice_id, **options):
         """Void a credit invoice.
 
         Parameters
         ----------
+
         invoice_id : str
             Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Invoice
             The updated invoice.
         """
         path = self._interpolate_path("/invoices/%s/void", invoice_id)
-        return self._make_request("PUT", path, None, None)
+        return self._make_request("PUT", path, None, **options)
 
-    def record_external_transaction(self, invoice_id, body):
+    def record_external_transaction(self, invoice_id, body, **options):
         """Record an external payment for a manual invoices.
 
         Parameters
         ----------
+
         invoice_id : str
             Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of ExternalTransaction.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Transaction
             The recorded transaction.
         """
         path = self._interpolate_path("/invoices/%s/transactions", invoice_id)
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def list_invoice_line_items(self, invoice_id, **kwargs):
+    def list_invoice_line_items(self, invoice_id, **options):
         """List an invoice's line items
 
         Parameters
         ----------
+
         invoice_id : str
             Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -1745,46 +2184,53 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        original : str
+        params.original : str
             Filter by original field.
-        state : str
+        params.state : str
             Filter by state field.
-        type : str
+        params.type : str
             Filter by type field.
 
         Returns
         -------
+
         Pager
             A list of the invoice's line items.
         """
         path = self._interpolate_path("/invoices/%s/line_items", invoice_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def list_invoice_coupon_redemptions(self, invoice_id, **kwargs):
+    def list_invoice_coupon_redemptions(self, invoice_id, **options):
         """Show the coupon redemptions applied to an invoice
 
         Parameters
         ----------
+
         invoice_id : str
             Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -1796,70 +2242,87 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 
         Returns
         -------
+
         Pager
             A list of the the coupon redemptions associated with the invoice.
         """
         path = self._interpolate_path("/invoices/%s/coupon_redemptions", invoice_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def list_related_invoices(self, invoice_id, **kwargs):
+    def list_related_invoices(self, invoice_id, **options):
         """List an invoice's related credit or charge invoices
 
         Parameters
         ----------
+
         invoice_id : str
             Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Pager
             A list of the credit or charge invoices associated with the invoice.
         """
         path = self._interpolate_path("/invoices/%s/related_invoices", invoice_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def refund_invoice(self, invoice_id, body):
+    def refund_invoice(self, invoice_id, body, **options):
         """Refund an invoice
 
         Parameters
         ----------
+
         invoice_id : str
             Invoice ID or number. For ID no prefix is used e.g. `e28zov4fw0v2`. For number use prefix `number-`, e.g. `number-1000`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of InvoiceRefund.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Invoice
             Returns the new credit invoice.
         """
         path = self._interpolate_path("/invoices/%s/refund", invoice_id)
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def list_line_items(self, **kwargs):
+    def list_line_items(self, **options):
         """List a site's line items
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -1871,78 +2334,95 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        original : str
+        params.original : str
             Filter by original field.
-        state : str
+        params.state : str
             Filter by state field.
-        type : str
+        params.type : str
             Filter by type field.
 
         Returns
         -------
+
         Pager
             A list of the site's line items.
         """
         path = self._interpolate_path("/line_items")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def get_line_item(self, line_item_id):
+    def get_line_item(self, line_item_id, **options):
         """Fetch a line item
 
         Parameters
         ----------
+
         line_item_id : str
             Line Item ID.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         LineItem
             A line item.
         """
         path = self._interpolate_path("/line_items/%s", line_item_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def remove_line_item(self, line_item_id):
+    def remove_line_item(self, line_item_id, **options):
         """Delete an uninvoiced line item
 
         Parameters
         ----------
+
         line_item_id : str
             Line Item ID.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Empty
             Line item deleted.
         """
         path = self._interpolate_path("/line_items/%s", line_item_id)
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None, **options)
 
-    def list_plans(self, **kwargs):
+    def list_plans(self, **options):
         """List a site's plans
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -1954,112 +2434,147 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        state : str
+        params.state : str
             Filter by state.
 
         Returns
         -------
+
         Pager
             A list of plans.
         """
         path = self._interpolate_path("/plans")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def create_plan(self, body):
+    def create_plan(self, body, **options):
         """Create a plan
 
         Parameters
         ----------
-        body
-            The body of the request.
 
+        body : dict
+            The request body. It should follow the schema of PlanCreate.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Plan
             A plan.
         """
         path = self._interpolate_path("/plans")
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def get_plan(self, plan_id):
+    def get_plan(self, plan_id, **options):
         """Fetch a plan
 
         Parameters
         ----------
+
         plan_id : str
             Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Plan
             A plan.
         """
         path = self._interpolate_path("/plans/%s", plan_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def update_plan(self, plan_id, body):
+    def update_plan(self, plan_id, body, **options):
         """Update a plan
 
         Parameters
         ----------
+
         plan_id : str
             Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of PlanUpdate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Plan
             A plan.
         """
         path = self._interpolate_path("/plans/%s", plan_id)
-        return self._make_request("PUT", path, body, None)
+        return self._make_request("PUT", path, body, **options)
 
-    def remove_plan(self, plan_id):
+    def remove_plan(self, plan_id, **options):
         """Remove a plan
 
         Parameters
         ----------
+
         plan_id : str
             Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Plan
             Plan deleted
         """
         path = self._interpolate_path("/plans/%s", plan_id)
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None, **options)
 
-    def list_plan_add_ons(self, plan_id, **kwargs):
+    def list_plan_add_ons(self, plan_id, **options):
         """List a plan's add-ons
 
         Parameters
         ----------
+
         plan_id : str
             Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -2071,118 +2586,149 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        state : str
+        params.state : str
             Filter by state.
 
         Returns
         -------
+
         Pager
             A list of add-ons.
         """
         path = self._interpolate_path("/plans/%s/add_ons", plan_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def create_plan_add_on(self, plan_id, body):
+    def create_plan_add_on(self, plan_id, body, **options):
         """Create an add-on
 
         Parameters
         ----------
+
         plan_id : str
             Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of AddOnCreate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         AddOn
             An add-on.
         """
         path = self._interpolate_path("/plans/%s/add_ons", plan_id)
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def get_plan_add_on(self, plan_id, add_on_id):
+    def get_plan_add_on(self, plan_id, add_on_id, **options):
         """Fetch a plan's add-on
 
         Parameters
         ----------
+
         plan_id : str
             Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
         add_on_id : str
             Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         AddOn
             An add-on.
         """
         path = self._interpolate_path("/plans/%s/add_ons/%s", plan_id, add_on_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def update_plan_add_on(self, plan_id, add_on_id, body):
+    def update_plan_add_on(self, plan_id, add_on_id, body, **options):
         """Update an add-on
 
         Parameters
         ----------
+
         plan_id : str
             Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
         add_on_id : str
             Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of AddOnUpdate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         AddOn
             An add-on.
         """
         path = self._interpolate_path("/plans/%s/add_ons/%s", plan_id, add_on_id)
-        return self._make_request("PUT", path, body, None)
+        return self._make_request("PUT", path, body, **options)
 
-    def remove_plan_add_on(self, plan_id, add_on_id):
+    def remove_plan_add_on(self, plan_id, add_on_id, **options):
         """Remove an add-on
 
         Parameters
         ----------
+
         plan_id : str
             Plan ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
         add_on_id : str
             Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         AddOn
             Add-on deleted
         """
         path = self._interpolate_path("/plans/%s/add_ons/%s", plan_id, add_on_id)
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None, **options)
 
-    def list_add_ons(self, **kwargs):
+    def list_add_ons(self, **options):
         """List a site's add-ons
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -2194,57 +2740,67 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        state : str
+        params.state : str
             Filter by state.
 
         Returns
         -------
+
         Pager
             A list of add-ons.
         """
         path = self._interpolate_path("/add_ons")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def get_add_on(self, add_on_id):
+    def get_add_on(self, add_on_id, **options):
         """Fetch an add-on
 
         Parameters
         ----------
+
         add_on_id : str
             Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         AddOn
             An add-on.
         """
         path = self._interpolate_path("/add_ons/%s", add_on_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def list_shipping_methods(self, **kwargs):
+    def list_shipping_methods(self, **options):
         """List a site's shipping methods
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -2256,108 +2812,139 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 
         Returns
         -------
+
         Pager
             A list of the site's shipping methods.
         """
         path = self._interpolate_path("/shipping_methods")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def create_shipping_method(self, body):
+    def create_shipping_method(self, body, **options):
         """Create a new shipping method
 
         Parameters
         ----------
-        body
-            The body of the request.
 
+        body : dict
+            The request body. It should follow the schema of ShippingMethodCreate.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         ShippingMethod
             A new shipping method.
         """
         path = self._interpolate_path("/shipping_methods")
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def get_shipping_method(self, shipping_method_id):
+    def get_shipping_method(self, shipping_method_id, **options):
         """Fetch a shipping method
 
         Parameters
         ----------
+
         shipping_method_id : str
             Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         ShippingMethod
             A shipping method.
         """
         path = self._interpolate_path("/shipping_methods/%s", shipping_method_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def update_shipping_method(self, shipping_method_id, body):
+    def update_shipping_method(self, shipping_method_id, body, **options):
         """Update an active Shipping Method
 
         Parameters
         ----------
+
         shipping_method_id : str
             Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of ShippingMethodUpdate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         ShippingMethod
             The updated shipping method.
         """
         path = self._interpolate_path("/shipping_methods/%s", shipping_method_id)
-        return self._make_request("PUT", path, body, None)
+        return self._make_request("PUT", path, body, **options)
 
-    def deactivate_shipping_method(self, shipping_method_id):
+    def deactivate_shipping_method(self, shipping_method_id, **options):
         """Deactivate a shipping method
 
         Parameters
         ----------
+
         shipping_method_id : str
             Shipping Method ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-usps_2-day`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         ShippingMethod
             A shipping method.
         """
         path = self._interpolate_path("/shipping_methods/%s", shipping_method_id)
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None, **options)
 
-    def list_subscriptions(self, **kwargs):
+    def list_subscriptions(self, **options):
         """List a site's subscriptions
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -2369,21 +2956,21 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        state : str
+        params.state : str
             Filter by state.
 
             - When `state=active`, `state=canceled`, `state=expired`, or `state=future`, subscriptions with states that match the query and only those subscriptions will be returned.
@@ -2392,76 +2979,104 @@ class Client(BaseClient):
 
         Returns
         -------
+
         Pager
             A list of the site's subscriptions.
         """
         path = self._interpolate_path("/subscriptions")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def create_subscription(self, body):
+    def create_subscription(self, body, **options):
         """Create a new subscription
 
         Parameters
         ----------
-        body
-            The body of the request.
 
+        body : dict
+            The request body. It should follow the schema of SubscriptionCreate.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Subscription
             A subscription.
         """
         path = self._interpolate_path("/subscriptions")
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def get_subscription(self, subscription_id):
+    def get_subscription(self, subscription_id, **options):
         """Fetch a subscription
 
         Parameters
         ----------
-        subscription_id : str
-            Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
-
-        Returns
-        -------
-        Subscription
-            A subscription.
-        """
-        path = self._interpolate_path("/subscriptions/%s", subscription_id)
-        return self._make_request("GET", path, None, None)
-
-    def modify_subscription(self, subscription_id, body):
-        """Modify a subscription
-
-        Parameters
-        ----------
-        subscription_id : str
-            Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-        body
-            The body of the request.
-
-
-        Returns
-        -------
-        Subscription
-            A subscription.
-        """
-        path = self._interpolate_path("/subscriptions/%s", subscription_id)
-        return self._make_request("PUT", path, body, None)
-
-    def terminate_subscription(self, subscription_id, **kwargs):
-        """Terminate a subscription
-
-        Parameters
-        ----------
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
         Keyword Arguments
-        =================
-        refund : str
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        Subscription
+            A subscription.
+        """
+        path = self._interpolate_path("/subscriptions/%s", subscription_id)
+        return self._make_request("GET", path, None, **options)
+
+    def modify_subscription(self, subscription_id, body, **options):
+        """Modify a subscription
+
+        Parameters
+        ----------
+
+        subscription_id : str
+            Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+        body : dict
+            The request body. It should follow the schema of SubscriptionUpdate.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+
+        Returns
+        -------
+
+        Subscription
+            A subscription.
+        """
+        path = self._interpolate_path("/subscriptions/%s", subscription_id)
+        return self._make_request("PUT", path, body, **options)
+
+    def terminate_subscription(self, subscription_id, **options):
+        """Terminate a subscription
+
+        Parameters
+        ----------
+
+        subscription_id : str
+            Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.refund : str
             The type of refund to perform:
 
             * `full` - Performs a full refund of the last invoice for the current subscription term.
@@ -2474,191 +3089,261 @@ class Client(BaseClient):
 
         Returns
         -------
+
         Subscription
             An expired subscription.
         """
         path = self._interpolate_path("/subscriptions/%s", subscription_id)
-        return self._make_request("DELETE", path, None, kwargs)
+        return self._make_request("DELETE", path, None, **options)
 
-    def cancel_subscription(self, subscription_id, **kwargs):
+    def cancel_subscription(self, subscription_id, **options):
         """Cancel a subscription
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
         Keyword Arguments
-        =================
-        body
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.body : SubscriptionCancel
             The body of the request.
 
         Returns
         -------
+
         Subscription
             A canceled or failed subscription.
         """
         body = kwargs.pop("body", None)
         path = self._interpolate_path("/subscriptions/%s/cancel", subscription_id)
-        return self._make_request("PUT", path, body, kwargs)
+        return self._make_request("PUT", path, body, **options)
 
-    def reactivate_subscription(self, subscription_id):
+    def reactivate_subscription(self, subscription_id, **options):
         """Reactivate a canceled subscription
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Subscription
             An active subscription.
         """
         path = self._interpolate_path("/subscriptions/%s/reactivate", subscription_id)
-        return self._make_request("PUT", path, None, None)
+        return self._make_request("PUT", path, None, **options)
 
-    def pause_subscription(self, subscription_id, body):
+    def pause_subscription(self, subscription_id, body, **options):
         """Pause subscription
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of SubscriptionPause.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Subscription
             A subscription.
         """
         path = self._interpolate_path("/subscriptions/%s/pause", subscription_id)
-        return self._make_request("PUT", path, body, None)
+        return self._make_request("PUT", path, body, **options)
 
-    def resume_subscription(self, subscription_id):
+    def resume_subscription(self, subscription_id, **options):
         """Resume subscription
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Subscription
             A subscription.
         """
         path = self._interpolate_path("/subscriptions/%s/resume", subscription_id)
-        return self._make_request("PUT", path, None, None)
+        return self._make_request("PUT", path, None, **options)
 
-    def convert_trial(self, subscription_id):
+    def convert_trial(self, subscription_id, **options):
         """Convert trial subscription
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Subscription
             A subscription.
         """
         path = self._interpolate_path(
             "/subscriptions/%s/convert_trial", subscription_id
         )
-        return self._make_request("PUT", path, None, None)
+        return self._make_request("PUT", path, None, **options)
 
-    def get_subscription_change(self, subscription_id):
+    def get_subscription_change(self, subscription_id, **options):
         """Fetch a subscription's pending change
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         SubscriptionChange
             A subscription's pending change.
         """
         path = self._interpolate_path("/subscriptions/%s/change", subscription_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def create_subscription_change(self, subscription_id, body):
+    def create_subscription_change(self, subscription_id, body, **options):
         """Create a new subscription change
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of SubscriptionChangeCreate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         SubscriptionChange
             A subscription change.
         """
         path = self._interpolate_path("/subscriptions/%s/change", subscription_id)
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def remove_subscription_change(self, subscription_id):
+    def remove_subscription_change(self, subscription_id, **options):
         """Delete the pending subscription change
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Empty
             Subscription change was deleted.
         """
         path = self._interpolate_path("/subscriptions/%s/change", subscription_id)
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None, **options)
 
-    def preview_subscription_change(self, subscription_id, body):
+    def preview_subscription_change(self, subscription_id, body, **options):
         """Preview a new subscription change
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of SubscriptionChangeCreate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         SubscriptionChange
             A subscription change.
         """
         path = self._interpolate_path(
             "/subscriptions/%s/change/preview", subscription_id
         )
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def list_subscription_invoices(self, subscription_id, **kwargs):
+    def list_subscription_invoices(self, subscription_id, **options):
         """List a subscription's invoices
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -2670,21 +3355,21 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        type : str
+        params.type : str
             Filter by type when:
             - `type=charge`, only charge invoices will be returned.
             - `type=credit`, only credit invoices will be returned.
@@ -2693,23 +3378,30 @@ class Client(BaseClient):
 
         Returns
         -------
+
         Pager
             A list of the subscription's invoices.
         """
         path = self._interpolate_path("/subscriptions/%s/invoices", subscription_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def list_subscription_line_items(self, subscription_id, **kwargs):
+    def list_subscription_line_items(self, subscription_id, **options):
         """List a subscription's line items
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -2721,46 +3413,53 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        original : str
+        params.original : str
             Filter by original field.
-        state : str
+        params.state : str
             Filter by state field.
-        type : str
+        params.type : str
             Filter by type field.
 
         Returns
         -------
+
         Pager
             A list of the subscription's line items.
         """
         path = self._interpolate_path("/subscriptions/%s/line_items", subscription_id)
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def list_subscription_coupon_redemptions(self, subscription_id, **kwargs):
+    def list_subscription_coupon_redemptions(self, subscription_id, **options):
         """Show the coupon redemptions for a subscription
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -2772,40 +3471,47 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
 
         Returns
         -------
+
         Pager
             A list of the the coupon redemptions on a subscription.
         """
         path = self._interpolate_path(
             "/subscriptions/%s/coupon_redemptions", subscription_id
         )
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def list_usage(self, subscription_id, add_on_id, **kwargs):
+    def list_usage(self, subscription_id, add_on_id, **options):
         """List a subscription add-on's usage records
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
         add_on_id : str
             Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
 
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -2817,118 +3523,149 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `usage_timestamp` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=usage_timestamp` or `sort=recorded_timestamp`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=usage_timestamp` or `sort=recorded_timestamp`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        billing_status : str
+        params.billing_status : str
             Filter by usage record's billing status
 
         Returns
         -------
+
         Pager
             A list of the subscription add-on's usage records.
         """
         path = self._interpolate_path(
             "/subscriptions/%s/add_ons/%s/usage", subscription_id, add_on_id
         )
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def create_usage(self, subscription_id, add_on_id, body):
+    def create_usage(self, subscription_id, add_on_id, body, **options):
         """Log a usage record on this subscription add-on
 
         Parameters
         ----------
+
         subscription_id : str
             Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
         add_on_id : str
             Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of UsageCreate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Usage
             The created usage record.
         """
         path = self._interpolate_path(
             "/subscriptions/%s/add_ons/%s/usage", subscription_id, add_on_id
         )
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def get_usage(self, usage_id):
+    def get_usage(self, usage_id, **options):
         """Get a usage record
 
         Parameters
         ----------
+
         usage_id : str
             Usage Record ID.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Usage
             The usage record.
         """
         path = self._interpolate_path("/usage/%s", usage_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def update_usage(self, usage_id, body):
+    def update_usage(self, usage_id, body, **options):
         """Update a usage record
 
         Parameters
         ----------
+
         usage_id : str
             Usage Record ID.
-        body
-            The body of the request.
+        body : dict
+            The request body. It should follow the schema of UsageCreate.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Usage
             The updated usage record.
         """
         path = self._interpolate_path("/usage/%s", usage_id)
-        return self._make_request("PUT", path, body, None)
+        return self._make_request("PUT", path, body, **options)
 
-    def remove_usage(self, usage_id):
+    def remove_usage(self, usage_id, **options):
         """Delete a usage record.
 
         Parameters
         ----------
+
         usage_id : str
             Usage Record ID.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Empty
             Usage was successfully deleted.
         """
         path = self._interpolate_path("/usage/%s", usage_id)
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None, **options)
 
-    def list_transactions(self, **kwargs):
+    def list_transactions(self, **options):
         """List a site's transactions
 
-        Parameters
-        ----------
-
         Keyword Arguments
-        =================
-        ids : :obj:`list` of :obj:`str`
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
+        params : dict
+            Query Parameters.
+        params.ids : :obj:`list` of :obj:`str`
             Filter results by their IDs. Up to 200 IDs can be passed at once using
             commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.
 
@@ -2940,133 +3677,176 @@ class Client(BaseClient):
               results correspond to your request.
             * Records are returned in an arbitrary order. Since results are all
               returned at once you can sort the records yourself.
-        limit : int
+        params.limit : int
             Limit number of records 1-200.
-        order : str
+        params.order : str
             Sort order.
-        sort : str
+        params.sort : str
             Sort field. You *really* only want to sort by `updated_at` in ascending
             order. In descending order updated records will move behind the cursor and could
             prevent some records from being returned.
-        begin_time : datetime
+        params.begin_time : datetime
             Inclusively filter by begin_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        end_time : datetime
+        params.end_time : datetime
             Inclusively filter by end_time when `sort=created_at` or `sort=updated_at`.
             **Note:** this value is an ISO8601 timestamp. A partial timestamp that does not include a time zone will default to UTC.
-        type : str
+        params.type : str
             Filter by type field. The value `payment` will return both `purchase` and `capture` transactions.
-        success : str
+        params.success : str
             Filter by success field.
 
         Returns
         -------
+
         Pager
             A list of the site's transactions.
         """
         path = self._interpolate_path("/transactions")
-        return Pager(self, path, kwargs)
+        return Pager(self, path, **options)
 
-    def get_transaction(self, transaction_id):
+    def get_transaction(self, transaction_id, **options):
         """Fetch a transaction
 
         Parameters
         ----------
+
         transaction_id : str
             Transaction ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         Transaction
             A transaction.
         """
         path = self._interpolate_path("/transactions/%s", transaction_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def get_unique_coupon_code(self, unique_coupon_code_id):
+    def get_unique_coupon_code(self, unique_coupon_code_id, **options):
         """Fetch a unique coupon code
 
         Parameters
         ----------
+
         unique_coupon_code_id : str
             Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         UniqueCouponCode
             A unique coupon code.
         """
         path = self._interpolate_path("/unique_coupon_codes/%s", unique_coupon_code_id)
-        return self._make_request("GET", path, None, None)
+        return self._make_request("GET", path, None, **options)
 
-    def deactivate_unique_coupon_code(self, unique_coupon_code_id):
+    def deactivate_unique_coupon_code(self, unique_coupon_code_id, **options):
         """Deactivate a unique coupon code
 
         Parameters
         ----------
+
         unique_coupon_code_id : str
             Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         UniqueCouponCode
             A unique coupon code.
         """
         path = self._interpolate_path("/unique_coupon_codes/%s", unique_coupon_code_id)
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None, **options)
 
-    def reactivate_unique_coupon_code(self, unique_coupon_code_id):
+    def reactivate_unique_coupon_code(self, unique_coupon_code_id, **options):
         """Restore a unique coupon code
 
         Parameters
         ----------
+
         unique_coupon_code_id : str
             Unique Coupon Code ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-abc-8dh2-def`.
 
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         UniqueCouponCode
             A unique coupon code.
         """
         path = self._interpolate_path(
             "/unique_coupon_codes/%s/restore", unique_coupon_code_id
         )
-        return self._make_request("PUT", path, None, None)
+        return self._make_request("PUT", path, None, **options)
 
-    def create_purchase(self, body):
+    def create_purchase(self, body, **options):
         """Create a new purchase
 
         Parameters
         ----------
-        body
-            The body of the request.
 
+        body : dict
+            The request body. It should follow the schema of PurchaseCreate.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         InvoiceCollection
             Returns the new invoices
         """
         path = self._interpolate_path("/purchases")
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)
 
-    def preview_purchase(self, body):
+    def preview_purchase(self, body, **options):
         """Preview a new purchase
 
         Parameters
         ----------
-        body
-            The body of the request.
 
+        body : dict
+            The request body. It should follow the schema of PurchaseCreate.
+
+        Keyword Arguments
+        -----------------
+
+        headers : dict
+            Extra HTTP headers to send with the request.
 
         Returns
         -------
+
         InvoiceCollection
             Returns preview of the new invoices
         """
         path = self._interpolate_path("/purchases/preview")
-        return self._make_request("POST", path, body, None)
+        return self._make_request("POST", path, body, **options)

--- a/tests/mock_client.py
+++ b/tests/mock_client.py
@@ -6,18 +6,18 @@ class MockClient(BaseClient):
     def api_version(self):
         return "v2018-08-09"
 
-    def list_resources(self, params={}):
+    def list_resources(self, **options):
         path = "/resources"
-        return Pager(self, path, params)
+        return Pager(self, path, **options)
 
-    def get_resource(self, resource_id, params={}):
+    def get_resource(self, resource_id, **options):
         path = self._interpolate_path("/resources/%s", resource_id)
-        return self._make_request("GET", path, None, params)
+        return self._make_request("GET", path, None, **options)
 
     def update_resource(self, resource_id, body):
         path = self._interpolate_path("/resources/%s", resource_id)
-        return self._make_request("PUT", path, body, None)
+        return self._make_request("PUT", path, body)
 
     def delete_resource(self, resource_id):
         path = self._interpolate_path("/resources/%s", resource_id)
-        return self._make_request("DELETE", path, None, None)
+        return self._make_request("DELETE", path, None)

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -149,7 +149,7 @@ class TestBaseClient(unittest.TestCase):
         request = MagicMock(return_value=None)
         with get_resource_client(True, request) as conn:
             client = MockClient("apikey")
-            resource = client.get_resource("123", {"q": 123})
+            resource = client.get_resource("123", params={"q": 123})
             request.assert_called_with(
                 "GET", "/resources/123?q=123", None, headers=expected_headers
             )
@@ -234,7 +234,7 @@ class TestBaseClient(unittest.TestCase):
                 client = MockClient("apikey")
                 d = datetime(2020, 10, 5)
                 params = {"q": 123, "d": d, "c": False, "b": True}
-                resource = client.get_resource("123", params)
+                resource = client.get_resource("123", params=params)
                 url = "/resources/123?q=123&d=2020-10-05T00%3A00%3A00&c=false&b=true"
 
                 request.assert_called_with("GET", url, None, headers=expected_headers)

--- a/tests/test_pager.py
+++ b/tests/test_pager.py
@@ -138,36 +138,36 @@ class TestPager(unittest.TestCase):
         with get_pager_first_item_client() as conn:
             client = MockClient("apikey")
             client._make_request = MagicMock()
-            pager = Pager(client, "/resources", {"limit": 3})
+            pager = Pager(client, "/resources", params={"limit": 3})
             pager.first()
             client._make_request.assert_called_with(
-                "GET", "/resources", None, {"limit": 1}
+                "GET", "/resources", None, params={"limit": 1}
             )
 
     def test_take(self):
         with get_pager_first_item_client() as conn:
             client = MockClient("apikey")
             client._make_request = MagicMock()
-            pager = Pager(client, "/resources", {"limit": 10})
+            pager = Pager(client, "/resources", params={"limit": 10})
             pager.take(3)
             client._make_request.assert_called_with(
-                "GET", "/resources", None, {"limit": 3}
+                "GET", "/resources", None, params={"limit": 3}
             )
 
     def test_count(self):
         with get_pager_count_client() as conn:
             client = MockClient("apikey")
             client._make_request = MagicMock()
-            pager = Pager(client, "/resources", {"limit": 3})
+            pager = Pager(client, "/resources", params={"limit": 3})
             pager.count()
             client._make_request.assert_called_with(
-                "HEAD", "/resources", None, {"limit": 3}
+                "HEAD", "/resources", None, params={"limit": 3}
             )
 
     def test_items(self):
         with get_pager_client() as conn:
             client = MockClient("apikey")
-            pager = Pager(client, "/resources", {})
+            pager = Pager(client, "/resources")
             item_count = 0
             for item in pager.items():
                 self.assertEqual(type(item), MyResource)
@@ -178,7 +178,7 @@ class TestPager(unittest.TestCase):
     def test_pages(self):
         with get_pager_client() as conn:
             client = MockClient("apikey")
-            pager = Pager(client, "/resources", {"limit": 3})
+            pager = Pager(client, "/resources", params={"limit": 3})
             page_count = 0
             item_count = 0
             for page in pager.pages():
@@ -193,7 +193,7 @@ class TestPager(unittest.TestCase):
     def test_empty_page(self):
         with get_empty_pager_client() as conn:
             client = MockClient("apikey")
-            pager = Pager(client, "/resources", {"limit": 3})
+            pager = Pager(client, "/resources", params={"limit": 3})
             item_count = 0
             for item in pager.items():
                 item_count += 1


### PR DESCRIPTION
This PR is going into `v3-v2020-01-01`. It contains a breaking change as you can no longer pass query params as kwargs into operations.

This serves a couple purposes:

1. It adds the `**options` kwargs to every operation. This will be where
   you can set custom request options.
2. We no longer support passing in query params as kwargs, they must now
   be passed as a dict to the `params` kwarg
3. We're adding support for the `headers` kwarg which overrides headers
   on the request.