### PR TITLE
Skipping object attribute for Errors

### DIFF
--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -94,6 +94,9 @@ class Resource:
 
         resource = klass()
         for k, v in properties.items():
+            # Skip "object" attribute for Errors
+            if k == "object" and class_name == "Error":
+                continue
             attr = None
             attr_type = klass.schema.get(k)
             if attr_type:

--- a/tests/mock_resources.py
+++ b/tests/mock_resources.py
@@ -20,7 +20,7 @@ class MySubResource(Resource):
 
 
 class Error(Resource):
-    schema = {"object": str, "message": str, "params": list, "type": str}
+    schema = {"message": str, "params": list, "type": str}
 
 
 class Empty(Resource):


### PR DESCRIPTION
This is a fix for an error that occurs when handling an API Error response while in strict mode. The issue being fixed only impacts the client when RECURLY_STRICT mode is set (which should only be for internal development)