### PR TITLE
Support item-specific coupons

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -602,7 +602,8 @@ class Coupon(Resource):
 
     @classmethod
     def value_for_element(cls, elem):
-        if elem is None or elem.tag != 'plan_codes' and elem.tag != 'item_codes' or elem.attrib.get('type') != 'array':
+        excludes = ['plan_codes', 'item_codes']
+        if elem is None or elem.tag not in excludes or elem.attrib.get('type') != 'array':
             return super(Coupon, cls).value_for_element(elem)
 
         return [code_elem.text for code_elem in elem]

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -582,12 +582,14 @@ class Coupon(Resource):
         'temporal_amount',
         'max_redemptions',
         'applies_to_all_plans',
+        'applies_to_all_items',
         'applies_to_non_plan_charges',
         'redemption_resource',
         'created_at',
         'updated_at',
         'deleted_at',
         'plan_codes',
+        'item_codes',
         'hosted_description',
         'max_redemptions_per_account',
         'coupon_type',
@@ -600,20 +602,21 @@ class Coupon(Resource):
 
     @classmethod
     def value_for_element(cls, elem):
-        if elem is None or elem.tag != 'plan_codes' or elem.attrib.get('type') != 'array':
+        if elem is None or elem.tag != 'plan_codes' and elem.tag != 'item_codes' or elem.attrib.get('type') != 'array':
             return super(Coupon, cls).value_for_element(elem)
 
         return [code_elem.text for code_elem in elem]
 
     @classmethod
     def element_for_value(cls, attrname, value):
-        if attrname != 'plan_codes':
+        if attrname != 'plan_codes' and attrname != 'item_codes':
             return super(Coupon, cls).element_for_value(attrname, value)
 
         elem = ElementTreeBuilder.Element(attrname)
         elem.attrib['type'] = 'array'
         for code in value:
-            code_el = ElementTreeBuilder.Element('plan_code')
+          # create element from singular version of attrname
+            code_el = ElementTreeBuilder.Element(attrname[0 : -1])
             code_el.text = code
             elem.append(code_el)
 

--- a/tests/fixtures/coupon/item-coupon-created.xml
+++ b/tests/fixtures/coupon/item-coupon-created.xml
@@ -1,0 +1,57 @@
+POST https://api.recurly.com/v2/coupons HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<coupon>
+    <coupon_code>itemcouponmock</coupon_code>
+    <name>Item Coupon</name>
+    <discount_type>dollars</discount_type>
+    <discount_in_cents>
+        <USD type="integer">2000</USD>
+    </discount_in_cents>
+    <item_codes type="array">
+        <item_code>newitem</item_code>
+    </item_codes>
+</coupon>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/coupons/itemcouponmock
+
+<?xml version="1.0" encoding="UTF-8"?>
+<coupon href="https://api.recurly.com/v2/coupons/itemcouponmock">
+  <coupon_code>itemcouponmock</coupon_code>
+  <name>Item Coupon</name>
+  <state>redeemable</state>
+  <description nil="nil"></description>
+  <discount_type>percent</discount_type>
+  <discount_percent type="integer">20</discount_percent>
+  <invoice_description nil="nil"></invoice_description>
+  <redeem_by_date nil="nil"></redeem_by_date>
+  <single_use type="boolean">false</single_use>
+  <applies_for_months nil="nil"></applies_for_months>
+  <max_redemptions nil="nil"></max_redemptions>
+  <applies_to_all_plans type="boolean">true</applies_to_all_plans>
+  <applies_to_all_items type="boolean">false</applies_to_all_items>
+  <created_at type="datetime">2020-10-27T21:05:58Z</created_at>
+  <updated_at type="datetime">2020-10-27T21:05:58Z</updated_at>
+  <deleted_at nil="nil"></deleted_at>
+  <duration>forever</duration>
+  <temporal_unit nil="nil"></temporal_unit>
+  <temporal_amount nil="nil"></temporal_amount>
+  <applies_to_non_plan_charges type="boolean">false</applies_to_non_plan_charges>
+  <redemption_resource>account</redemption_resource>
+  <max_redemptions_per_account type="integer">50</max_redemptions_per_account>
+  <coupon_type>single_code</coupon_type>
+  <id type="integer">3129494014099465742</id>
+  <plan_codes type="array">
+  </plan_codes>
+  <item_codes type="array">
+    <item_code>newitem</item_code>
+  </item_codes>
+  <a name="redeem" href="https://api.recurly.com/v2/coupons/itemcouponmock/redeem" method="put"/>
+</coupon>

--- a/tests/fixtures/coupon/item-coupon-deleted.xml
+++ b/tests/fixtures/coupon/item-coupon-deleted.xml
@@ -1,0 +1,8 @@
+DELETE https://api.recurly.com/v2/coupons/itemcouponmock HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 204 No Content

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -964,6 +964,23 @@ class TestResources(RecurlyTest):
                 with self.mock_request('coupon/plan-deleted.xml'):
                     plan.delete()
 
+            try:
+                item_coupon = Coupon(
+                  coupon_code='itemcoupon%s' %self.test_id,
+                  name='Item Coupon',
+                  discount_type='dollars',
+                  discount_in_cents=Money(2000),
+                  item_codes=('newitem',),
+                )
+                with self.mock_request('coupon/item-coupon-created.xml'):
+                  item_coupon.save()
+                coupon_items = list(item_coupon.item_codes)
+                self.assertEqual(len(coupon_items), 1)
+                self.assertEqual(coupon_items[0], 'newitem')
+            finally:
+              with self.mock_request('coupon/item-coupon-deleted.xml'):
+                item_coupon.delete()
+
         finally:
             with self.mock_request('coupon/deleted.xml'):
                 coupon.delete()


### PR DESCRIPTION
Add `item_codes` and `applies_to_all_items` to Coupon

Example
```python
coupon = recurly.Coupon(
  coupon_code = 'special'
)
coupon.name = 'Special'
coupon.discount_type = 'percent'
coupon.discount_percent = 20
# `applies_to_all_items` defaults to false, so next line is optional
coupon.applies_to_all_items = False
coupon.item_codes = ['one_item', 'two_item']
coupon.save()
```