### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -232,7 +232,7 @@ tags:
   description: |-
     For merchants who sell the same things to many customers, documenting those offerings in a catalog allows for faster charge creation, easier management of offerings, and analytics about your offerings across all sales channels. Because your offerings can be physical, digital, or service-oriented, Recurly collectively calls these offerings "Items".
 
-    Recurly's item catalog requires the Credit Invoices and Subscription Billing Terms features to be enabled.
+    Recurly's item catalog requires the Credit Invoices features to be enabled.
 - name: plan
   x-displayName: Plan
   description: A plan tells Recurly how often and how much to charge your customers.
@@ -15540,6 +15540,8 @@ components:
           "$ref": "#/components/schemas/BillingInfo"
         custom_fields:
           "$ref": "#/components/schemas/CustomFields"
+        invoice_template:
+          "$ref": "#/components/schemas/AccountInvoiceTemplate"
     AccountNote:
       type: object
       required:
@@ -15636,6 +15638,20 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+    AccountInvoiceTemplate:
+      type: object
+      title: Invoice Template
+      description: Invoice template associated to the account. Available when invoice
+        customization flag is enabled.
+      properties:
+        id:
+          type: string
+          title: ID
+          description: Unique ID to identify the invoice template.
+        name:
+          type: string
+          title: Name
+          description: Template name
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -15900,16 +15916,16 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the `Credit
-            Invoices` and `Subscription Billing Terms` features are enabled. If `item_id`
-            and `item_code` are both present, `item_id` will be used.
+            Invoices` feature are enabled. If `item_id` and `item_code` are both present,
+            `item_id` will be used.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the `Credit Invoices` and `Subscription Billing Terms` features are enabled.
-            If `item_id` and `item_code` are both present, `item_id` will be used.
+            the `Credit Invoices` feature is enabled. If `item_id` and `item_code`
+            are both present, `item_id` will be used.
           maxLength: 13
         code:
           type: string
@@ -17888,20 +17904,20 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the Credit
-            Invoices and Subscription Billing Terms features are enabled.
+            Invoices feature is enabled.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the Credit Invoices and Subscription Billing Terms features are enabled.
+            the Credit Invoices feature is enabled.
           maxLength: 13
         external_sku:
           type: string
           title: External SKU
           description: Optional Stock Keeping Unit assigned to an item. Available
-            when the Credit Invoices and Subscription Billing Terms features are enabled.
+            when the Credit Invoices feature is enabled.
           maxLength: 50
         revenue_schedule_type:
           title: Revenue schedule type
@@ -18204,14 +18220,14 @@ components:
           type: string
           title: Item Code
           description: Unique code to identify an item. Available when the Credit
-            Invoices and Subscription Billing Terms features are enabled.
+            Invoices feature is enabled.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 50
         item_id:
           type: string
           title: Item ID
           description: System-generated unique identifier for an item. Available when
-            the Credit Invoices and Subscription Billing Terms features are enabled.
+            the Credit Invoices feature is enabled.
           maxLength: 13
         revenue_schedule_type:
           title: Revenue schedule type
@@ -22160,9 +22176,10 @@ components:
     AchTypeEnum:
       type: string
       description: The payment method type for a non-credit card based billing info.
-        The value of `bacs` is the only accepted value (Bacs only)
+        `bacs` and `becs` are the only accepted values.
       enum:
       - bacs
+      - becs
     AchAccountTypeEnum:
       type: string
       description: The bank account type. (ACH only)

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -155,6 +155,8 @@ class Account(Resource):
     hosted_login_token : str
         The unique token for automatically logging the account in to the hosted management pages. You may automatically log the user into their hosted management pages by directing the user to: `https://{subdomain}.recurly.com/account/{hosted_login_token}`.
     id : str
+    invoice_template : AccountInvoiceTemplate
+        Invoice template associated to the account. Available when invoice customization flag is enabled.
     last_name : str
     object : str
         Object type
@@ -198,6 +200,7 @@ class Account(Resource):
         "has_paused_subscription": bool,
         "hosted_login_token": str,
         "id": str,
+        "invoice_template": "AccountInvoiceTemplate",
         "last_name": str,
         "object": str,
         "parent_account_id": str,
@@ -407,6 +410,19 @@ class CustomField(Resource):
     """
 
     schema = {"name": str, "value": str}
+
+
+class AccountInvoiceTemplate(Resource):
+    """
+    Attributes
+    ----------
+    id : str
+        Unique ID to identify the invoice template.
+    name : str
+        Template name
+    """
+
+    schema = {"id": str, "name": str}
 
 
 class ErrorMayHaveTransaction(Resource):
@@ -1294,7 +1310,7 @@ class LineItem(Resource):
     end_date : datetime
         If this date is provided, it indicates the end of a time range.
     external_sku : str
-        Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+        Optional Stock Keeping Unit assigned to an item. Available when the Credit Invoices feature is enabled.
     id : str
         Line item ID
     invoice_id : str
@@ -1302,9 +1318,9 @@ class LineItem(Resource):
     invoice_number : str
         Once the line item has been invoiced this will be the invoice's number. If VAT taxation and the Country Invoice Sequencing feature are enabled, invoices will have country-specific invoice numbers for invoices billed to EU countries (ex: FR1001). Non-EU invoices will continue to use the site-level invoice number sequence.
     item_code : str
-        Unique code to identify an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+        Unique code to identify an item. Available when the Credit Invoices feature is enabled.
     item_id : str
-        System-generated unique identifier for an item. Available when the Credit Invoices and Subscription Billing Terms features are enabled.
+        System-generated unique identifier for an item. Available when the Credit Invoices feature is enabled.
     legacy_category : str
         Category to describe the role of a line item on a legacy invoice:
         - "charges" refers to charges being billed for on this invoice.


### PR DESCRIPTION
Support `becs` as a payment method type for non-credit card based billing info.
- Added `becs` as a valid non-credit card payment method type.

Support `invoice_template` in account when invoice customization feature is enabled.
- Added `invoice_template` to Account.

Updated documentation for the removal of the `Subscription Billing Terms` feature flag as the feature is now fully accessible on all sites.