### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16265,6 +16265,8 @@ components:
           readOnly: true
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -16443,6 +16445,8 @@ components:
             * Must be absent if `add_on_type` is `usage` and `usage_type` is `percentage`.
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeCreateEnum"
         tiers:
           type: array
           title: Tiers
@@ -20059,6 +20063,13 @@ components:
           type: string
           title: Billing Info ID
           description: Billing Info ID.
+        active_invoice_id:
+          type: string
+          title: Active invoice ID
+          description: The invoice ID of the latest invoice created for an active
+            subscription.
+          maxLength: 13
+          readOnly: true
     SubscriptionAddOn:
       type: object
       title: Subscription Add-on
@@ -20098,6 +20109,8 @@ components:
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
         tier_type:
           "$ref": "#/components/schemas/TierTypeEnum"
+        usage_timeframe:
+          "$ref": "#/components/schemas/UsageTimeframeEnum"
         tiers:
           type: array
           title: Tiers
@@ -22176,6 +22189,25 @@ components:
       - tiered
       - stairstep
       - volume
+    UsageTimeframeEnum:
+      type: string
+      title: Usage Timeframe
+      description: The time at which usage totals are reset for billing purposes.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
+    UsageTimeframeCreateEnum:
+      type: string
+      title: Usage Timeframe
+      description: |
+        The time at which usage totals are reset for billing purposes.
+        Allows for `tiered` add-ons to accumulate usage over the course of multiple
+        billing periods.
+      enum:
+      - billing_period
+      - subscription_term
+      default: billing_period
     CreditPaymentActionEnum:
       type: string
       enum:

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -1501,6 +1501,8 @@ class Subscription(Resource):
         Account mini details
     activated_at : datetime
         Activated at
+    active_invoice_id : str
+        The invoice ID of the latest invoice created for an active subscription.
     add_ons : :obj:`list` of :obj:`SubscriptionAddOn`
         Add-ons
     add_ons_total : float
@@ -1594,6 +1596,7 @@ class Subscription(Resource):
     schema = {
         "account": "AccountMini",
         "activated_at": datetime,
+        "active_invoice_id": str,
         "add_ons": ["SubscriptionAddOn"],
         "add_ons_total": float,
         "auto_renew": bool,
@@ -1852,6 +1855,8 @@ class SubscriptionAddOn(Resource):
         Updated at
     usage_percentage : float
         The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if add_on_type is usage and usage_type is percentage.
+    usage_timeframe : str
+        The time at which usage totals are reset for billing purposes.
     """
 
     schema = {
@@ -1871,6 +1876,7 @@ class SubscriptionAddOn(Resource):
         "unit_amount_decimal": str,
         "updated_at": datetime,
         "usage_percentage": float,
+        "usage_timeframe": str,
     }
 
 
@@ -2392,6 +2398,8 @@ class AddOn(Resource):
         Last updated at
     usage_percentage : float
         The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0.
+    usage_timeframe : str
+        The time at which usage totals are reset for billing purposes.
     usage_type : str
         Type of usage, returns usage type if `add_on_type` is `usage`.
     """
@@ -2423,6 +2431,7 @@ class AddOn(Resource):
         "tiers": ["Tier"],
         "updated_at": datetime,
         "usage_percentage": float,
+        "usage_timeframe": str,
         "usage_type": str,
     }
 


### PR DESCRIPTION
Adds `active_invoice_id` to `subscription` response. It contains the invoice ID of the latest invoice created for an active subscription. It is `null` if the subscription is `future` or `expired`.

Adds `usage_timeframe` to the add-on create request and responses. It represents the time at which usage totals are reset for billing purposes. Allows for `tiered` add-ons to accumulate usage over the course of multiple billing periods.  The valid values are `billing_period` or `subscription_term` with `billing_period` being the default value.