### PR TITLE
Generated Latest Changes for v2019-10-10 (get_preview_renewal)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12405,6 +12405,43 @@ paths:
               schema:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
+  "/sites/{site_id}/subscriptions/{subscription_id}/preview_renewal":
+    get:
+      tags:
+      - subscription
+      operationId: get_preview_renewal
+      summary: Fetch a preview of a subscription's renewal invoice(s)
+      description: The subscriptions's renewal invoice(s) will be returned if they
+        exist; if they don't (for example, if the subscription is not set to renew),
+        it will return an result with no invoices.
+      parameters:
+      - "$ref": "#/components/parameters/subscription_id"
+      responses:
+        '200':
+          description: A preview of the subscription's renewal invoice(s).
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/InvoiceCollection"
+        '400':
+          description: Invalid or unpermitted parameter.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site ID or subscription ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples: []
   "/sites/{site_id}/subscriptions/{subscription_id}/change":
     get:
       tags:
@@ -20568,7 +20605,8 @@ components:
         remaining_pause_cycles:
           type: integer
           title: Remaining pause cycles
-          description: Number of billing cycles to pause the subscriptions.
+          description: Number of billing cycles to pause the subscriptions. A value
+            of 0 will cancel any pending pauses on the subscription.
       required:
       - remaining_pause_cycles
     SubscriptionShipping:

--- a/recurly/client.py
+++ b/recurly/client.py
@@ -3164,6 +3164,30 @@ class Client(BaseClient):
         )
         return self._make_request("PUT", path, None, None)
 
+    def get_preview_renewal(self, subscription_id):
+        """Fetch a preview of a subscription's renewal invoice(s)
+
+        Parameters
+        ----------
+
+        subscription_id : str
+            Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.
+
+        Keyword Arguments
+        -----------------
+
+
+        Returns
+        -------
+
+        InvoiceCollection
+            A preview of the subscription's renewal invoice(s).
+        """
+        path = self._interpolate_path(
+            "/subscriptions/%s/preview_renewal", subscription_id
+        )
+        return self._make_request("GET", path, None, None)
+
     def get_subscription_change(self, subscription_id):
         """Fetch a subscription's pending change
 


### PR DESCRIPTION
* Adds new endpoint GET /sites/:site_id/subscriptions/:id/preview_renewal which returns a preview of the subscription's renewal invoice(s)