### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -15426,11 +15426,13 @@ components:
           - ko-KR
           - nl-BE
           - nl-NL
+          - pl-PL
           - pt-BR
           - pt-PT
           - ro-RO
           - ru-RU
           - sk-SK
+          - sv-SE
           - tr-TR
           - zh-CN
         cc_emails:
@@ -15556,11 +15558,13 @@ components:
           - ko-KR
           - nl-BE
           - nl-NL
+          - pl-PL
           - pt-BR
           - pt-PT
           - ro-RO
           - ru-RU
           - sk-SK
+          - sv-SE
           - tr-TR
           - zh-CN
         cc_emails:
@@ -15714,6 +15718,12 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+        processing_prepayment_amount:
+          type: number
+          format: float
+          title: Amount
+          description: Total amount for the prepayment credit invoices in a `processing`
+            state on the account.
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19127,9 +19137,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
     PlanUpdate:
       type: object
       properties:
@@ -19294,9 +19303,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -19318,9 +19326,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -20289,9 +20296,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Subscription quantity
@@ -20401,9 +20407,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Quantity
@@ -20862,9 +20867,7 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: This field is deprecated. Do not use it anymore to update a
-            subscription's tax inclusivity. Use the POST subscription change route
-            instead.
+          description: This field is deprecated. Please do not use it.
           deprecated: true
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"

--- a/recurly/client.py
+++ b/recurly/client.py
@@ -46,7 +46,9 @@ class Client(BaseClient):
         Pager
             A list of sites.
         """
-        path = self._interpolate_path("/sites")
+        path = self._interpolate_path(
+            "/sites",
+        )
         return Pager(self, path, options)
 
     def get_site(self, site_id):
@@ -117,7 +119,9 @@ class Client(BaseClient):
         Pager
             A list of the site's accounts.
         """
-        path = self._interpolate_path("/accounts")
+        path = self._interpolate_path(
+            "/accounts",
+        )
         return Pager(self, path, options)
 
     def create_account(self, body):
@@ -139,7 +143,9 @@ class Client(BaseClient):
         Account
             An account.
         """
-        path = self._interpolate_path("/accounts")
+        path = self._interpolate_path(
+            "/accounts",
+        )
         return self._make_request("POST", path, body, None)
 
     def get_account(self, account_id):
@@ -1311,7 +1317,9 @@ class Client(BaseClient):
         Pager
             A list of the site's account acquisition data.
         """
-        path = self._interpolate_path("/acquisitions")
+        path = self._interpolate_path(
+            "/acquisitions",
+        )
         return Pager(self, path, options)
 
     def list_coupons(self, **options):
@@ -1353,7 +1361,9 @@ class Client(BaseClient):
         Pager
             A list of the site's coupons.
         """
-        path = self._interpolate_path("/coupons")
+        path = self._interpolate_path(
+            "/coupons",
+        )
         return Pager(self, path, options)
 
     def create_coupon(self, body):
@@ -1375,7 +1385,9 @@ class Client(BaseClient):
         Coupon
             A new coupon.
         """
-        path = self._interpolate_path("/coupons")
+        path = self._interpolate_path(
+            "/coupons",
+        )
         return self._make_request("POST", path, body, None)
 
     def get_coupon(self, coupon_id):
@@ -1545,7 +1557,9 @@ class Client(BaseClient):
         Pager
             A list of the site's credit payments.
         """
-        path = self._interpolate_path("/credit_payments")
+        path = self._interpolate_path(
+            "/credit_payments",
+        )
         return Pager(self, path, options)
 
     def get_credit_payment(self, credit_payment_id):
@@ -1611,7 +1625,9 @@ class Client(BaseClient):
         Pager
             A list of the site's custom field definitions.
         """
-        path = self._interpolate_path("/custom_field_definitions")
+        path = self._interpolate_path(
+            "/custom_field_definitions",
+        )
         return Pager(self, path, options)
 
     def get_custom_field_definition(self, custom_field_definition_id):
