### PR TITLE
Set url value to access either href and url

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -424,7 +424,7 @@ class BillingInfo(Resource):
     xml_attribute_attributes = ('type',)
 
     def verify(self, gateway_code = None):
-      url_value = self._elem.attrib.get('url')
+      url_value = self._elem.attrib.get('href') or self._elem.attrib.get('url')
       url = urljoin(url_value, '/verify')
 
       if gateway_code:


### PR DESCRIPTION
The `BillingInfo` object elem attributes seem to include either `href` or `url` - need time to further investigate the circumstances that make one available over the other. But in order to make this endpoint available, I'd like to include both before releasing a more comprehensive patch that also addresses the known issue outlined in https://github.com/recurly/recurly-client-python/pull/431