### PR TITLE
Add V2 invoice templates suport

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -192,6 +192,8 @@ class Account(Resource):
         'custom_fields',
         'transaction_type',
         'dunning_campaign_id',
+        'invoice_template',
+        'invoice_template_uuid',
     )
 
     _classes_for_nodename = { 'address': Address, 'custom_field': CustomField }
@@ -594,6 +596,25 @@ class DunningCycle(Resource):
         'version',
         'created_at',
         'updated_at',
+    )
+
+class InvoiceTemplate(Resource):
+
+    """An invoice template available on the site"""
+
+    member_path = 'invoice_templates/%s'
+    collection_path = 'invoice_templates'
+
+    nodename = 'invoice_template'
+
+    attributes = (
+      'uuid',
+      'code',
+      'name',
+      'description',
+      'created_at',
+      'updated_at',
+      'accounts',
     )
 
 # This is used internally for proper XML generation

--- a/tests/fixtures/invoice_templates/accounts/list.xml
+++ b/tests/fixtures/invoice_templates/accounts/list.xml
@@ -1,0 +1,28 @@
+GET https://api.recurly.com/v2/invoice_templates/q0tzf7o7fpbl/accounts HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<accounts type="array">
+  <account href="https://api.recurly.com/v2/accounts/testmock">
+    <adjustments href="https://api.recurly.com/v2/accounts/testmock/adjustments"/>
+    <billing_info href="https://api.recurly.com/v2/accounts/testmock/billing_info"/>
+    <invoices href="https://api.recurly.com/v2/accounts/testmock/invoices"/>
+    <subscriptions href="https://api.recurly.com/v2/accounts/testmock/subscriptions"/>
+    <transactions href="https://api.recurly.com/v2/accounts/testmock/transactions"/>
+    <account_code>testmock</account_code>
+    <username nil="nil"></username>
+    <email nil="nil"></email>
+    <first_name nil="nil"></first_name>
+    <last_name nil="nil"></last_name>
+    <company_name nil="nil"></company_name>
+    <accept_language nil="nil"></accept_language>
+  </account>
+</accounts>

--- a/tests/fixtures/invoice_templates/list.xml
+++ b/tests/fixtures/invoice_templates/list.xml
@@ -1,0 +1,23 @@
+GET https://api.recurly.com/v2/invoice_templates HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice_templates type="array">
+  <invoice_template href="https://api.recurly.com/v2/invoice_templates/q0tzf7o7fpbl">
+    <uuid>q0tzf7o7fpbl</uuid>
+    <name>Alternate Invoice Template</name>
+    <code>code1</code>
+    <description>Some Description</description>
+    <created_at type="datetime">2021-12-09T21:19:47Z</created_at>
+    <updated_at type="datetime">2022-01-14T13:48:24Z</updated_at>
+    <accounts href="https://api.recurly.com/v2/invoice_templates/q0tzf7o7fpbl/accounts"/>
+  </invoice_template>
+</invoice_templates>

--- a/tests/fixtures/invoice_templates/show.xml
+++ b/tests/fixtures/invoice_templates/show.xml
@@ -1,0 +1,21 @@
+GET https://api.recurly.com/v2/invoice_templates/q0tzf7o7fpbl HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice_template href="https://api.recurly.com/v2/invoice_templates/q0tzf7o7fpbl">
+  <uuid>q0tzf7o7fpbl</uuid>
+  <name>Alternate Invoice Template</name>
+  <code>code1</code>
+  <description>Some Description</description>
+  <created_at type="datetime">2021-12-09T21:19:47Z</created_at>
+  <updated_at type="datetime">2022-01-14T13:48:24Z</updated_at>
+  <accounts href="https://api.recurly.com/v2/invoice_templates/q0tzf7o7fpbl/accounts"/>
+</invoice_template>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -9,7 +9,7 @@ import recurly
 from recurly import Account, AddOn, Address, Adjustment, BillingInfo, Coupon, Item, Plan, Redemption, Subscription, \
     SubscriptionAddOn, Transaction, MeasuredUnit, Usage, GiftCard, Delivery, ShippingAddress, AccountAcquisition, \
     Purchase, Invoice, InvoiceCollection, CreditPayment, CustomField, ExportDate, ExportDateFile, DunningCampaign, \
-    DunningCycle
+    DunningCycle, InvoiceTemplate
 from recurly import Money, NotFoundError, ValidationError, BadRequestError, PageError
 from recurly import recurly_logging as logging
 from recurlytests import RecurlyTest
@@ -1067,6 +1067,30 @@ class TestResources(RecurlyTest):
         with self.mock_request('dunning-campaigns/updated.xml'):
             update = campaign.bulk_update('testmock', ['pc-967-343'])
         self.assertIsNone(update)
+
+    def test_invoice_templates(self):
+        with self.mock_request('invoice_templates/list.xml'):
+            template = InvoiceTemplate.all()[0]
+
+        self.assertEqual(template.name, 'Alternate Invoice Template')
+        self.assertEqual(template.code, 'code1')
+        self.assertEqual(template.description, 'Some Description')
+
+    def test_invoice_template(self):
+        with self.mock_request('invoice_templates/show.xml'):
+            template = InvoiceTemplate.get('q0tzf7o7fpbl')
+
+        self.assertEqual(template.name, 'Alternate Invoice Template')
+        self.assertEqual(template.code, 'code1')
+        self.assertEqual(template.description, 'Some Description')
+
+    def test_invoice_template_accounts(self):
+        with self.mock_request('invoice_templates/show.xml'):
+            template = InvoiceTemplate.get('q0tzf7o7fpbl')
+        with self.mock_request('invoice_templates/accounts/list.xml'):
+            account = template.accounts()[0]
+
+        self.assertEqual(account.account_code, 'testmock')
 
     def test_invoice(self):
         account = Account(account_code='invoice%s' % self.test_id)


### PR DESCRIPTION
* Add `InvoiceTemplate` resource
```
recurly.InvoiceTemplate.get('q0tzf7o7fpbl')
recurly.InvoiceTemplate.all()
```

* Add `invoice_template_uuid ` and `invoice_template` to `Account`
```
account = recurly.Account.get("acc"')
account. invoice_template_uuid = 'q0tzf7o7fpbl'
account.save()
account.invoice_template().code
```
