### PR TITLE
Release 2.9.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## Version 2.9.23 - November 23, 2020 ##
+
+- Expose response fields and add field to test fixture [PR](https://github.com/recurly/recurly-client-python/pull/464)
+- Update readme with memo about headers [PR](https://github.com/recurly/recurly-client-python/pull/466)
+
 ## Version 2.9.22 - November 5, 2020 ##
 
 - Support item-specific coupons [PR](https://github.com/recurly/recurly-client-python/pull/459)

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -22,7 +22,7 @@ https://dev.recurly.com/docs/getting-started
 
 """
 
-__version__ = '2.9.22'
+__version__ = '2.9.23'
 __python_version__ = '.'.join(map(str, sys.version_info[:3]))
 
 cached_rate_limits = {


### PR DESCRIPTION
- Bump Python client library version to 2.9.23
- Update changelog

-----

- Expose response fields and add field to test fixture https://github.com/recurly/recurly-client-python/pull/464
- Update readme with memo about headers https://github.com/recurly/recurly-client-python/pull/466
