### PR TITLE
Expose fraud attribute in BillingInfo class

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -386,6 +386,13 @@ class Account(Resource):
         url = urljoin(self._url, '/shipping_addresses')
         return shipping_address.post(url)
 
+class BillingInfoFraudInfo(recurly.Resource):
+    node_name = 'fraud'
+    attributes = (
+        'score',
+        'decision',
+    )
+
 class BillingInfo(Resource):
 
     """A set of billing information for an account."""
@@ -437,10 +444,14 @@ class BillingInfo(Resource):
         'sort_code',
         'bsb_code',
         'tax_identifier',
-        'tax_identifier_type'
+        'tax_identifier_type',
+        'fraud'
     )
     sensitive_attributes = ('number', 'verification_value', 'account_number', 'iban')
     xml_attribute_attributes = ('type',)
+    _classes_for_nodename = {
+        'fraud': BillingInfoFraudInfo,
+    }
 
     # Allows user to call verify() on billing_info object
     # References Account#verify

--- a/tests/fixtures/billing-info/created.xml
+++ b/tests/fixtures/billing-info/created.xml
@@ -45,4 +45,8 @@ Location: https://api.recurly.com/v2/accounts/binfomock/billing_info
   <currency>USD</currency>
   <gateway_token>gatewaytoken123</gateway_token>
   <gateway_code>gatewaycode123</gateway_code>
+  <fraud>
+    <score type="integer">87</score>
+    <decision>DECLINED</decision>
+  </fraud>
 </billing_info>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -556,6 +556,8 @@ class TestResources(RecurlyTest):
 
             self.assertEqual(binfo.gateway_token, 'gatewaytoken123')
             self.assertEqual(binfo.gateway_code, 'gatewaycode123')
+            self.assertEqual(binfo.fraud.score, 87)
+            self.assertEqual(binfo.fraud.decision, 'DECLINED')
 
             logger.removeHandler(log_handler)
             log_content = log_content.getvalue()


### PR DESCRIPTION
Allows users to parse fraud information.

Example: 
```python
billing_info.fraud.decision // 'DECLINED'
```