### PR TITLE
Expose response fields and add field to test fixture

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -1604,6 +1604,8 @@ class AddOn(Resource):
     attributes = (
         'add_on_code',
         'item_code',
+        'item_state',
+        'external_sku',
         'name',
         'display_quantity_on_hosted_page',
         'display_quantity',

--- a/tests/fixtures/billing-info/account-iban-created.xml
+++ b/tests/fixtures/billing-info/account-iban-created.xml
@@ -22,6 +22,7 @@ Location: https://api.recurly.com/v2/accounts/binfo-mock-4
 <?xml version="1.0" encoding="UTF-8"?>
 <account href="https://api.recurly.com/v2/accounts/binfo-mock-4">
   <adjustments href="https://api.recurly.com/v2/accounts/binfo-mock-4/adjustments"/>
+  <billing_info href="https://api.recurly.com/v2/accounts/binfo-mock-4//billing_info"/>
   <invoices href="https://api.recurly.com/v2/accounts/binfo-mock-4/invoices"/>
   <subscriptions href="https://api.recurly.com/v2/accounts/binfo-mock-4/subscriptions"/>
   <transactions href="https://api.recurly.com/v2/accounts/binfo-mock-4/transactions"/>


### PR DESCRIPTION
- Because `item_state` and `external_sku` are included in the xml response for item-based add-ons, it would be good practice to expose this fields to the programmer.
- Included billing_info link in mock xml response for account 