@@ -1679,7 +1695,9 @@ class Client(BaseClient):
         Pager
             A list of the site's items.
         """
-        path = self._interpolate_path("/items")
+        path = self._interpolate_path(
+            "/items",
+        )
         return Pager(self, path, options)
 
     def create_item(self, body):
@@ -1701,7 +1719,9 @@ class Client(BaseClient):
         Item
             A new item.
         """
-        path = self._interpolate_path("/items")
+        path = self._interpolate_path(
+            "/items",
+        )
         return self._make_request("POST", path, body, None)
 
     def get_item(self, item_id):
@@ -1835,7 +1855,9 @@ class Client(BaseClient):
         Pager
             A list of the site's measured units.
         """
-        path = self._interpolate_path("/measured_units")
+        path = self._interpolate_path(
+            "/measured_units",
+        )
         return Pager(self, path, options)
 
     def create_measured_unit(self, body):
@@ -1857,7 +1879,9 @@ class Client(BaseClient):
         MeasuredUnit
             A new measured unit.
         """
-        path = self._interpolate_path("/measured_units")
+        path = self._interpolate_path(
+            "/measured_units",
+        )
         return self._make_request("POST", path, body, None)
 
     def get_measured_unit(self, measured_unit_id):
@@ -1973,7 +1997,9 @@ class Client(BaseClient):
         Pager
             A list of the site's invoices.
         """
-        path = self._interpolate_path("/invoices")
+        path = self._interpolate_path(
+            "/invoices",
+        )
         return Pager(self, path, options)
 
     def get_invoice(self, invoice_id):
@@ -2370,7 +2396,9 @@ class Client(BaseClient):
         Pager
             A list of the site's line items.
         """
-        path = self._interpolate_path("/line_items")
+        path = self._interpolate_path(
+            "/line_items",
+        )
         return Pager(self, path, options)
 
     def get_line_item(self, line_item_id):
@@ -2458,7 +2486,9 @@ class Client(BaseClient):
         Pager
             A list of plans.
         """
-        path = self._interpolate_path("/plans")
+        path = self._interpolate_path(
+            "/plans",
+        )
         return Pager(self, path, options)
 
     def create_plan(self, body):
@@ -2480,7 +2510,9 @@ class Client(BaseClient):
         Plan
             A plan.
         """
-        path = self._interpolate_path("/plans")
+        path = self._interpolate_path(
+            "/plans",
+        )
         return self._make_request("POST", path, body, None)
 
     def get_plan(self, plan_id):
@@ -2740,7 +2772,9 @@ class Client(BaseClient):
         Pager
             A list of add-ons.
         """
-        path = self._interpolate_path("/add_ons")
+        path = self._interpolate_path(
+            "/add_ons",
+        )
         return Pager(self, path, options)
 
     def get_add_on(self, add_on_id):
@@ -2804,7 +2838,9 @@ class Client(BaseClient):
         Pager
             A list of the site's shipping methods.
         """
-        path = self._interpolate_path("/shipping_methods")
+        path = self._interpolate_path(
+            "/shipping_methods",
+        )
         return Pager(self, path, options)
 
     def create_shipping_method(self, body):
@@ -2826,7 +2862,9 @@ class Client(BaseClient):
         ShippingMethod
             A new shipping method.
         """
-        path = self._interpolate_path("/shipping_methods")
+        path = self._interpolate_path(
+            "/shipping_methods",
+        )
         return self._make_request("POST", path, body, None)
 
     def get_shipping_method(self, id):
@@ -2942,7 +2980,9 @@ class Client(BaseClient):
         Pager
             A list of the site's subscriptions.
         """
-        path = self._interpolate_path("/subscriptions")
+        path = self._interpolate_path(
+            "/subscriptions",
+        )
         return Pager(self, path, options)
 
     def create_subscription(self, body):
@@ -2964,7 +3004,9 @@ class Client(BaseClient):
         Subscription
             A subscription.
         """
-        path = self._interpolate_path("/subscriptions")
+        path = self._interpolate_path(
+            "/subscriptions",
+        )
         return self._make_request("POST", path, body, None)
 
     def get_subscription(self, subscription_id):
@@ -3629,7 +3671,9 @@ class Client(BaseClient):
         Pager
             A list of the site's transactions.
         """
