### PR TITLE
Release 2.9.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## Version 2.9.22 - November 5, 2020 ##
+
+- Support item-specific coupons [PR](https://github.com/recurly/recurly-client-python/pull/459)
+
 ## Version 2.9.21 - October 5, 2020 ##
 
 - Fixed issue with RFC 2616 compliance: field names are case-insensitive [PR](https://github.com/recurly/recurly-client-python/pull/440)

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -22,7 +22,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.21'
+__version__ = '2.9.22'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {


### PR DESCRIPTION
- Bump to Python client library version 2.9.22
- Update changelog
------
Support item-specific coupons https://github.com/recurly/recurly-client-python/pull/459