### PR TITLE
Updating client to be compliant with RFC 2616: case-insensitive headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.3
+      dist: trusty
+    - python: 3.4
+    - python: 3.5
 install:
   - pip install six mock iso8601 backports.ssl-match-hostname
   - python setup.py install

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 ## Unreleased
 #
+## Version 2.6.4 October 5, 2020
+
+- Fixed issue with RFC 2616 compliance: field names are case-insensitive
+
 ## Version 2.6.1 October 26, 2017
 
 - Added missing attributes on Delivery resource

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -71,9 +71,9 @@ def cache_rate_limit_headers(resp_headers):
     try:
         recurly.cached_rate_limits = {
                 'cached_at': datetime.utcnow(),
-                'limit': int(resp_headers['X-RateLimit-Limit']),
-                'remaining': int(resp_headers['X-RateLimit-Remaining']),
-                'resets_at': datetime.utcfromtimestamp(int(resp_headers['X-RateLimit-Reset']))
+                'limit': int(resp_headers['x-ratelimit-limit']),
+                'remaining': int(resp_headers['x-ratelimit-remaining']),
+                'resets_at': datetime.utcfromtimestamp(int(resp_headers['x-ratelimit-reset']))
                 }
     except:
         log = logging.getLogger('recurly.cached_rate_limits')

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -247,7 +247,7 @@ class Account(Resource):
         url = urljoin(self._url, '%s/invoices' % self.account_code)
 
         if kwargs:
