### PR TITLE
Fix version check for python 3.10+

### DIFF
--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -3,16 +3,15 @@ import datetime
 from datetime import timezone
 import recurly
 import json
-import platform
+import sys
 from .response import Response
 
 # TODO - more resilient parsing
 
 DT_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
-major, minor, patch = platform.python_version_tuple()
 # For versions 3.6 and prior, timezone queries will return "None"
 # instead of "UTC"
-if major <= "3" and minor <= "6":
+if sys.version_info.major <= 3 and sys.version_info.minor <= 6:
     DT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,6 +1,6 @@
 import unittest
 import recurly
-import platform
+import sys
 import json
 from datetime import datetime
 from datetime import timezone
@@ -8,8 +8,6 @@ from recurly import Resource, Response, Request
 from pydoc import locate
 from .mock_resources import MyResource, MySubResource
 from unittest.mock import Mock, MagicMock
-
-major, minor, patch = platform.python_version_tuple()
 
 
 def cast(obj, class_name=None, resp=None):
@@ -121,7 +119,7 @@ class TestResource(unittest.TestCase):
         self.assertEqual(obj.my_int, 123)
         self.assertEqual(obj.my_float, 1.123)
         self.assertEqual(obj.my_bool, False)
-        if major >= "3" and minor >= "7":
+        if sys.version_info.major >= 3 and sys.version_info.minor >= 7:
             self.assertEqual(
                 obj.my_datetime, datetime(2022, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
             )


### PR DESCRIPTION
This fixes a major regression in Python 3.10+. The version check was doing string comparisons and reverting to old parsing styles. This meant that an otherwise unchanged update from Python 3.9 to Python 3.10 would have recurly emit datetime objects without the timezone, which creates consistent errors on everything that works with the recurly datetime objects as python carefully asserts when you try to use or compare naive with localized datetimes.