### PR TITLE
Add tax_type and tax_region to TaxDetail

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -831,7 +831,6 @@ class Invoice(Resource):
         'tax_in_cents',
         'tax_type',
         'tax_rate',
-        'tax_details',
         'total_in_cents',
         'currency',
         'created_at',

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -831,6 +831,7 @@ class Invoice(Resource):
         'tax_in_cents',
         'tax_type',
         'tax_rate',
+        'tax_details',
         'total_in_cents',
         'currency',
         'created_at',

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -733,6 +733,8 @@ class TaxDetail(Resource):
     attributes = (
         'name',
         'type',
+        'level',
+        'billable',
         'tax_rate',
         'tax_in_cents',
         'tax_type',

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -727,7 +727,7 @@ class TaxDetail(Resource):
 
     """A charge's tax breakdown"""
 
-    nodename = 'taxdetail'
+    nodename = 'tax_detail'
     inherits_currency = True
 
     attributes = (
@@ -735,12 +735,14 @@ class TaxDetail(Resource):
         'type',
         'tax_rate',
         'tax_in_cents',
+        'tax_type',
+        'tax_region'
     )
 
 class Item(Resource):
 
     """An item for a customer to apply to their account."""
-    
+
     member_path = 'items/%s'
     collection_path = 'items'
     nodename = 'item'
@@ -1335,7 +1337,7 @@ class Subscription(Resource):
         transaction_type = ElementTreeBuilder.SubElement(request, 'transaction_type')
         transaction_type.text = "moto"
         body = ElementTree.tostring(request, encoding='UTF-8')
-        
+
         response = self.http_request(url, 'PUT', body, { 'content-type':
             'application/xml; charset=utf-8' })
 

--- a/tests/fixtures/invoice/show-invoice.xml
+++ b/tests/fixtures/invoice/show-invoice.xml
@@ -27,6 +27,14 @@ Location: https://api.recurly.com/v2/invoices/6019
   <invoice_number type="integer">6019</invoice_number>
   <vat_number nil="nil"></vat_number>
   <tax_in_cents type="integer">0</tax_in_cents>
+  <tax_details type="array">
+    <tax_detail>
+      <tax_type>GST</tax_type>
+      <tax_region>CA</tax_region>
+      <tax_rate type="float">0.05</tax_rate>
+      <tax_in_cents type="integer">20</tax_in_cents>
+    </tax_detail>
+  </tax_details>
   <total_in_cents type="integer">5000</total_in_cents>
   <currency>USD</currency>
   <created_at type="datetime">2018-07-13T17:13:57Z</created_at>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -529,7 +529,7 @@ class TestResources(RecurlyTest):
                     recurly.Tier(
                         unit_amount_in_cents = recurly.Money(USD=800)
                     )
-                ]  
+                ]
             )
             with self.mock_request('add-on/created-tiered.xml'):
                 plan.create_add_on(add_on)
@@ -629,7 +629,7 @@ class TestResources(RecurlyTest):
             # See if we redacted our sensitive fields properly.
             self.assertTrue('4111' not in log_content)
             self.assertTrue('7777' not in log_content)
-              
+
             with self.mock_request('billing-info/account-exists.xml'):
                 same_account = Account.get('binfo%s' % self.test_id)
             with self.mock_request('billing-info/exists.xml'):
@@ -1134,11 +1134,22 @@ class TestResources(RecurlyTest):
 
     def test_invoice_collect(self):
         with self.mock_request('invoice/show-invoice.xml'):
-            invoice = Invoice.get("6019")      
+            invoice = Invoice.get("6019")
 
         with self.mock_request('invoice/collect-invoice.xml'):
             collection = invoice.force_collect()
             self.assertIsInstance(collection, InvoiceCollection)
+
+    def test_invoice_tax_details(self):
+        with self.mock_request('invoice/show-invoice.xml'):
+            invoice = Invoice.get("6019")
+
+        self.assertEqual(len(invoice.tax_details), 1)
+        tax_detail = invoice.tax_details[0]
+        self.assertEqual(tax_detail.tax_type, 'GST')
+        self.assertEqual(tax_detail.tax_region, 'CA')
+        self.assertEqual(tax_detail.tax_rate, 0.05)
+        self.assertEqual(tax_detail.tax_in_cents, 20)
 
     def test_invoice_with_optionals(self):
         account = Account(account_code='invoice%s' % self.test_id)
@@ -1648,18 +1659,18 @@ class TestResources(RecurlyTest):
     def test_subscription_convert_trial(self):
         with self.mock_request('subscription/show-trial.xml'):
             sub = Subscription.get('123456789012345678901234567890ab')
-        
+
         with self.mock_request('subscription/convert-trial.xml'):
             sub.convert_trial()
-        self.assertEqual(sub.trial_ends_at, sub.current_period_started_at)   
+        self.assertEqual(sub.trial_ends_at, sub.current_period_started_at)
 
         with self.mock_request('subscription/convert-trial-3ds.xml'):
             sub.convert_trial("token")
-        self.assertEqual(sub.trial_ends_at, sub.current_period_started_at)   
+        self.assertEqual(sub.trial_ends_at, sub.current_period_started_at)
 
         with self.mock_request('subscription/convert-trial-moto.xml'):
             sub.convert_trial_moto()
-        self.assertEqual(sub.trial_ends_at, sub.current_period_started_at)            
+        self.assertEqual(sub.trial_ends_at, sub.current_period_started_at)
 
     def test_usage(self):
         usage = Usage()
@@ -1743,7 +1754,7 @@ class TestResources(RecurlyTest):
                 recurly.Tier(
                   unit_amount_in_cents = recurly.Money(USD=800)
                 )
-              ]  
+              ]
             )
 
             with self.mock_request('subscribe-add-on/tiered-add-on-created.xml'):


### PR DESCRIPTION
Add `tax_type` and `tax_region` to `TaxDetail` class.  Also add previously missing `level` and `billable` fields.