### PR TITLE
Updating client to be compliant with RFC 2616: case-insensitive headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
-python:
-  - "2.7"
-  - "3.3"
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.3
+      dist: trusty
 install:
-  - pip install six mock iso8601 backports.ssl-match-hostname --use-mirrors
+  - pip install six mock iso8601 backports.ssl-match-hostname
   - python setup.py install
 script:
   - RECURLY_INSECURE_DEBUG=true python -m unittest discover -s tests

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## Version 2.1.18 October 8, 2020
+
+- Fixed issue with RFC 2616 compliance: field names are case-insensitive
+
 ## Version 2.1.15 April 8, 2014
 
 - Added token_id support to BillingInfo

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -215,7 +215,7 @@ class Account(Resource):
         """Change this account's billing information to the given `BillingInfo`."""
         url = urljoin(self._url, '%s/billing_info' % self.account_code)
         response = billing_info.http_request(url, 'PUT', billing_info,
-            {'Content-Type': 'application/xml; charset=utf-8'})
+            {'content-type': 'application/xml; charset=utf-8'})
         if response.status == 200:
             pass
         elif response.status == 201:
@@ -454,7 +454,7 @@ class Invoice(Resource):
 
         """
         url = urljoin(base_uri(), cls.member_path % (uuid,))
-        pdf_response = cls.http_request(url, headers={'Accept': 'application/pdf'})
+        pdf_response = cls.http_request(url, headers={'accept': 'application/pdf'})
         return pdf_response.read()
 
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -18,7 +18,7 @@ http://docs.recurly.com/api/
 """
 
 
-__version__ = '2.1.17'
+__version__ = '2.1.18'
 
 VALID_DOMAINS = ('.recurly.com',)
 """A tuple of whitelisted domains that this client can connect to."""

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -370,7 +370,7 @@ class Resource(object):
         if response.status != 200:
             cls.raise_http_error(response)
 
-        assert response.getheader('content-type').startswith('application/xml')
+        assert response.getheader('Content-Type').startswith('application/xml')
 
         response_xml = response.read()
         logging.getLogger('recurly.http.response').debug(response_xml)

--- a/tests/recurlytests.py
+++ b/tests/recurlytests.py
@@ -59,12 +59,12 @@ class MockRequestManager(object):
 
         if six.PY2:
             msg = http_client.HTTPMessage(self.fixture_file, 0)
-            self.headers = dict((k, v.strip()) for k, v in (header.split(':', 1) for header in msg.headers))
+            self.headers = dict((k.lower(), v.strip()) for k, v in (header.split(':', 1) for header in msg.headers))
         else:
             # http.client.HTTPMessage doesn't have importing headers from file
             msg = http_client.HTTPMessage()
             headers = email.message_from_bytes(six.b('').join(read_headers(self.fixture_file)))
-            self.headers = dict((k, v.strip()) for k, v in headers._headers)
+            self.headers = dict((k.lower(), v.strip()) for k, v in headers._headers)
             # self.headers = {k: v for k, v in headers._headers}
         msg.fp = None
 
@@ -82,8 +82,8 @@ class MockRequestManager(object):
         body = six.b('').join(nextline(self.fixture_file))  # exhaust the request either way
         self.body = None
         if self.method in ('PUT', 'POST'):
-            if 'Content-Type' in self.headers:
-                if 'application/xml' in self.headers['Content-Type']:
+            if 'content-type' in self.headers:
+                if 'application/xml' in self.headers['content-type']:
                     self.body = xml(body)
                 else:
                     self.body = body
@@ -101,9 +101,9 @@ class MockRequestManager(object):
 
     def assert_request(self):
         headers = dict(self.headers)
-        if 'User-Agent' in headers:
+        if 'user-agent' in headers:
             import recurly
-            headers['User-Agent'] = headers['User-Agent'].replace('{version}', recurly.__version__)
+            headers['user-agent'] = headers['user-agent'].replace('{version}', recurly.__version__)
         self.request_mock.assert_called_once_with(self.method, self.uri, self.body, headers)
 
     def __exit__(self, exc_type, exc_value, traceback):


### PR DESCRIPTION
According to section 4.2 of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

This update will make the client treat headers in a case-insensitive manner.