### PR TITLE
Use ErrorMayHaveTransaction instead of Error

### DIFF
--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -35,7 +35,7 @@ class Resource:
             json_body = json.loads(response.body.decode("utf-8"))
 
             error_json = json_body["error"]
-            error_json["object"] = "error"
+            error_json["object"] = "error_may_have_transaction"
             error = cls.cast_json(error_json, response=response)
             error_type = error.type
             name_parts = error_type.split("_")
@@ -95,7 +95,7 @@ class Resource:
         resource = klass()
         for k, v in properties.items():
             # Skip "object" attribute for Errors
-            if k == "object" and class_name == "Error":
+            if k == "object" and class_name == "ErrorMayHaveTransaction":
                 continue
             attr = None
             attr_type = klass.schema.get(k)

--- a/tests/mock_resources.py
+++ b/tests/mock_resources.py
@@ -19,8 +19,13 @@ class MySubResource(Resource):
     schema = {"object": str, "my_string": str}
 
 
-class Error(Resource):
-    schema = {"message": str, "params": list, "type": str}
+class ErrorMayHaveTransaction(Resource):
+    schema = {
+        "message": str,
+        "params": list,
+        "transaction_error": "TransactionError",
+        "type": str,
+    }
 
 
 class Empty(Resource):


### PR DESCRIPTION
Using the `ErrorMayHaveTransaction` class instead of the `Error` class in the same manner that was applied in other clients (https://github.com/recurly/recurly-client-ruby/issues/540) (https://github.com/recurly/recurly-client-dotnet/pull/465).

This change makes it easier for the developer to access information when there is a `TransactionError` thrown by Recurly API.

Previously, to access the data about a transaction error, the developer would have to access the response meta-data to read the transaction data:
```python
error.error.get_response().body['transaction_error']
```
By using the `ErrorMayHaveTransaction` class, the developer can access this data directly without having to access the JSON response:
```python
error.error.transaction_error
```