-        path = self._interpolate_path("/transactions")
+        path = self._interpolate_path(
+            "/transactions",
+        )
         return Pager(self, path, options)
 
     def get_transaction(self, transaction_id):
@@ -3741,7 +3785,9 @@ class Client(BaseClient):
         InvoiceCollection
             Returns the new invoices
         """
-        path = self._interpolate_path("/purchases")
+        path = self._interpolate_path(
+            "/purchases",
+        )
         return self._make_request("POST", path, body, None)
 
     def preview_purchase(self, body):
@@ -3763,7 +3809,9 @@ class Client(BaseClient):
         InvoiceCollection
             Returns preview of the new invoices
         """
-        path = self._interpolate_path("/purchases/preview")
+        path = self._interpolate_path(
+            "/purchases/preview",
+        )
         return self._make_request("POST", path, body, None)
 
     def get_export_dates(self):
@@ -3775,7 +3823,9 @@ class Client(BaseClient):
         ExportDates
             Returns a list of dates.
         """
-        path = self._interpolate_path("/export_dates")
+        path = self._interpolate_path(
+            "/export_dates",
+        )
         return self._make_request("GET", path, None, None)
 
     def get_export_files(self, export_date):
@@ -3817,7 +3867,9 @@ class Client(BaseClient):
         Pager
             A list of the the dunning_campaigns on an account.
         """
-        path = self._interpolate_path("/dunning_campaigns")
+        path = self._interpolate_path(
+            "/dunning_campaigns",
+        )
         return Pager(self, path, options)
 
     def get_dunning_campaign(self, dunning_campaign_id):
@@ -3861,5 +3913,7 @@ class Client(BaseClient):
         DunningCampaignsBulkUpdateResponse
             A list of updated plans.
         """
-        path = self._interpolate_path("/dunning_campaigns/%s/bulk_update")
+        path = self._interpolate_path(
+            "/dunning_campaigns/%s/bulk_update",
+        )
         return self._make_request("PUT", path, body, None)

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -117,7 +117,11 @@ class Error(Resource):
         Type
     """
 
-    schema = {"message": str, "params": list, "type": str}
+    schema = {
+        "message": str,
+        "params": list,
+        "type": str,
+    }
 
 
 class Account(Resource):
@@ -386,7 +390,11 @@ class FraudInfo(Resource):
         Kount score
     """
 
-    schema = {"decision": str, "risk_rules_triggered": dict, "score": int}
+    schema = {
+        "decision": str,
+        "risk_rules_triggered": dict,
+        "score": int,
+    }
 
 
 class BillingInfoUpdatedBy(Resource):
@@ -399,7 +407,10 @@ class BillingInfoUpdatedBy(Resource):
         Customer's IP address when updating their billing information.
     """
 
-    schema = {"country": str, "ip": str}
+    schema = {
+        "country": str,
+        "ip": str,
+    }
 
 
 class CustomField(Resource):
@@ -412,7 +423,10 @@ class CustomField(Resource):
         Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
     """
 
-    schema = {"name": str, "value": str}
+    schema = {
+        "name": str,
+        "value": str,
+    }
 
 
 class ErrorMayHaveTransaction(Resource):
@@ -514,7 +528,10 @@ class AccountAcquisitionCost(Resource):
         3-letter ISO 4217 currency code.
     """
 
-    schema = {"amount": float, "currency": str}
+    schema = {
+        "amount": float,
+        "currency": str,
+    }
 
 
 class AccountMini(Resource):
@@ -579,9 +596,15 @@ class AccountBalanceAmount(Resource):
         Total amount the account is past due.
     currency : str
         3-letter ISO 4217 currency code.
+    processing_prepayment_amount : float
+        Total amount for the prepayment credit invoices in a `processing` state on the account.
     """
 
-    schema = {"amount": float, "currency": str}
+    schema = {
+        "amount": float,
+        "currency": str,
+        "processing_prepayment_amount": float,
+    }
 
 
 class Transaction(Resource):
@@ -729,7 +752,13 @@ class InvoiceMini(Resource):
         Invoice type
     """
 
