### PR TITLE
Updating client to be compliant with RFC 2616: case-insensitive headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.3
+      dist: trusty
+    - python: 3.4
+    - python: 3.5
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install virtualenv==15.2.0; fi 
-  - pip install six mock iso8601 backports.ssl-match-hostname --use-mirrors
+  - pip install six mock iso8601 backports.ssl-match-hostname
   - python setup.py install
 script:
   - RECURLY_INSECURE_DEBUG=true python -m unittest discover -s tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.4"
   - "3.5"
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install virtualenv==15.2.0; fi 
   - pip install six mock iso8601 backports.ssl-match-hostname --use-mirrors
   - python setup.py install
 script:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## Version 2.2.24 October 6, 2020
+
+- Fixed issue with RFC 2616 compliance: field names are case-insensitive
+
 ## Version 2.2.21 June 29, 2016
 
 - Adding `collection_path` to `MeasuredUnit`

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -19,7 +19,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.2.23'
+__version__ = '2.2.24'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 VALID_DOMAINS = ('.recurly.com',)

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -191,7 +191,7 @@ class Account(Resource):
         url = urljoin(self._url, '%s/invoices' % self.account_code)
 
         if kwargs:
-            response = self.http_request(url, 'POST', Invoice(**kwargs), {'Content-Type':
+            response = self.http_request(url, 'POST', Invoice(**kwargs), {'content-type':
                 'application/xml; charset=utf-8'})
         else:
             response = self.http_request(url, 'POST')
@@ -204,7 +204,7 @@ class Account(Resource):
         elem = ElementTree.fromstring(response_xml)
 
         invoice = Invoice.from_element(elem)
-        invoice._url = response.getheader('Location')
+        invoice._url = response.getheader('location')
         return invoice
 
     def build_invoice(self):
@@ -253,11 +253,11 @@ class Account(Resource):
         """Change this account's billing information to the given `BillingInfo`."""
         url = urljoin(self._url, '%s/billing_info' % self.account_code)
         response = billing_info.http_request(url, 'PUT', billing_info,
-            {'Content-Type': 'application/xml; charset=utf-8'})
+            {'content-type': 'application/xml; charset=utf-8'})
         if response.status == 200:
             pass
         elif response.status == 201:
-            billing_info._url = response.getheader('Location')
+            billing_info._url = response.getheader('location')
         else:
             billing_info.raise_http_error(response)
 
@@ -405,13 +405,13 @@ class Coupon(Resource):
         url = urljoin(self._url, '%s/generate' % (self.coupon_code, ))
         body = ElementTree.tostring(elem, encoding='UTF-8')
 
-        response = self.http_request(url, 'POST', body, { 'Content-Type':
+        response = self.http_request(url, 'POST', body, { 'content-type':
             'application/xml; charset=utf-8' })
 
         if response.status not in (200, 201, 204):
             self.raise_http_error(response)
 
-        return Page.page_for_url(response.getheader('Location'))
+        return Page.page_for_url(response.getheader('location'))
 
     def restore(self):
         url = urljoin(self._url, '%s/restore' % self.coupon_code)
@@ -579,7 +579,7 @@ class Invoice(Resource):
 
         """
         url = urljoin(base_uri(), cls.member_path % (uuid,))
-        pdf_response = cls.http_request(url, headers={'Accept': 'application/pdf'})
+        pdf_response = cls.http_request(url, headers={'accept': 'application/pdf'})
         return pdf_response.read()
 
     def refund_amount(self, amount_in_cents, refund_apply_order = 'credit'):
@@ -817,7 +817,7 @@ class Transaction(Resource):
         if response.status != 202:
             self.raise_http_error(response)
 
-        self._refund_transaction_url = response.getheader('Location')
+        self._refund_transaction_url = response.getheader('location')
         return self
 
     def get_refund_transaction(self):

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -295,10 +295,10 @@ class Resource(object):
             log.debug("HTTP/1.1 %d %s", resp.status, resp.reason)
             if six.PY2:
                 for header in resp.msg.headers:
-                    pairs = [header.split(': ')]
+                    pairs = [header.split(':', 1)]
                     for k, v in pairs:
-                      k = k.lower()
-                    log.debug(header.rstrip('\n'))
+                        header = ": ".join((k.lower(), v.strip()))
+                    log.debug(header)              
             else:
                 log.debug(resp.msg._headers)
             log.debug('')

--- a/tests/recurlytests.py
+++ b/tests/recurlytests.py
@@ -59,12 +59,12 @@ class MockRequestManager(object):
 
         if six.PY2:
             msg = http_client.HTTPMessage(self.fixture_file, 0)
-            self.headers = dict((k, v.strip()) for k, v in (header.split(':', 1) for header in msg.headers))
+            self.headers = dict((k.lower(), v.strip()) for k, v in (header.split(':', 1) for header in msg.headers))
         else:
             # http.client.HTTPMessage doesn't have importing headers from file
             msg = http_client.HTTPMessage()
             headers = email.message_from_bytes(six.b('').join(read_headers(self.fixture_file)))
-            self.headers = dict((k, v.strip()) for k, v in headers._headers)
+            self.headers = dict((k.lower(), v.strip()) for k, v in headers._headers)
             # self.headers = {k: v for k, v in headers._headers}
         msg.fp = None
 
@@ -82,8 +82,8 @@ class MockRequestManager(object):
         body = six.b('').join(nextline(self.fixture_file))  # exhaust the request either way
         self.body = None
         if self.method in ('PUT', 'POST'):
-            if 'Content-Type' in self.headers:
-                if 'application/xml' in self.headers['Content-Type']:
+            if 'content-type' in self.headers:
+                if 'application/xml' in self.headers['content-type']:
                     self.body = xml(body)
                 else:
                     self.body = body
@@ -101,9 +101,9 @@ class MockRequestManager(object):
 
     def assert_request(self):
         headers = dict(self.headers)
-        if 'User-Agent' in headers:
+        if 'user-agent' in headers:
             import recurly
-            headers['User-Agent'] = headers['User-Agent'].replace('{user-agent}', recurly.USER_AGENT)
+            headers['user-agent'] = headers['user-agent'].replace('{user-agent}', recurly.USER_AGENT)
         self.request_mock.assert_called_once_with(self.method, self.uri, self.body, headers)
 
     def __exit__(self, exc_type, exc_value, traceback):


### PR DESCRIPTION
According to section 4.2 of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

This update will make the client treat headers in a case-insensitive manner.