### PR TITLE
Ignoring 'internal' tags in changelog generation

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,7 +1,7 @@
 user=recurly
 project=recurly-client-python
 unreleased=false
-exclude-labels=question,bug?,duplicate,V2
+exclude-labels=internal,question,bug?,duplicate,V2
 exclude-tags-regex=^[^3]+\..*
 issues-wo-labels=false
 verbose=false


### PR DESCRIPTION
Internal only update to ignore issues and pull requests with the `internal` label from changelog generation.