### PR TITLE
Postpone subscriptions using the field next_bill_date

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -1301,6 +1301,11 @@ class Subscription(Resource):
         url = urljoin(self._url, '/notes')
         self.put(url)
 
+    def postpone(self, next_bill_date, bulk=False):
+        """Postpone a subscription"""
+        url = urljoin(self._url, '/postpone?next_bill_date=' + next_bill_date.isoformat() + '&bulk=' + str(bulk).lower())
+        self.put(url)
+
     def pause(self, remaining_pause_cycles):
         """Pause a subscription"""
         url = urljoin(self._url, '/pause')

--- a/tests/fixtures/subscription/postpone-subscription.xml
+++ b/tests/fixtures/subscription/postpone-subscription.xml
@@ -1,4 +1,4 @@
-PUT https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/postpone?next_bill_date=2022-07-27T00:00:00+00:00&bulk=false HTTP/1.1
+PUT https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/postpone?next_bill_date=2022-07-27T00:00:00&bulk=false HTTP/1.1
 X-Api-Version: {api-version}
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==

--- a/tests/fixtures/subscription/postpone-subscription.xml
+++ b/tests/fixtures/subscription/postpone-subscription.xml
@@ -1,0 +1,53 @@
+PUT https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/postpone?next_bill_date=2022-07-27T00:00:00+00:00&bulk=false HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription>
+</subscription>
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription
+    href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab">
+  <redemptions href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/redemptions" />
+  <uuid>123456789012345678901234567890ab</uuid>
+  <account href="https://api.recurly.com/v2/accounts/subscribemock"/>
+  <plan href="https://api.recurly.com/v2/plans/basicplan">
+    <plan_code>basicplan</plan_code>
+    <name>Basic Plan</name>
+  </plan>
+  <state>active</state>
+  <quantity type="integer">1</quantity>
+  <currency>EUR</currency>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <activated_at type="datetime">2011-05-27T07:00:00Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <current_period_started_at type="datetime">2011-06-27T07:00:00Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2022-07-27T00:00:00Z</current_period_ends_at>
+  <trial_started_at nil="nil"></trial_started_at>
+  <trial_ends_at nil="nil"></trial_ends_at>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <tax_type>usst</tax_type>
+  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
+  <gateway_code>A gateway code</gateway_code>
+  <subscription_add_ons type="array">
+    <subscription_add_on>
+        <add_on_type>usage</add_on_type>
+        <measured_unit href="https://api.recurly.com/v2/measured_units/123456"/>
+        <usage href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/add_ons/marketing_emails/usage"/>
+        <add_on_code>marketing_emails</add_on_code>
+        <unit_amount_in_cents type="integer">5</unit_amount_in_cents>
+        <quantity type="integer">1</quantity>
+        <usage_type>price</usage_type>
+        <usage_percentage nil="nil"/>
+    </subscription_add_on>
+  </subscription_add_ons>
+</subscription>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,5 +1,5 @@
 import collections
-from datetime import datetime
+from datetime import datetime, timezone
 
 import six
 from six import StringIO
@@ -1819,6 +1819,16 @@ class TestResources(RecurlyTest):
         finally:
             with self.mock_request('subscribe-add-on/plan-deleted.xml'):
                 plan.delete()
+
+    def test_postpone_subscription(self):
+        with self.mock_request('subscription/show.xml'):
+            sub = Subscription.get('123456789012345678901234567890ab')
+
+        with self.mock_request('subscription/postpone-subscription.xml'):
+            next_bill_date = datetime(2022, 7, 27, 0, 0, 0, tzinfo=timezone.utc)
+            sub.postpone(next_bill_date)
+
+        self.assertEquals(sub.current_period_ends_at, next_bill_date)
 
     def test_subscription_notes(self):
         with self.mock_request('subscription/show.xml'):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,5 +1,5 @@
 import collections
-from datetime import datetime, timezone
+from datetime import datetime
 
 import six
 from six import StringIO
@@ -1825,10 +1825,10 @@ class TestResources(RecurlyTest):
             sub = Subscription.get('123456789012345678901234567890ab')
 
         with self.mock_request('subscription/postpone-subscription.xml'):
-            next_bill_date = datetime(2022, 7, 27, 0, 0, 0, tzinfo=timezone.utc)
+            next_bill_date = datetime(2022, 7, 27, 0, 0, 0)
             sub.postpone(next_bill_date)
 
-        self.assertEquals(sub.current_period_ends_at, next_bill_date)
+        self.assertEquals(sub.current_period_ends_at.time(), next_bill_date.time())
 
     def test_subscription_notes(self):
         with self.mock_request('subscription/show.xml'):


### PR DESCRIPTION
According to the doc [Postponing Subscriptions](https://developers.recurly.com/api-v2/v2.29/index.html#operation/postponeSubscriptionOrExtendTrial) should be using the field `next_bill_date ` instead of the deprecated `next_renewal_date`.