### PR TITLE
Generated Latest Changes for v2021-02-25 (Support to new subscription fields and response)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12611,7 +12611,16 @@ paths:
       - subscription_change
       operationId: create_subscription_change
       summary: Create a new subscription change
-      description: Calling this will overwrite an existing, pending subscription change.
+      description: |
+        Calling this will overwrite an existing, pending subscription change.
+
+        If a subscription has a pending change, and a change is submitted which matches
+        the subscription as it currently exists, the pending change will be deleted,
+        and you will receive a 204 No Content response.
+
+        If a subscription has no pending
+        change, and a change is submitted which matches the subscription as it currently
+        exists, a 422 Unprocessable Entity validation error will be returned.
       parameters:
       - "$ref": "#/components/parameters/subscription_id"
       requestBody:
@@ -12627,6 +12636,8 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/SubscriptionChange"
+        '204':
+          description: The previous pending change was reverted.
         '404':
           description: Incorrect site ID.
           content:
@@ -19443,6 +19454,16 @@ components:
           format: float
           title: Estimated total, before tax.
           minimum: 0
+        tax:
+          type: number
+          format: float
+          title: Estimated tax
+        tax_info:
+          "$ref": "#/components/schemas/TaxInfo"
+        total:
+          type: number
+          format: float
+          title: Estimated total
         collection_method:
           title: Collection method
           default: automatic
@@ -19502,6 +19523,12 @@ components:
             set. This timestamp is used for alerting customers to reauthorize in 3
             years in accordance with NACHA rules. If a subscription becomes inactive
             or the billing info is no longer a bank account, this timestamp is cleared.
+        gateway_code:
+          type: string
+          title: Gateway Code
+          description: If present, this subscription's transactions will use the payment
+            gateway with this code.
+          maxLength: 13
         billing_info_id:
           type: string
           title: Billing Info ID
@@ -19956,6 +19983,13 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+        address_id:
+          type: string
+          titpe: Shipping address ID
+          description: Assign a shipping address from the account's existing shipping
+            addresses. If this and address are both present, address will take precedence.
+        address:
+          "$ref": "#/components/schemas/ShippingAddressCreate"
     SubscriptionCreate:
       type: object
       properties:
@@ -20264,6 +20298,12 @@ components:
             at 31 days exactly.
           minimum: 0
           default: 0
+        gateway_code:
+          type: string
+          title: Gateway Code
+          description: If present, this subscription's transactions will use the payment
+            gateway with this code.
+          maxLength: 13
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -1528,6 +1528,8 @@ class Subscription(Resource):
         Expiration reason
     expires_at : datetime
         Expires at
+    gateway_code : str
+        If present, this subscription's transactions will use the payment gateway with this code.
     id : str
         Subscription ID
     net_terms : int
@@ -1558,8 +1560,14 @@ class Subscription(Resource):
         State
     subtotal : float
         Estimated total, before tax.
+    tax : float
+        Estimated tax
+    tax_info : TaxInfo
+        Tax info
     terms_and_conditions : str
         Terms and conditions
+    total : float
+        Estimated total
     total_billing_cycles : int
         The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.
     trial_ends_at : datetime
@@ -1595,6 +1603,7 @@ class Subscription(Resource):
         "customer_notes": str,
         "expiration_reason": str,
         "expires_at": datetime,
+        "gateway_code": str,
         "id": str,
         "net_terms": int,
         "object": str,
@@ -1610,7 +1619,10 @@ class Subscription(Resource):
         "shipping": "SubscriptionShipping",
         "state": str,
         "subtotal": float,
+        "tax": float,
+        "tax_info": "TaxInfo",
         "terms_and_conditions": str,
+        "total": float,
         "total_billing_cycles": int,
         "trial_ends_at": datetime,
         "trial_started_at": datetime,


### PR DESCRIPTION
Generated Latest Changes for v2021-02-25

SubscriptionCreate request format has changed:
* Added `gateway_code`.

SubscriptionUpdate request format has changed:
* Added `gateway_code`.

Subscription response format has changed:
* Added `gateway_code`.

SubscriptionChangeShippingCreate request format has changed:
* Added `address`.
* Added `address_id`.

Added tax information to `Subscription` response
* Added the fields `tax`, `tax_info` and `total`.

Updated the response for `POST /subscriptions/{subscription_id}/change`.
* Responding with `204 No Content` when the subscription has a pending change, and a change is submitted which matches the subscription as it currently exists.