-    schema = {"id": str, "number": str, "object": str, "state": str, "type": str}
+    schema = {
+        "id": str,
+        "number": str,
+        "object": str,
+        "state": str,
+        "type": str,
+    }
 
 
 class TransactionPaymentGateway(Resource):
@@ -743,7 +772,12 @@ class TransactionPaymentGateway(Resource):
     type : str
     """
 
-    schema = {"id": str, "name": str, "object": str, "type": str}
+    schema = {
+        "id": str,
+        "name": str,
+        "object": str,
+        "type": str,
+    }
 
 
 class CouponRedemption(Resource):
@@ -912,7 +946,12 @@ class PlanMini(Resource):
         Object type
     """
 
-    schema = {"code": str, "id": str, "name": str, "object": str}
+    schema = {
+        "code": str,
+        "id": str,
+        "name": str,
+        "object": str,
+    }
 
 
 class ItemMini(Resource):
@@ -974,7 +1013,10 @@ class CouponDiscountPricing(Resource):
         3-letter ISO 4217 currency code.
     """
 
-    schema = {"amount": float, "currency": str}
+    schema = {
+        "amount": float,
+        "currency": str,
+    }
 
 
 class CouponDiscountTrial(Resource):
@@ -987,7 +1029,10 @@ class CouponDiscountTrial(Resource):
         Temporal unit of the free trial
     """
 
-    schema = {"length": int, "unit": str}
+    schema = {
+        "length": int,
+        "unit": str,
+    }
 
 
 class CreditPayment(Resource):
@@ -1213,7 +1258,12 @@ class TaxInfo(Resource):
         Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries.
     """
 
-    schema = {"rate": float, "region": str, "tax_details": ["TaxDetail"], "type": str}
+    schema = {
+        "rate": float,
+        "region": str,
+        "tax_details": ["TaxDetail"],
+        "type": str,
+    }
 
 
 class TaxDetail(Resource):
@@ -1230,7 +1280,12 @@ class TaxDetail(Resource):
         Provides the tax type for the region. For Canadian Sales Tax, this will be GST, HST, QST or PST.
     """
 
-    schema = {"rate": float, "region": str, "tax": float, "type": str}
+    schema = {
+        "rate": float,
+        "region": str,
+        "tax": float,
+        "type": str,
+    }
 
 
 class LineItemList(Resource):
@@ -1246,7 +1301,12 @@ class LineItemList(Resource):
         Will always be List.
     """
 
-    schema = {"data": ["LineItem"], "has_more": bool, "next": str, "object": str}
+    schema = {
+        "data": ["LineItem"],
+        "has_more": bool,
+        "next": str,
+        "object": str,
+    }
 
 
 class LineItem(Resource):
@@ -1647,7 +1707,12 @@ class ShippingMethodMini(Resource):
         Object type
     """
 
-    schema = {"code": str, "id": str, "name": str, "object": str}
+    schema = {
+        "code": str,
+        "id": str,
+        "name": str,
+        "object": str,
+    }
 
 
 class CouponRedemptionMini(Resource):
@@ -1749,7 +1814,7 @@ class SubscriptionChange(Resource):
     subscription_id : str
         The ID of the subscription that is going to be changed.
     tax_inclusive : bool
-        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+        This field is deprecated. Please do not use it.
     unit_amount : float
         Unit amount
     updated_at : datetime
@@ -1888,7 +1953,10 @@ class SubscriptionAddOnTier(Resource):
         Unit amount
     """
 
-    schema = {"ending_quantity": int, "unit_amount": float}
+    schema = {
+        "ending_quantity": int,
+        "unit_amount": float,
+    }
 
 
 class SubscriptionChangeBillingInfo(Resource):
@@ -1899,7 +1967,9 @@ class SubscriptionChangeBillingInfo(Resource):
         A token generated by Recurly.js after completing a 3-D Secure device fingerprinting or authentication challenge.
     """
 
-    schema = {"three_d_secure_action_result_token_id": str}
+    schema = {
+        "three_d_secure_action_result_token_id": str,
+    }
 
 
 class UniqueCouponCode(Resource):
