### PR TITLE
New endpoint to verify an account's billing information 

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -423,6 +423,25 @@ class BillingInfo(Resource):
     sensitive_attributes = ('number', 'verification_value', 'account_number', 'iban')
     xml_attribute_attributes = ('type',)
 
+    def verify(self, gateway_code = None):
+      url_value = self._elem.attrib.get('url')
+      url = urljoin(url_value, '/verify')
+
+      if gateway_code:
+          elem = ElementTreeBuilder.Element('verify')
+          elem.append(Resource.element_for_value('gateway_code', gateway_code))
+          body = ElementTree.tostring(elem, encoding='UTF-8')
+          response = self.http_request(url, 'POST', body, {'Content-Type':'application/xml; charset=utf-8'})
+      else:
+          response = self.http_request(url, 'POST')
+
+      if response.status != 200:
+        self.raise_http_error(response)
+      response_xml = response.read()
+      logging.getLogger('recurly.http.response').debug(response_xml)
+      elem = ElementTree.fromstring(response_xml)
+      return Transaction.from_element(elem)
+
 class ShippingAddress(Resource):
 
     """Shipping Address information"""

--- a/tests/fixtures/billing-info/account-embed-created.xml
+++ b/tests/fixtures/billing-info/account-embed-created.xml
@@ -34,6 +34,7 @@ Location: https://api.recurly.com/v2/accounts/binfo-mock-2
   <invoices href="https://api.recurly.com/v2/accounts/binfo-mock-2/invoices"/>
   <subscriptions href="https://api.recurly.com/v2/accounts/binfo-mock-2/subscriptions"/>
   <transactions href="https://api.recurly.com/v2/accounts/binfo-mock-2/transactions"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/binfo-mock-2/billing_info"/>
   <account_code>binfo-mock-2</account_code>
   <username nil="nil"></username>
   <email nil="nil"></email>

--- a/tests/fixtures/billing-info/verified-with-gateway-code-200.xml
+++ b/tests/fixtures/billing-info/verified-with-gateway-code-200.xml
@@ -1,0 +1,74 @@
+POST https://api.recurly.com/v2/accounts/binfo-mock-2/billing_info/verify HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<verify>
+  <gateway_code>gateway-code</gateway_code>
+</verify>
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/transactions/46036dcc04137580364f244e9591813f
+
+<?xml version="1.0" encoding="UTF-8"?>
+<transaction href="https://api.recurly.com/v2/transactions/abcdef1234567890" type="credit_card">
+  <account href="https://api.recurly.com/v2/accounts/binfo-mock-2"/>
+  <uuid>55e508df05ca7ea5bb9da34d98be5d61</uuid>
+  <action>verify</action>
+  <amount_in_cents type="integer">0</amount_in_cents>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <currency>USD</currency>
+  <status>success</status>
+  <payment_method>credit_card</payment_method>
+  <reference>1903896</reference>
+  <source>billing_info</source>
+  <recurring type="boolean">false</recurring>
+  <test type="boolean">true</test>
+  <voidable type="boolean">false</voidable>
+  <refundable type="boolean">false</refundable>
+  <ip_address nil="nil"></ip_address>
+  <gateway_type>test</gateway_type>
+  <origin>api_verify_card</origin>
+  <description nil="nil"></description>
+  <message>Successful test transaction</message>
+  <approval_code nil="nil"></approval_code>
+  <failure_type nil="nil"></failure_type>
+  <gateway_error_codes nil="nil"></gateway_error_codes>
+  <cvv_result code="" nil="nil"></cvv_result>
+  <avs_result code="D">Street address and postal code match.</avs_result>
+  <avs_result_street nil="nil"></avs_result_street>
+  <avs_result_postal nil="nil"></avs_result_postal>
+  <created_at type="datetime">2020-09-10T04:19:44Z</created_at>
+  <collected_at type="datetime">2020-09-10T04:19:44Z</collected_at>
+  <updated_at type="datetime">2020-09-10T04:19:44Z</updated_at>
+  <details>
+    <account>
+      <account_code>binfo-mock-2</account_code>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <company nil="nil"></company>
+      <email nil="nil"></email>
+      <billing_info type="credit_card">
+        <first_name>Vera</first_name>
+        <last_name>Verification</last_name>
+        <address1>11060 US-31</address1>
+        <address2 nil="nil"></address2>
+        <city>Elk Rapids</city>
+        <state>MI</state>
+        <zip>49629</zip>
+        <country>US</country>
+        <phone nil="nil"></phone>
+        <vat_number nil="nil"></vat_number>
+        <card_type>Visa</card_type>
+        <year type="integer">2045</year>
+        <month type="integer">12</month>
+        <first_six>411111</first_six>
+        <last_four>1111</last_four>
+      </billing_info>
+    </account>
+  </details>
+</transaction>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -570,7 +570,6 @@ class TestResources(RecurlyTest):
                 same_binfo = same_account.billing_info
             self.assertEqual(same_binfo.first_name, 'Verena')
             self.assertEqual(same_binfo.city, six.u('San Jos\xe9'))
-
             with self.mock_request('billing-info/deleted.xml'):
                 binfo.delete()
         finally:
@@ -613,6 +612,11 @@ class TestResources(RecurlyTest):
             with self.mock_request('billing-info/embedded-exists.xml'):
                 binfo = same_account.billing_info
             self.assertEqual(binfo.first_name, 'Verena')
+            # test credit card billing info verification
+            with self.mock_request('billing-info/verified-with-gateway-code-200.xml'):
+                verified = binfo.verify('gateway-code')
+                self.assertEqual(verified.origin, 'api_verify_card')
+
         finally:
             with self.mock_request('billing-info/account-embed-deleted.xml'):
                 account.delete()


### PR DESCRIPTION
If the account has billing information for anything other than a credit card, this will return 422, with an appropriate error message. If successful, this will return 200, with the transaction's data.
gateway_code (optional) is the code for the gateway to use for the verification. If unspecified, a gateway will be selected using the normal rules.

Example:
```python
# verify without specifying gateway code to use 
billing_info = recurly.Account.get('account_code').billing_info
billing_info.verify()
# verify with a specific gateway code
billing_info.verify("gateway-code")
```

*Known issue*: Note that `billing_info` can be accessed by fetching an existing account first, e.g. `recurly.Account.get('account_code').billing_info`
Attempting to verify billing info directly after creating an account with billing info will result in an AttributeError
```python
account = recurly.Account(account_code = 'account-code'),
    email = 'verena@example.com',
    first_name = 'Verena',
    last_name = 'Example',
    billing_info = recurly.BillingInfo(
      first_name = 'Benjamin',
      last_name = 'DuMonde',
      number = '4111111111111111',
      verification_value = '123',
      month = 11,
      year = 2020,
      address1 = '123 Main St',
      city = 'New Orleans',
      state = 'LA',
      zip = '70114',
      country = 'US'
    )
  )
account.save()
account.billing_info.verify() # throws AttributeError
```