### PR TITLE
Add ability to verify billing_info without fetching account first

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -614,7 +614,7 @@ class TestResources(RecurlyTest):
             self.assertEqual(binfo.first_name, 'Verena')
             # test credit card billing info verification
             with self.mock_request('billing-info/verified-with-gateway-code-200.xml'):
-                verified = binfo.verify('gateway-code')
+                verified = same_account.verify('gateway-code')
                 self.assertEqual(verified.origin, 'api_verify_card')
 
         finally:


### PR DESCRIPTION
Patches known issue from https://github.com/recurly/recurly-client-python/pull/431 where attempting to verify billing info directly after creating an account with billing info will result in an AttributeError. This patch also cancels out https://github.com/recurly/recurly-client-python/pull/435.

I added a `verify` method to the `Account`, and then had the `verify` method in `BillingInfo` reference it. Consequently, the user could also feasibly verify billing info directly on account, e.g. `account.verify()` instead of `billing_info.verify(account.account_code)`

Example:
```python
account = recurly.Account(
    account_code = 'account-code',
    email = 'verena@example.com',
    first_name = 'Verena',
    last_name = 'Example',
    billing_info = recurly.BillingInfo(
      first_name = 'Benjamin',
      last_name = 'DuMonde',
      number = '4111111111111111',
      verification_value = '123',
      month = 11,
      year = 2020,
      address1 = '123 Main St',
      city = 'New Orleans',
      state = 'LA',
      zip = '70114',
      country = 'US'
    )
)
account.save()
account.billing_info.verify(account.account_code, 'gateway-code`) #account_code is a required param, gateway_code is optional
```