### PR TITLE
Add ability to set timeouts

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -20,7 +20,7 @@ USER_AGENT = "Recurly/{}; python {}; {}".format(
 # You do not want to enable this for production.
 STRICT_MODE = os.getenv("RECURLY_STRICT_MODE", "FALSE").upper() == "TRUE"
 
-DEFAULT_REQUEST_TIMEOUT = os.getenv("RECURLY_REQUEST_TIMEOUT")
+DEFAULT_REQUEST_TIMEOUT = os.getenv("RECURLY_DEFAULT_REQUEST_TIMEOUT")
 
 
 from .base_errors import RecurlyError, ApiError, NetworkError

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -20,6 +20,8 @@ USER_AGENT = "Recurly/{}; python {}; {}".format(
 # You do not want to enable this for production.
 STRICT_MODE = os.getenv("RECURLY_STRICT_MODE", "FALSE").upper() == "TRUE"
 
+DEFAULT_REQUEST_TIMEOUT = os.getenv("RECURLY_REQUEST_TIMEOUT")
+
 
 from .base_errors import RecurlyError, ApiError, NetworkError
 from . import errors

--- a/recurly/base_client.py
+++ b/recurly/base_client.py
@@ -27,8 +27,8 @@ def request_converter(value):
 class BaseClient:
     def __init__(self, api_key, timeout=None):
         self.__api_key = api_key
-        self.timeout = timeout if timeout is not None else DEFAULT_REQUEST_TIMEOUT
-        self.__conn = http.client.HTTPSConnection(HOST, PORT, timeout=self.timeout)
+        actual_timeout = timeout if timeout is not None else DEFAULT_REQUEST_TIMEOUT
+        self.__conn = http.client.HTTPSConnection(HOST, PORT, timeout=actual_timeout)
 
     def _make_request(self, method, path, body, params):
         try:

--- a/recurly/base_client.py
+++ b/recurly/base_client.py
@@ -6,7 +6,7 @@ from . import resources
 from .resource import Resource, Empty
 from .request import Request
 from .response import Response
-from recurly import USER_AGENT, ApiError, NetworkError
+from recurly import USER_AGENT, DEFAULT_REQUEST_TIMEOUT, ApiError, NetworkError
 from pydoc import locate
 import urllib.parse
 from datetime import datetime
@@ -25,9 +25,10 @@ def request_converter(value):
 
 
 class BaseClient:
-    def __init__(self, api_key):
+    def __init__(self, api_key, timeout=None):
         self.__api_key = api_key
-        self.__conn = http.client.HTTPSConnection(HOST, PORT)
+        self.timeout = timeout if timeout is not None else DEFAULT_REQUEST_TIMEOUT
+        self.__conn = http.client.HTTPSConnection(HOST, PORT, timeout=self.timeout)
 
     def _make_request(self, method, path, body, params):
         try:

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -244,10 +244,3 @@ class TestBaseClient(unittest.TestCase):
         timeout = 3
         client = MockClient("apikey", timeout=timeout)
         self.assertEqual(client.timeout, timeout)
-
-    def test_client_timeout(self):
-        client = MockClient("apikey", timeout=0)
-        with self.assertRaises(recurly.NetworkError) as e:
-            client._make_request("GET", "wef", body=None, params=None)
-
-        self.assertIn("Operation now in progress", str(e.exception))

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -243,4 +243,4 @@ class TestBaseClient(unittest.TestCase):
     def test_client_can_set_timeout(self):
         timeout = 3
         client = MockClient("apikey", timeout=timeout)
-        self.assertEqual(client.timeout, timeout)
+        self.assertEqual(client.__dict__["_BaseClient__conn"].timeout, timeout)

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -239,3 +239,15 @@ class TestBaseClient(unittest.TestCase):
 
                 request.assert_called_with("GET", url, None, headers=expected_headers)
                 self.assertEqual(type(resource), MyResource)
+
+    def test_client_can_set_timeout(self):
+        timeout = 3
+        client = MockClient("apikey", timeout=timeout)
+        self.assertEqual(client.timeout, timeout)
+
+    def test_client_timeout(self):
+        client = MockClient("apikey", timeout=0)
+        with self.assertRaises(recurly.NetworkError) as e:
+            client._make_request("GET", "wef", body=None, params=None)
+
+        self.assertIn("Operation now in progress", str(e.exception))


### PR DESCRIPTION
Add ability to set timeouts for requests in multiple ways:

- set `RECURLY_DEFAULT_REQUEST_TIMEOUT` environment variable
- override `recurly.DEFAULT_REQUEST_TIMEOUT`
- set in the client constructor with `client = Client("apikey", timeout=5)`

This mimics the current behavior and uses `None` as the default value. I could see a case for making that something reasonable by default, so everyone ges the benefit of not shooting themselves in the foot.

Implements #422 