### PR TITLE
Add tax identifier fields to billing info

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -416,7 +416,9 @@ class BillingInfo(Resource):
         'transaction_type',
         'iban',
         'sort_code',
-        'bsb_code'
+        'bsb_code',
+        'tax_identifier',
+        'tax_identifier_type'
     )
     sensitive_attributes = ('number', 'verification_value', 'account_number', 'iban')
     xml_attribute_attributes = ('type',)


### PR DESCRIPTION
Allows merchants to specify individual tax identifiers for customers (CPF + Brazil support) when creating and updating billing information.

Two fields introduced:
`tax_identifier`
`tax_identifier_type`

Example code:
```python
billing_info = recurly.BillingInfo(
  address1           = '125 Paper Street',
  city               = 'Los Angeles',
  state              = 'CA',
  zip                = '95312',
  country            = 'US',
  number             = '4111111111111111',
  month              = '10',
  year               = '2020',
  tax_identifier     = '758.356.352-65',
  tax_identifier_type = 'cpf',
)
account.update_billing_info(billing_info)
```