### PR TITLE
Generated Latest Changes for v2019-10-10 (Tax Inclusive Pricing)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14525,7 +14525,8 @@ components:
     billing_info_id:
       name: billing_info_id
       in: path
-      description: Billing Info ID.
+      description: Billing Info ID. Can ONLY be used for sites utilizing the Wallet
+        feature.
       required: true
       schema:
         type: string
@@ -17683,7 +17684,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         subscription_ids:
           type: array
           title: Subscription IDs
@@ -17939,7 +17941,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     InvoiceCollection:
       type: object
       title: Invoice collection
@@ -18551,6 +18554,13 @@ components:
             A positive or negative amount with `type=credit` will result in a negative `unit_amount`.
             If `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the `Item`'s
             `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required.
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -19113,6 +19123,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
     PlanUpdate:
       type: object
       properties:
@@ -19274,6 +19291,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -19291,6 +19315,13 @@ components:
           title: Unit price
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
       required:
       - currency
       - unit_amount
@@ -20248,6 +20279,13 @@ components:
           type: number
           format: float
           title: Unit amount
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Subscription quantity
@@ -20353,6 +20391,13 @@ components:
             be used.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20485,7 +20530,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         shipping:
           title: Shipping address
           description: Create a shipping address on the account and assign it to the
@@ -20512,6 +20558,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20649,6 +20702,13 @@ components:
             the subscription plan for the provided currency.
           minimum: 0
           maximum: 1000000
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         quantity:
           type: integer
           title: Quantity
@@ -20792,6 +20852,13 @@ components:
             at 31 days exactly.
           minimum: 0
           default: 0
+        tax_inclusive:
+          type: boolean
+          title: Tax Inclusive?
+          default: false
+          description: Determines whether or not tax is included in the unit amount.
+            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
+            feature) must be enabled to use this flag.
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
         billing_info_id:
@@ -20800,7 +20867,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
     SubscriptionPause:
       type: object
       properties:
@@ -21469,7 +21537,8 @@ components:
           description: The `billing_info_id` is the value that represents a specific
             billing info for an end customer. When `billing_info_id` is used to assign
             billing info to the subscription, all future billing events for the subscription
-            will bill to the specified billing info.
+            will bill to the specified billing info. `billing_info_id` can ONLY be
+            used for sites utilizing the Wallet feature.
         collection_method:
           type: string
           title: Collection method

--- a/recurly/client.py
+++ b/recurly/client.py
@@ -492,7 +492,7 @@ class Client(BaseClient):
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
         billing_info_id : str
-            Billing Info ID.
+            Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
 
         Keyword Arguments
         -----------------
@@ -518,7 +518,7 @@ class Client(BaseClient):
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
         billing_info_id : str
-            Billing Info ID.
+            Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
         body : dict
             The request body. It should follow the schema of BillingInfoCreate.
 
@@ -546,7 +546,7 @@ class Client(BaseClient):
         account_id : str
             Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.
         billing_info_id : str
-            Billing Info ID.
+            Billing Info ID. Can ONLY be used for sites utilizing the Wallet feature.
 
         Keyword Arguments
         -----------------

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -1051,7 +1051,7 @@ class Invoice(Resource):
     balance : float
         The outstanding balance remaining on this invoice.
     billing_info_id : str
-        The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info.
+        The `billing_info_id` is the value that represents a specific billing info for an end customer. When `billing_info_id` is used to assign billing info to the subscription, all future billing events for the subscription will bill to the specified billing info. `billing_info_id` can ONLY be used for sites utilizing the Wallet feature.
     closed_at : datetime
         Date invoice was marked paid or failed.
     collection_method : str
@@ -1745,6 +1745,8 @@ class SubscriptionChange(Resource):
         Subscription shipping details
     subscription_id : str
         The ID of the subscription that is going to be changed.
+    tax_inclusive : bool
+        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
     unit_amount : float
         Unit amount
     updated_at : datetime
@@ -1768,6 +1770,7 @@ class SubscriptionChange(Resource):
         "setup_fee_revenue_schedule_type": str,
         "shipping": "SubscriptionShipping",
         "subscription_id": str,
+        "tax_inclusive": bool,
         "unit_amount": float,
         "updated_at": datetime,
     }
@@ -2050,11 +2053,13 @@ class Pricing(Resource):
     ----------
     currency : str
         3-letter ISO 4217 currency code.
+    tax_inclusive : bool
+        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
     unit_amount : float
         Unit price
     """
 
-    schema = {"currency": str, "unit_amount": float}
+    schema = {"currency": str, "tax_inclusive": bool, "unit_amount": float}
 
 
 class MeasuredUnit(Resource):
@@ -2208,11 +2213,18 @@ class PlanPricing(Resource):
         3-letter ISO 4217 currency code.
     setup_fee : float
         Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
+    tax_inclusive : bool
+        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
     unit_amount : float
         Unit price
     """
 
-    schema = {"currency": str, "setup_fee": float, "unit_amount": float}
+    schema = {
+        "currency": str,
+        "setup_fee": float,
+        "tax_inclusive": bool,
+        "unit_amount": float,
+    }
 
 
 class PlanHostedPages(Resource):
@@ -2331,11 +2343,13 @@ class AddOnPricing(Resource):
     ----------
     currency : str
         3-letter ISO 4217 currency code.
+    tax_inclusive : bool
+        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
     unit_amount : float
         Unit price
     """
 
-    schema = {"currency": str, "unit_amount": float}
+    schema = {"currency": str, "tax_inclusive": bool, "unit_amount": float}
 
 
 class Tier(Resource):
@@ -2434,6 +2448,8 @@ class SubscriptionChangePreview(Resource):
         Subscription shipping details
     subscription_id : str
         The ID of the subscription that is going to be changed.
+    tax_inclusive : bool
+        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
     unit_amount : float
         Unit amount
     updated_at : datetime
@@ -2457,6 +2473,7 @@ class SubscriptionChangePreview(Resource):
         "setup_fee_revenue_schedule_type": str,
         "shipping": "SubscriptionShipping",
         "subscription_id": str,
+        "tax_inclusive": bool,
         "unit_amount": float,
         "updated_at": datetime,
     }


### PR DESCRIPTION
Adds to description of `billing_info_id`.
Adds support for **Tax Inclusive Pricing** feature of Recurly API.

Adds `tax_inclusive` bool to the following resources:
- SubscriptionChange
- Pricing
- PlanPricing
- AddOnPricing
- SubscriptionChangePreview