-            response = self.http_request(url, 'POST', Invoice(**kwargs), {'Content-Type':
+            response = self.http_request(url, 'POST', Invoice(**kwargs), {'content-type':
                 'application/xml; charset=utf-8'})
         else:
             response = self.http_request(url, 'POST')
@@ -260,7 +260,7 @@ class Account(Resource):
         elem = ElementTree.fromstring(response_xml)
 
         invoice = Invoice.from_element(elem)
-        invoice._url = response.getheader('Location')
+        invoice._url = response.getheader('location')
         return invoice
 
     def build_invoice(self):
@@ -309,11 +309,11 @@ class Account(Resource):
         """Change this account's billing information to the given `BillingInfo`."""
         url = urljoin(self._url, '%s/billing_info' % self.account_code)
         response = billing_info.http_request(url, 'PUT', billing_info,
-            {'Content-Type': 'application/xml; charset=utf-8'})
+            {'content-type': 'application/xml; charset=utf-8'})
         if response.status == 200:
             pass
         elif response.status == 201:
-            billing_info._url = response.getheader('Location')
+            billing_info._url = response.getheader('location')
         else:
             billing_info.raise_http_error(response)
 
@@ -579,13 +579,13 @@ class Coupon(Resource):
         url = urljoin(self._url, '%s/generate' % (self.coupon_code, ))
         body = ElementTree.tostring(elem, encoding='UTF-8')
 
-        response = self.http_request(url, 'POST', body, { 'Content-Type':
+        response = self.http_request(url, 'POST', body, { 'content-type':
             'application/xml; charset=utf-8' })
 
         if response.status not in (200, 201, 204):
             self.raise_http_error(response)
 
-        return Page.page_for_url(response.getheader('Location'))
+        return Page.page_for_url(response.getheader('location'))
 
     def restore(self):
         url = urljoin(self._url, '%s/restore' % self.coupon_code)
@@ -760,7 +760,7 @@ class Invoice(Resource):
 
         """
         url = urljoin(base_uri(), cls.member_path % (uuid,))
-        pdf_response = cls.http_request(url, headers={'Accept': 'application/pdf'})
+        pdf_response = cls.http_request(url, headers={'accept': 'application/pdf'})
         return pdf_response.read()
 
     def refund_amount(self, amount_in_cents, refund_apply_order = 'credit'):
@@ -1084,7 +1084,7 @@ class Transaction(Resource):
         if response.status != 202:
             self.raise_http_error(response)
 
-        self._refund_transaction_url = response.getheader('Location')
+        self._refund_transaction_url = response.getheader('location')
         return self
 
     def get_refund_transaction(self):

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -136,7 +136,7 @@ class Page(list):
     def count_for_url(cls, url):
         """Return the count of server side resources given a url"""
         headers = Resource.headers_for_url(url)
-        return int(headers['X-Records'])
+        return int(headers['x-records'])
 
     @classmethod
     def page_for_value(cls, resp, value):

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -149,7 +149,7 @@ class Page(list):
 
         """
         page = cls(value)
-        links = parse_link_value(resp.getheader('Link'))
+        links = parse_link_value(resp.getheader('link'))
         for url, data in six.iteritems(links):
             if data.get('rel') == 'start':
                 page.start_url = url
@@ -256,18 +256,18 @@ class Resource(object):
             connection = http_client.HTTPSConnection(urlparts.netloc, **connection_options)
 
         headers = {} if headers is None else dict(headers)
-        headers.setdefault('Accept', 'application/xml')
+        headers.setdefault('accept', 'application/xml')
         headers.update({
-            'User-Agent': recurly.USER_AGENT
+            'user-agent': recurly.USER_AGENT
         })
-        headers['X-Api-Version'] = recurly.api_version()
-        headers['Authorization'] = 'Basic %s' % base64.b64encode(six.b('%s:' % recurly.API_KEY)).decode()
+        headers['x-api-version'] = recurly.api_version()
+        headers['authorization'] = 'Basic %s' % base64.b64encode(six.b('%s:' % recurly.API_KEY)).decode()
 
         log = logging.getLogger('recurly.http.request')
         if log.isEnabledFor(logging.DEBUG):
             log.debug("%s %s HTTP/1.1", method, url)
             for header, value in six.iteritems(headers):
-                if header == 'Authorization':
+                if header == 'authorization':
                     value = '<redacted>'
                 log.debug("%s: %s", header, value)
             log.debug('')
@@ -279,9 +279,9 @@ class Resource(object):
 
         if isinstance(body, Resource):
             body = ElementTree.tostring(body.to_element(), encoding='UTF-8')
-            headers['Content-Type'] = 'application/xml; charset=utf-8'
+            headers['content-type'] = 'application/xml; charset=utf-8'
         if method in ('POST', 'PUT') and body is None:
-            headers['Content-Length'] = '0'
+            headers['content-length'] = '0'
         connection.request(method, url, body, headers)
         resp = connection.getresponse()
 
@@ -302,9 +302,9 @@ class Resource(object):
         """Turns an array of response headers into a dictionary"""
         if six.PY2:
             pairs = [header.split(': ') for header in resp.msg.headers]
-            return dict([(k, v.strip()) for k, v in pairs])
+            return dict([(k.lower(), v.strip()) for k, v in pairs])
         else:
-            return dict([(k, v.strip()) for k, v in resp.msg._headers])
+            return dict([(k.lower(), v.strip()) for k, v in resp.msg._headers])
 
     def as_log_output(self):
         """Returns an XML string containing a serialization of this
@@ -367,7 +367,7 @@ class Resource(object):
         if response.status != 200:
             cls.raise_http_error(response)
 
-        assert response.getheader('Content-Type').startswith('application/xml')
+        assert response.getheader('content-type').startswith('application/xml')
 
         response_xml = response.read()
         logging.getLogger('recurly.http.response').debug(response_xml)
@@ -651,7 +651,7 @@ class Resource(object):
     def put(self, url):
         """Sends this `Resource` instance to the service with a
         ``PUT`` request to the given URL."""
-        response = self.http_request(url, 'PUT', self, {'Content-Type': 'application/xml; charset=utf-8'})
+        response = self.http_request(url, 'PUT', self, {'content-type': 'application/xml; charset=utf-8'})
         if response.status != 200:
             self.raise_http_error(response)
 
@@ -662,11 +662,11 @@ class Resource(object):
     def post(self, url, body=None):
         """Sends this `Resource` instance to the service with a
         ``POST`` request to the given URL. Takes an optional body"""
-        response = self.http_request(url, 'POST', body or self, {'Content-Type': 'application/xml; charset=utf-8'})
+        response = self.http_request(url, 'POST', body or self, {'content-type': 'application/xml; charset=utf-8'})
         if response.status not in (200, 201, 204):
             self.raise_http_error(response)
 
-        self._url = response.getheader('Location')
+        self._url = response.getheader('location')
 
         if response.status in (200, 201):
             response_xml = response.read()

--- a/tests/fixtures/account/exists-with-rate-limit-headers.xml
+++ b/tests/fixtures/account/exists-with-rate-limit-headers.xml
@@ -7,9 +7,9 @@ User-Agent: {user-agent}
 
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-X-RateLimit-Limit: 2000
-X-RateLimit-Reset: 1486064760
-X-RateLimit-Remaining: 1992
+x-ratelimit-limit: 2000
+x-ratelimit-reset: 1486064760
+x-ratelimit-remaining: 1992
 
 <?xml version="1.0" encoding="UTF-8"?>
 <account href="https://api.recurly.com/v2/accounts/testmock">

--- a/tests/fixtures/pages/count.xml
+++ b/tests/fixtures/pages/count.xml
@@ -6,4 +6,4 @@ User-Agent: {user-agent}
 
 
 HTTP/1.1 200 OK
-X-Records: 23
+x-records: 23

--- a/tests/recurlytests.py
+++ b/tests/recurlytests.py
@@ -60,12 +60,12 @@ class MockRequestManager(object):
 
         if six.PY2:
             msg = http_client.HTTPMessage(self.fixture_file, 0)
-            self.headers = dict((k, v.strip()) for k, v in (header.split(':', 1) for header in msg.headers))
+            self.headers = dict((k.lower(), v.strip()) for k, v in (header.split(':', 1) for header in msg.headers))
         else:
             # http.client.HTTPMessage doesn't have importing headers from file
             msg = http_client.HTTPMessage()
             headers = email.message_from_bytes(six.b('').join(read_headers(self.fixture_file)))
-            self.headers = dict((k, v.strip()) for k, v in headers._headers)
+            self.headers = dict((k.lower(), v.strip()) for k, v in headers._headers)
             # self.headers = {k: v for k, v in headers._headers}
         msg.fp = None
 
@@ -83,8 +83,8 @@ class MockRequestManager(object):
         body = six.b('').join(nextline(self.fixture_file))  # exhaust the request either way
         self.body = None
         if self.method in ('PUT', 'POST'):
-            if 'Content-Type' in self.headers:
-                if 'application/xml' in self.headers['Content-Type']:
+            if 'content-type' in self.headers:
+                if 'application/xml' in self.headers['content-type']:
                     self.body = xml(body)
                 else:
                     self.body = body
@@ -105,10 +105,10 @@ class MockRequestManager(object):
 
     def assert_request(self):
         headers = dict(self.headers)
-        if 'User-Agent' in headers:
+        if 'user-agent' in headers:
             import recurly
-            headers['User-Agent'] = headers['User-Agent'].replace('{user-agent}', recurly.USER_AGENT)
-        headers['X-Api-Version'] = headers['X-Api-Version'].replace('{api-version}', recurly.API_VERSION)
+            headers['user-agent'] = headers['user-agent'].replace('{user-agent}', recurly.USER_AGENT)
+        headers['x-api-version'] = headers['x-api-version'].replace('{api-version}', recurly.API_VERSION)
         self.request_mock.assert_called_once_with(self.method, self.uri, self.body, headers)
 
     def __exit__(self, exc_type, exc_value, traceback):


### PR DESCRIPTION
According to section 4.2 of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

This update will make the client treat headers in a case-insensitive manner.