### PR TITLE
Updating client to be compliant with RFC 2616: case-insensitive headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.3
+      dist: trusty
+    - python: 3.4
+    - python: 3.5
 install:
   - pip install six mock iso8601 backports.ssl-match-hostname
   - python setup.py install

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+## October 13, 2020 ##
+Version 2.0.7 
+
+- Fixed issue with RFC 2616 compliance: field names are case-insensitive
+
+
 ## January 6, 2012 ##
 Version 2.0.4
 

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -19,7 +19,7 @@ http://docs.recurly.com/api/
 """
 
 
-__version__ = '2.0.6'
+__version__ = '2.0.7'
 
 VALID_DOMAINS = ('.recurly.com',)
 """A tuple of whitelisted domains that this client can connect to."""

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -158,7 +158,7 @@ class Account(Resource):
         """Change this account's billing information to the given `BillingInfo`."""
         url = urljoin(self._url, '%s/billing_info' % self.account_code)
         response = billing_info.http_request(url, 'PUT', billing_info,
-            {'Content-Type': 'application/xml; charset=utf-8'})
+            {'content-type': 'application/xml; charset=utf-8'})
         if response.status == 200:
             pass
         elif response.status == 201:

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -185,11 +185,11 @@ class Resource(object):
 
         headers = {} if headers is None else dict(headers)
         headers.update({
-            'Accept': 'application/xml',
-            'User-Agent': 'recurly-python/%s' % recurly.__version__,
+            'accept': 'application/xml',
+            'user-agent': 'recurly-python/%s' % recurly.__version__,
         })
         if recurly.API_KEY is not None:
-            headers['Authorization'] = 'Basic %s' % base64.b64encode('%s:' % recurly.API_KEY)
+            headers['authorization'] = 'Basic %s' % base64.b64encode('%s:' % recurly.API_KEY)
 
         log = logging.getLogger('recurly.http.request')
         if log.isEnabledFor(logging.DEBUG):
@@ -207,9 +207,9 @@ class Resource(object):
 
         if isinstance(body, Resource):
             body = ElementTree.tostring(body.to_element(), encoding='UTF-8')
-            headers['Content-Type'] = 'application/xml; charset=utf-8'
+            headers['content-type'] = 'application/xml; charset=utf-8'
         if method in ('POST', 'PUT') and body is None:
-            headers['Content-Length'] = '0'
+            headers['content-length'] = '0'
         connection.request(method, url, body, headers)
         resp = connection.getresponse()
 
@@ -217,7 +217,10 @@ class Resource(object):
         if log.isEnabledFor(logging.DEBUG):
             log.debug("HTTP/1.1 %d %s", resp.status, resp.reason)
             for header in resp.msg.headers:
-                log.debug(header.rstrip('\n'))
+                pairs = [header.split(':', 1)]
+                for k, v in pairs:
+                    header = ": ".join((k.lower(), v.strip()))
+                log.debug(header)              
             log.debug('')
 
         return resp
@@ -274,7 +277,7 @@ class Resource(object):
         if response.status != 200:
             cls.raise_http_error(response)
 
-        assert response.getheader('Content-Type').startswith('application/xml')
+        assert response.getheader('content-type').startswith('application/xml')
 
         response_xml = response.read()
         logging.getLogger('recurly.http.response').debug(response_xml)
@@ -522,7 +525,7 @@ class Resource(object):
 
     def _update(self):
         url = self._url
-        response = self.http_request(url, 'PUT', self, {'Content-Type': 'application/xml; charset=utf-8'})
+        response = self.http_request(url, 'PUT', self, {'content-type': 'application/xml; charset=utf-8'})
         if response.status != 200:
             self.raise_http_error(response)
 
@@ -537,7 +540,7 @@ class Resource(object):
     def post(self, url):
         """Sends this `Resource` instance to the service with a
         ``POST`` request to the given URL."""
-        response = self.http_request(url, 'POST', self, {'Content-Type': 'application/xml; charset=utf-8'})
+        response = self.http_request(url, 'POST', self, {'content-type': 'application/xml; charset=utf-8'})
         if response.status != 201:
             self.raise_http_error(response)
 

--- a/tests/recurlytests.py
+++ b/tests/recurlytests.py
@@ -42,7 +42,7 @@ class MockRequestManager(object):
             raise ValueError("Couldn't parse preamble line from fixture file %r; does it have a fixture in it?"
                 % self.fixture)
         msg = httplib.HTTPMessage(self.fixture_file, 0)
-        self.headers = dict((k, v.strip()) for k, v in (header.split(':', 1) for header in msg.headers))
+        self.headers = dict((k.lower(), v.strip()) for k, v in (header.split(':', 1) for header in msg.headers))
         msg.fp = None
 
         # Read through to the vertical space.
@@ -59,8 +59,8 @@ class MockRequestManager(object):
         body = ''.join(nextline(self.fixture_file))  # exhaust the request either way
         self.body = None
         if self.method in ('PUT', 'POST'):
-            if 'Content-Type' in self.headers:
-                if 'application/xml' in self.headers['Content-Type']:
+            if 'content-type' in self.headers:
+                if 'application/xml' in self.headers['content-type']:
                     self.body = xml(body)
                 else:
                     self.body = body
@@ -78,9 +78,9 @@ class MockRequestManager(object):
 
     def assert_request(self):
         headers = dict(self.headers)
-        if 'User-Agent' in headers:
+        if 'user-agent' in headers:
             import recurly
-            headers['User-Agent'] = headers['User-Agent'].replace('{version}', recurly.__version__)
+            headers['user-agent'] = headers['user-agent'].replace('{version}', recurly.__version__)
         self.request_mock.assert_called_once_with(self.method, self.uri, self.body, headers)
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -20,7 +20,7 @@ class TestResources(RecurlyTest):
         with self.mock_request('authentication/unauthenticated.xml'):
             try:
                 Account.get(account_code)
-            except recurly.UnauthorizedError, exc:
+            except recurly.UnauthorizedError as exc:
                 pass
             else:
                 self.fail("Updating account with invalid email address did not raise a ValidationError")
@@ -59,7 +59,7 @@ class TestResources(RecurlyTest):
         with self.mock_request('account/update-bad-email.xml'):
             try:
                 account.save()
-            except ValidationError, exc:
+            except ValidationError as exc:
                 self.assertTrue(isinstance(exc.errors, collections.Mapping))
                 self.assertTrue('account.email' in exc.errors)
                 suberror = exc.errors['account.email']
@@ -131,7 +131,7 @@ class TestResources(RecurlyTest):
             with self.mock_request('add-on/need-amount.xml'):
                 try:
                     plan.create_add_on(add_on)
-                except ValidationError, exc:
+                except ValidationError as exc:
                     pass
                 else:
                     self.fail("Creating a plan add-on without an amount did not raise a ValidationError")
@@ -409,7 +409,7 @@ class TestResources(RecurlyTest):
             with self.mock_request('invoice/error-no-charges.xml'):
                 try:
                     account.invoice()
-                except ValidationError, exc:
+                except ValidationError as exc:
                     error = exc
                 else:
                     self.fail("Invoicing an account with no charges did not raise a ValidationError")
@@ -534,7 +534,7 @@ class TestResources(RecurlyTest):
                 with self.mock_request('subscription/error-no-billing-info.xml'):
                     try:
                         account.subscribe(sub)
-                    except BadRequestError, exc:
+                    except BadRequestError as exc:
                         error = exc
                     else:
                         self.fail("Subscribing with no billing info did not raise a BadRequestError")


### PR DESCRIPTION
According to section 4.2 of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

This update will make the client treat headers in a case-insensitive manner.