### PR TITLE
V2 add processing_prepayment_balance_in_cents to AccountBalance

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -114,6 +114,7 @@ class AccountBalance(Resource):
 
     attributes = (
         'balance_in_cents',
+        'processing_prepayment_balance_in_cents',
         'past_due',
     )
 

--- a/tests/fixtures/account-balance/exists.xml
+++ b/tests/fixtures/account-balance/exists.xml
@@ -16,4 +16,8 @@ Content-Type: application/xml; charset=utf-8
         <USD type="integer">2910</USD>
         <EUR type="integer">-520</EUR>
     </balance_in_cents>
+    <processing_prepayment_balance_in_cents>
+        <USD type="integer">-3000</USD>
+        <EUR type="integer">0</EUR>
+    </processing_prepayment_balance_in_cents>
 </account_balance>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -193,6 +193,9 @@ class TestResources(RecurlyTest):
         balance = account_balance.balance_in_cents
         self.assertTrue(balance['USD'] == 2910)
         self.assertTrue(balance['EUR'] == -520)
+        processing_prepayment_balance = account_balance.processing_prepayment_balance_in_cents
+        self.assertTrue(processing_prepayment_balance['USD'] == -3000)
+        self.assertTrue(processing_prepayment_balance['EUR'] == 0)
 
         account.username = 'shmohawk58'
         account.email = 'larry.david'


### PR DESCRIPTION
Add new add `processing_prepayment_balance_in_cents` attribute to `AccountBalance`. The `processing_prepayment_balance_in_cents` attribute is a similar format to the `balance_in_cents` attribute and contains
the total for processing prepayment credit invoices in each currency. This value is useful when trying to determine if the customer's prepayment balance has run out or if it is currently processing while waiting on a payment for the corresponding purchase invoice.