@@ -2057,12 +2127,16 @@ class Pricing(Resource):
     currency : str
         3-letter ISO 4217 currency code.
     tax_inclusive : bool
-        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+        This field is deprecated. Please do not use it.
     unit_amount : float
         Unit price
     """
 
-    schema = {"currency": str, "tax_inclusive": bool, "unit_amount": float}
+    schema = {
+        "currency": str,
+        "tax_inclusive": bool,
+        "unit_amount": float,
+    }
 
 
 class MeasuredUnit(Resource):
@@ -2109,7 +2183,9 @@ class BinaryFile(Resource):
     data : str
     """
 
-    schema = {"data": str}
+    schema = {
+        "data": str,
+    }
 
 
 class Plan(Resource):
@@ -2217,7 +2293,7 @@ class PlanPricing(Resource):
     setup_fee : float
         Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
     tax_inclusive : bool
-        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+        This field is deprecated. Please do not use it.
     unit_amount : float
         Unit price
     """
@@ -2347,12 +2423,16 @@ class AddOnPricing(Resource):
     currency : str
         3-letter ISO 4217 currency code.
     tax_inclusive : bool
-        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+        This field is deprecated. Please do not use it.
     unit_amount : float
         Unit price
     """
 
-    schema = {"currency": str, "tax_inclusive": bool, "unit_amount": float}
+    schema = {
+        "currency": str,
+        "tax_inclusive": bool,
+        "unit_amount": float,
+    }
 
 
 class Tier(Resource):
@@ -2365,7 +2445,10 @@ class Tier(Resource):
         Ending quantity
     """
 
-    schema = {"currencies": ["Pricing"], "ending_quantity": int}
+    schema = {
+        "currencies": ["Pricing"],
+        "ending_quantity": int,
+    }
 
 
 class ShippingMethod(Resource):
@@ -2452,7 +2535,7 @@ class SubscriptionChangePreview(Resource):
     subscription_id : str
         The ID of the subscription that is going to be changed.
     tax_inclusive : bool
-        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+        This field is deprecated. Please do not use it.
     unit_amount : float
         Unit amount
     updated_at : datetime
@@ -2547,7 +2630,10 @@ class ExportDates(Resource):
         Object type
     """
 
-    schema = {"dates": list, "object": str}
+    schema = {
+        "dates": list,
+        "object": str,
+    }
 
 
 class ExportFiles(Resource):
@@ -2559,7 +2645,10 @@ class ExportFiles(Resource):
         Object type
     """
 
-    schema = {"files": ["ExportFile"], "object": str}
+    schema = {
+        "files": ["ExportFile"],
+        "object": str,
+    }
 
 
 class ExportFile(Resource):
@@ -2574,7 +2663,11 @@ class ExportFile(Resource):
         Name of the export file.
     """
 
-    schema = {"href": str, "md5sum": str, "name": str}
+    schema = {
+        "href": str,
+        "md5sum": str,
+        "name": str,
+    }
 
 
 class DunningCampaign(Resource):
@@ -2672,7 +2765,10 @@ class DunningInterval(Resource):
         Email template being used.
     """
 
-    schema = {"days": int, "email_template": str}
+    schema = {
+        "days": int,
+        "email_template": str,
+    }
 
 
 class DunningCampaignsBulkUpdateResponse(Resource):
@@ -2685,4 +2781,7 @@ class DunningCampaignsBulkUpdateResponse(Resource):
         An array containing all of the `Plan` resources that have been updated.
     """
 
-    schema = {"object": str, "plans": ["Plan"]}
+    schema = {
+        "object": str,
+        "plans": ["Plan"],
+    }


### PR DESCRIPTION
- Added `pl-PL` and `sv-SE` to the acceptable values for `preferred_locale` to allow specifying Polish or Swedish for the preferred email language on an account.
- Added `processing_prepayment_amount` to the `GET accounts/{account_id}/balance` response in the `AccountBalanceAmount` element. This is the total amount for the prepayment credit invoices in a `processing` state on the account.
- The `tax_inclusive ` field has been deprecated on the `plans`, `add_ons`, `subscriptions` and `subscription_change` endpoints.