### PR TITLE
Release 4.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.9.0
+current_version = 4.0.0
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)
@@ -11,4 +11,3 @@ serialize =
 [bumpversion:file:docs/README.md]
 parse = (?P<major>\d+)\.(?P<minor>\d+)
 serialize = {major}.{minor}
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This library is the official python client for Recurly's V3 API.
 
 We recommend specifying this dependency in your requirements.txt:
 ```
-recurly~=3.9
+recurly~=4.0
 ```
 
 Or installing via the command line:

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -6,7 +6,7 @@ import glob
 import ssl
 import sys
 
-__version__ = "3.9.0"
+__version__ = "4.0.0"
 __python_version__ = ".".join(map(str, sys.version_info[:3]))
 
 USER_AGENT = "Recurly/{}; python {}; {}".format(


### PR DESCRIPTION
# Changelog

## [Unreleased](https://github.com/recurly/recurly-client-python/tree/HEAD)

[Full Changelog](https://github.com/recurly/recurly-client-python/compare/3.15.0...HEAD)

# Major Version Release

The 4.x major version of the client pairs with the `v2021-02-25` API version. This version of the client and the API contain breaking changes that should be considered before upgrading your integration.

## Breaking Changes in the API
All changes to the core API are documented in the [Developer Portal changelog](https://developers.recurly.com/api/changelog.html#v2021-02-25---current-ga-version)

## Breaking Changes in Client

- Add `**options`` kwargs to every operation [[#420](https://github.com/recurly/recurly-client-python/pull/420)]
- Require query params be passed in as a dict to the `params` kwarg [[#420](https://github.com/recurly/recurly-client-python/pull/420)]
- Add support for `headers` kwarg [[#420](https://github.com/recurly/recurly-client-python/pull/420)]
- Add validation to ensure only allowed options are passed to operations [[#430](https://github.com/recurly/recurly-client-python/pull/430)]
- Preserve internal headers that should not be overridden by optional headers [[#430](https://github.com/recurly/recurly-client-python/pull/430)]

**Merged pull requests:**

- Updating changelog script and changelog generator config for 4.x release [\#475](https://github.com/recurly/recurly-client-python/pull/475) ([douglasmiller](https://github.com/douglasmiller))
- Adding options validation and preserving internal headers [\#430](https://github.com/recurly/recurly-client-python/pull/430) ([douglasmiller](https://github.com/douglasmiller))
- Add \*\*options kwargs to operations [\#420](https://github.com/recurly/recurly-client-python/pull/420) ([bhelx](https://github.com/bhelx))