### PR TITLE
Release 2.9.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+## Version 2.9.19 - August 20, 2020 ##
+
+This version brings us up to API version 2.29, but has no breaking changes
+
+- Add tiers attribute to sub add-on [PR](https://github.com/recurly/recurly-client-python/pull/417)
+- Add tax identifier fields to billing info [PR](https://github.com/recurly/recurly-client-python/pull/421)
+
 ## Version 2.9.18 - July 22, 2020 ##
 
 This version brings us up to API version 2.28, but has no breaking changes

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -22,7 +22,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.18'
+__version__ = '2.9.19'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -46,7 +46,7 @@ SUBDOMAIN = 'api'
 API_KEY = None
 """The API key to use when authenticating API requests."""
 
-API_VERSION = '2.28'
+API_VERSION = '2.29'
 """The API version to use when making API requests."""
 
 CA_CERTS_FILE = None


### PR DESCRIPTION
This PR merges v2.29 features into v2 branch for release and bumps the client library version to 2.9.19.

---

This version brings us up to API version 2.29, but has no breaking changes

- Add tiers attribute to sub add-on https://github.com/recurly/recurly-client-python/pull/417
- Add tax identifier fields to billing info https://github.com/recurly/recurly-client-python/pull/421
