### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12519,7 +12519,97 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
-      x-code-samples: []
+      x-code-samples:
+      - lang: Node.js
+        source: |
+          try {
+            const invoiceCollection = await client.getPreviewRenewal(subscriptionId)
+            console.log('Fetched Renewal Preview with total: ', invoiceCollection.chargeInvoice.total)
+          } catch (err) {
+            if (err instanceof recurly.errors.NotFoundError) {
+              // If the request was not found, you may want to alert the user or
+              // just return null
+              console.log('Resource Not Found')
+            } else {
+              // If we don't know what to do with the err, we should
+              // probably re-raise and let our web framework and logger handle it
+              console.log('Unknown Error: ', err)
+            }
+          }
+      - lang: Python
+        source: |
+          try:
+              invoice_collection = client.get_preview_renewal(subscription_id)
+              print("Fetched Renewal Preview with total: %s" % invoice_collection.charge_invoice.total)
+          except recurly.errors.NotFoundError:
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              print("Resource Not Found")
+      - lang: ".NET"
+        source: |
+          try
+          {
+              InvoiceCollection invoiceCollection = client.GetPreviewRenewal(subscriptionId);
+              Console.WriteLine($"Fetched Renewal Preview with total {invoiceCollection.ChargeInvoice.Total}");
+          }
+          catch (Recurly.Errors.NotFound ex)
+          {
+              // If the resource was not found
+              // we may want to alert the user or just return null
+              Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
+          }
+          catch (Recurly.Errors.ApiError ex)
+          {
+              // Use ApiError to catch a generic error from the API
+              Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+          }
+      - lang: Ruby
+        source: |
+          begin
+            invoice_collection = @client.get_preview_renewal(
+              subscription_id: subscription_id
+            )
+            puts "Fetched Renewal Preview with total: #{invoice_collection.charge_invoice.total}"
+          rescue Recurly::Errors::NotFoundError
+            # If the resource was not found, you may want to alert the user or
+            # just return nil
+            puts "Resource Not Found"
+          end
+      - lang: Java
+        source: |
+          try {
+              final InvoiceCollection invoiceCollection = client.getPreviewRenewal(subscriptionId);
+              System.out.println("Fetched Renewal Preview with total: " + invoiceCollection.getChargeInvoice().getTotal());
+          } catch (ValidationException e) {
+              // If the request was not valid, you may want to tell your user
+              // why. You can find the invalid params and reasons in e.getError().getParams()
+              System.out.println("Failed validation: " + e.getError().getMessage());
+          } catch (ApiException e) {
+              // Use ApiException to catch a generic error from the API
+              System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+          }
+      - lang: PHP
+        source: |
+          try {
+              $invoiceCollection = $client->getPreviewRenewal($subscription_id);
+
+              echo 'Fetched Renewal Preview with total: ' . $invoiceCollection->getChargeInvoice()->getTotal() . PHP_EOL;
+              var_dump($invoiceCollection);
+          } catch (\Recurly\Errors\NotFound $e) {
+              // Could not find the resource, you may want to inform the user
+              // or just return a NULL
+              echo 'Could not find resource.' . PHP_EOL;
+              var_dump($e);
+          } catch (\Recurly\RecurlyError $e) {
+              // Something bad happened... tell the user so that they can fix it?
+              echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+          }
+      - lang: Go
+        source: "invoiceCollection, err := client.GetPreviewRenewal(subID)\nif e,
+          ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
+          {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
+          Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Fetched Renewal
+          Preview with total: %f\", invoiceCollection.ChargeInvoice.Total)"
   "/subscriptions/{subscription_id}/change":
     get:
       tags:
@@ -15852,7 +15942,7 @@ components:
           type: string
           title: Invoice Template ID
           description: Unique ID to identify an invoice template.  Available when
-            the Invoice Customization feature is enabled.  Used to specify which invoice
+            the site is on a Pro or Enterprise plan.  Used to specify which invoice
             template, if any, should be used to generate invoices for the account.
         address:
           "$ref": "#/components/schemas/Address"
@@ -15935,7 +16025,7 @@ components:
           type: string
           title: Invoice Template ID
           description: Unique ID to identify an invoice template. Available when the
-            Invoice Customization feature is enabled. Used to specify if a non-default
+            site is on a Pro or Enterprise plan. Used to specify if a non-default
             invoice template will be used to generate invoices for the account. For
             sites without multiple invoice templates enabled, the default template
             will always be used.
@@ -16040,6 +16130,12 @@ components:
           format: float
           title: Amount
           description: Total amount the account is past due.
+        processing_prepayment_amount:
+          type: number
+          format: float
+          title: Amount
+          description: Total amount for the prepayment credit invoices in a `processing`
+            state on the account.
     InvoiceAddress:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -16805,11 +16901,12 @@ components:
           type: string
           description: Tax identifier is required if adding a billing info that is
             a consumer card in Brazil or in Argentina. This would be the customer's
-            CPF (Brazil) and CUIT (Argentina). CPF and CUIT are tax identifiers for
-            all residents who pay taxes in Brazil and Argentina respectively.
+            CPF/CNPJ (Brazil) and CUIT (Argentina). CPF, CNPJ and CUIT are tax identifiers
+            for all residents who pay taxes in Brazil and Argentina respectively.
         tax_identifier_type:
-          description: This field and a value of `cpf` or `cuit` are required if adding
-            a billing info that is an elo or hipercard type in Brazil or in Argentina.
+          description: This field and a value of `cpf`, `cnpj` or `cuit` are required
+            if adding a billing info that is an elo or hipercard type in Brazil or
+            in Argentina.
           "$ref": "#/components/schemas/TaxIdentifierTypeEnum"
         primary_payment_method:
           type: boolean
@@ -19143,9 +19240,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
     PlanUpdate:
       type: object
       properties:
@@ -19307,9 +19403,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
     TierPricing:
@@ -19356,9 +19451,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
       required:
       - currency
       - unit_amount
@@ -20397,9 +20491,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Subscription quantity
@@ -20491,9 +20584,8 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: Determines whether or not tax is included in the unit amount.
-            The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing
-            feature) must be enabled to use this flag.
+          description: This field is deprecated. Please do not use it.
+          deprecated: true
         quantity:
           type: integer
           title: Quantity
@@ -20932,9 +21024,7 @@ components:
           type: boolean
           title: Tax Inclusive?
           default: false
-          description: This field is deprecated. Do not use it anymore to update a
-            subscription's tax inclusivity. Use the POST subscription change route
-            instead.
+          description: This field is deprecated. Please do not use it.
           deprecated: true
         shipping:
           "$ref": "#/components/schemas/SubscriptionShippingUpdate"
@@ -22074,11 +22164,13 @@ components:
       - ko-KR
       - nl-BE
       - nl-NL
+      - pl-PL
       - pt-BR
       - pt-PT
       - ro-RO
       - ru-RU
       - sk-SK
+      - sv-SE
       - tr-TR
       - zh-CN
     BillToEnum:
@@ -22752,6 +22844,7 @@ components:
       type: string
       enum:
       - cpf
+      - cnpj
       - cuit
     DunningCycleTypeEnum:
       type: string

--- a/recurly/client.py
+++ b/recurly/client.py
@@ -50,7 +50,9 @@ class Client(BaseClient):
         Pager
             A list of sites.
         """
-        path = self._interpolate_path("/sites")
+        path = self._interpolate_path(
+            "/sites",
+        )
         return Pager(self, path, **options)
 
     def get_site(self, site_id, **options):
@@ -127,7 +129,9 @@ class Client(BaseClient):
         Pager
             A list of the site's accounts.
         """
-        path = self._interpolate_path("/accounts")
+        path = self._interpolate_path(
+            "/accounts",
+        )
         return Pager(self, path, **options)
 
     def create_account(self, body, **options):
@@ -151,7 +155,9 @@ class Client(BaseClient):
         Account
             An account.
         """
-        path = self._interpolate_path("/accounts")
+        path = self._interpolate_path(
+            "/accounts",
+        )
         return self._make_request("POST", path, body, **options)
 
     def get_account(self, account_id, **options):
@@ -1423,7 +1429,9 @@ class Client(BaseClient):
         Pager
             A list of the site's account acquisition data.
         """
-        path = self._interpolate_path("/acquisitions")
+        path = self._interpolate_path(
+            "/acquisitions",
+        )
         return Pager(self, path, **options)
 
     def list_coupons(self, **options):
@@ -1469,7 +1477,9 @@ class Client(BaseClient):
         Pager
             A list of the site's coupons.
         """
-        path = self._interpolate_path("/coupons")
+        path = self._interpolate_path(
+            "/coupons",
+        )
         return Pager(self, path, **options)
 
     def create_coupon(self, body, **options):
@@ -1493,7 +1503,9 @@ class Client(BaseClient):
         Coupon
             A new coupon.
         """
-        path = self._interpolate_path("/coupons")
+        path = self._interpolate_path(
+            "/coupons",
+        )
         return self._make_request("POST", path, body, **options)
 
     def get_coupon(self, coupon_id, **options):
@@ -1706,7 +1718,9 @@ class Client(BaseClient):
         Pager
             A list of the site's credit payments.
         """
-        path = self._interpolate_path("/credit_payments")
+        path = self._interpolate_path(
+            "/credit_payments",
+        )
         return Pager(self, path, **options)
 
     def get_credit_payment(self, credit_payment_id, **options):
@@ -1778,7 +1792,9 @@ class Client(BaseClient):
         Pager
             A list of the site's custom field definitions.
         """
-        path = self._interpolate_path("/custom_field_definitions")
+        path = self._interpolate_path(
+            "/custom_field_definitions",
+        )
         return Pager(self, path, **options)
 
     def get_custom_field_definition(self, custom_field_definition_id, **options):
@@ -1913,7 +1929,9 @@ class Client(BaseClient):
         Pager
             A list of the site's items.
         """
-        path = self._interpolate_path("/items")
+        path = self._interpolate_path(
+            "/items",
+        )
         return Pager(self, path, **options)
 
     def create_item(self, body, **options):
@@ -1937,7 +1955,9 @@ class Client(BaseClient):
         Item
             A new item.
         """
-        path = self._interpolate_path("/items")
+        path = self._interpolate_path(
+            "/items",
+        )
         return self._make_request("POST", path, body, **options)
 
     def get_item(self, item_id, **options):
@@ -2083,7 +2103,9 @@ class Client(BaseClient):
         Pager
             A list of the site's measured units.
         """
-        path = self._interpolate_path("/measured_units")
+        path = self._interpolate_path(
+            "/measured_units",
+        )
         return Pager(self, path, **options)
 
     def create_measured_unit(self, body, **options):
@@ -2107,7 +2129,9 @@ class Client(BaseClient):
         MeasuredUnit
             A new measured unit.
         """
-        path = self._interpolate_path("/measured_units")
+        path = self._interpolate_path(
+            "/measured_units",
+        )
         return self._make_request("POST", path, body, **options)
 
     def get_measured_unit(self, measured_unit_id, **options):
@@ -2233,7 +2257,9 @@ class Client(BaseClient):
         Pager
             A list of the site's invoices.
         """
-        path = self._interpolate_path("/invoices")
+        path = self._interpolate_path(
+            "/invoices",
+        )
         return Pager(self, path, **options)
 
     def get_invoice(self, invoice_id, **options):
@@ -2666,7 +2692,9 @@ class Client(BaseClient):
         Pager
             A list of the site's line items.
         """
-        path = self._interpolate_path("/line_items")
+        path = self._interpolate_path(
+            "/line_items",
+        )
         return Pager(self, path, **options)
 
     def get_line_item(self, line_item_id, **options):
@@ -2762,7 +2790,9 @@ class Client(BaseClient):
         Pager
             A list of plans.
         """
-        path = self._interpolate_path("/plans")
+        path = self._interpolate_path(
+            "/plans",
+        )
         return Pager(self, path, **options)
 
     def create_plan(self, body, **options):
@@ -2786,7 +2816,9 @@ class Client(BaseClient):
         Plan
             A plan.
         """
-        path = self._interpolate_path("/plans")
+        path = self._interpolate_path(
+            "/plans",
+        )
         return self._make_request("POST", path, body, **options)
 
     def get_plan(self, plan_id, **options):
@@ -3068,7 +3100,9 @@ class Client(BaseClient):
         Pager
             A list of add-ons.
         """
-        path = self._interpolate_path("/add_ons")
+        path = self._interpolate_path(
+            "/add_ons",
+        )
         return Pager(self, path, **options)
 
     def get_add_on(self, add_on_id, **options):
@@ -3138,7 +3172,9 @@ class Client(BaseClient):
         Pager
             A list of the site's shipping methods.
         """
-        path = self._interpolate_path("/shipping_methods")
+        path = self._interpolate_path(
+            "/shipping_methods",
+        )
         return Pager(self, path, **options)
 
     def create_shipping_method(self, body, **options):
@@ -3162,7 +3198,9 @@ class Client(BaseClient):
         ShippingMethod
             A new shipping method.
         """
-        path = self._interpolate_path("/shipping_methods")
+        path = self._interpolate_path(
+            "/shipping_methods",
+        )
         return self._make_request("POST", path, body, **options)
 
     def get_shipping_method(self, shipping_method_id, **options):
@@ -3288,7 +3326,9 @@ class Client(BaseClient):
         Pager
             A list of the site's subscriptions.
         """
-        path = self._interpolate_path("/subscriptions")
+        path = self._interpolate_path(
+            "/subscriptions",
+        )
         return Pager(self, path, **options)
 
     def create_subscription(self, body, **options):
@@ -3312,7 +3352,9 @@ class Client(BaseClient):
         Subscription
             A subscription.
         """
-        path = self._interpolate_path("/subscriptions")
+        path = self._interpolate_path(
+            "/subscriptions",
+        )
         return self._make_request("POST", path, body, **options)
 
     def get_subscription(self, subscription_id, **options):
@@ -4035,7 +4077,9 @@ class Client(BaseClient):
         Pager
             A list of the site's transactions.
         """
-        path = self._interpolate_path("/transactions")
+        path = self._interpolate_path(
+            "/transactions",
+        )
         return Pager(self, path, **options)
 
     def get_transaction(self, transaction_id, **options):
@@ -4157,7 +4201,9 @@ class Client(BaseClient):
         InvoiceCollection
             Returns the new invoices
         """
-        path = self._interpolate_path("/purchases")
+        path = self._interpolate_path(
+            "/purchases",
+        )
         return self._make_request("POST", path, body, **options)
 
     def preview_purchase(self, body, **options):
@@ -4181,7 +4227,9 @@ class Client(BaseClient):
         InvoiceCollection
             Returns preview of the new invoices
         """
-        path = self._interpolate_path("/purchases/preview")
+        path = self._interpolate_path(
+            "/purchases/preview",
+        )
         return self._make_request("POST", path, body, **options)
 
     def create_pending_purchase(self, body, **options):
@@ -4205,7 +4253,9 @@ class Client(BaseClient):
         InvoiceCollection
             Returns the pending invoice
         """
-        path = self._interpolate_path("/purchases/pending")
+        path = self._interpolate_path(
+            "/purchases/pending",
+        )
         return self._make_request("POST", path, body, **options)
 
     def get_export_dates(self, **options):
@@ -4217,7 +4267,9 @@ class Client(BaseClient):
         ExportDates
             Returns a list of dates.
         """
-        path = self._interpolate_path("/export_dates")
+        path = self._interpolate_path(
+            "/export_dates",
+        )
         return self._make_request("GET", path, None, **options)
 
     def get_export_files(self, export_date, **options):
@@ -4265,7 +4317,9 @@ class Client(BaseClient):
         Pager
             A list of the the dunning_campaigns on an account.
         """
-        path = self._interpolate_path("/dunning_campaigns")
+        path = self._interpolate_path(
+            "/dunning_campaigns",
+        )
         return Pager(self, path, **options)
 
     def get_dunning_campaign(self, dunning_campaign_id, **options):
@@ -4313,7 +4367,9 @@ class Client(BaseClient):
         DunningCampaignsBulkUpdateResponse
             A list of updated plans.
         """
-        path = self._interpolate_path("/dunning_campaigns/%s/bulk_update")
+        path = self._interpolate_path(
+            "/dunning_campaigns/%s/bulk_update",
+        )
         return self._make_request("PUT", path, body, **options)
 
     def list_invoice_templates(self, **options):
@@ -4337,7 +4393,9 @@ class Client(BaseClient):
         Pager
             A list of the the invoice templates on a site.
         """
-        path = self._interpolate_path("/invoice_templates")
+        path = self._interpolate_path(
+            "/invoice_templates",
+        )
         return Pager(self, path, **options)
 
     def get_invoice_template(self, invoice_template_id, **options):

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -111,7 +111,11 @@ class Error(Resource):
         Type
     """
 
-    schema = {"message": str, "params": list, "type": str}
+    schema = {
+        "message": str,
+        "params": list,
+        "type": str,
+    }
 
 
 class Account(Resource):
@@ -156,7 +160,7 @@ class Account(Resource):
         The unique token for automatically logging the account in to the hosted management pages. You may automatically log the user into their hosted management pages by directing the user to: `https://{subdomain}.recurly.com/account/{hosted_login_token}`.
     id : str
     invoice_template_id : str
-        Unique ID to identify an invoice template. Available when the Invoice Customization feature is enabled. Used to specify if a non-default invoice template will be used to generate invoices for the account. For sites without multiple invoice templates enabled, the default template will always be used.
+        Unique ID to identify an invoice template. Available when the site is on a Pro or Enterprise plan. Used to specify if a non-default invoice template will be used to generate invoices for the account. For sites without multiple invoice templates enabled, the default template will always be used.
     last_name : str
     object : str
         Object type
@@ -383,7 +387,11 @@ class FraudInfo(Resource):
         Kount score
     """
 
-    schema = {"decision": str, "risk_rules_triggered": dict, "score": int}
+    schema = {
+        "decision": str,
+        "risk_rules_triggered": dict,
+        "score": int,
+    }
 
 
 class BillingInfoUpdatedBy(Resource):
@@ -396,7 +404,10 @@ class BillingInfoUpdatedBy(Resource):
         Customer's IP address when updating their billing information.
     """
 
-    schema = {"country": str, "ip": str}
+    schema = {
+        "country": str,
+        "ip": str,
+    }
 
 
 class CustomField(Resource):
@@ -409,7 +420,10 @@ class CustomField(Resource):
         Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
     """
 
-    schema = {"name": str, "value": str}
+    schema = {
+        "name": str,
+        "value": str,
+    }
 
 
 class ErrorMayHaveTransaction(Resource):
@@ -511,7 +525,10 @@ class AccountAcquisitionCost(Resource):
         3-letter ISO 4217 currency code.
     """
 
-    schema = {"amount": float, "currency": str}
+    schema = {
+        "amount": float,
+        "currency": str,
+    }
 
 
 class AccountMini(Resource):
@@ -576,9 +593,15 @@ class AccountBalanceAmount(Resource):
         Total amount the account is past due.
     currency : str
         3-letter ISO 4217 currency code.
+    processing_prepayment_amount : float
+        Total amount for the prepayment credit invoices in a `processing` state on the account.
     """
 
-    schema = {"amount": float, "currency": str}
+    schema = {
+        "amount": float,
+        "currency": str,
+        "processing_prepayment_amount": float,
+    }
 
 
 class Transaction(Resource):
@@ -726,7 +749,13 @@ class InvoiceMini(Resource):
         Invoice type
     """
 
-    schema = {"id": str, "number": str, "object": str, "state": str, "type": str}
+    schema = {
+        "id": str,
+        "number": str,
+        "object": str,
+        "state": str,
+        "type": str,
+    }
 
 
 class AddressWithName(Resource):
@@ -777,7 +806,12 @@ class TransactionPaymentGateway(Resource):
     type : str
     """
 
-    schema = {"id": str, "name": str, "object": str, "type": str}
+    schema = {
+        "id": str,
+        "name": str,
+        "object": str,
+        "type": str,
+    }
 
 
 class CouponRedemption(Resource):
@@ -937,7 +971,12 @@ class PlanMini(Resource):
         Object type
     """
 
-    schema = {"code": str, "id": str, "name": str, "object": str}
+    schema = {
+        "code": str,
+        "id": str,
+        "name": str,
+        "object": str,
+    }
 
 
 class ItemMini(Resource):
@@ -999,7 +1038,10 @@ class CouponDiscountPricing(Resource):
         3-letter ISO 4217 currency code.
     """
 
-    schema = {"amount": float, "currency": str}
+    schema = {
+        "amount": float,
+        "currency": str,
+    }
 
 
 class CouponDiscountTrial(Resource):
@@ -1012,7 +1054,10 @@ class CouponDiscountTrial(Resource):
         Temporal unit of the free trial
     """
 
-    schema = {"length": int, "unit": str}
+    schema = {
+        "length": int,
+        "unit": str,
+    }
 
 
 class CreditPayment(Resource):
@@ -1245,7 +1290,12 @@ class TaxInfo(Resource):
         Provides the tax type as "vat" for EU VAT, "usst" for U.S. Sales Tax, or the 2 letter country code for country level tax types like Canada, Australia, New Zealand, Israel, and all non-EU European countries.
     """
 
-    schema = {"rate": float, "region": str, "tax_details": ["TaxDetail"], "type": str}
+    schema = {
+        "rate": float,
+        "region": str,
+        "tax_details": ["TaxDetail"],
+        "type": str,
+    }
 
 
 class TaxDetail(Resource):
@@ -1262,7 +1312,12 @@ class TaxDetail(Resource):
         Provides the tax type for the region. For Canadian Sales Tax, this will be GST, HST, QST or PST.
     """
 
-    schema = {"rate": float, "region": str, "tax": float, "type": str}
+    schema = {
+        "rate": float,
+        "region": str,
+        "tax": float,
+        "type": str,
+    }
 
 
 class LineItem(Resource):
@@ -1678,7 +1733,12 @@ class ShippingMethodMini(Resource):
         Object type
     """
 
-    schema = {"code": str, "id": str, "name": str, "object": str}
+    schema = {
+        "code": str,
+        "id": str,
+        "name": str,
+        "object": str,
+    }
 
 
 class CouponRedemptionMini(Resource):
@@ -1778,7 +1838,7 @@ class SubscriptionChange(Resource):
     subscription_id : str
         The ID of the subscription that is going to be changed.
     tax_inclusive : bool
-        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+        This field is deprecated. Please do not use it.
     unit_amount : float
         Unit amount
     updated_at : datetime
@@ -1958,7 +2018,10 @@ class SubscriptionAddOnPercentageTier(Resource):
         This can be up to 4 decimal places represented as a string.
     """
 
-    schema = {"ending_amount": float, "usage_percentage": str}
+    schema = {
+        "ending_amount": float,
+        "usage_percentage": str,
+    }
 
 
 class SubscriptionChangeBillingInfo(Resource):
@@ -1969,7 +2032,9 @@ class SubscriptionChangeBillingInfo(Resource):
         A token generated by Recurly.js after completing a 3-D Secure device fingerprinting or authentication challenge.
     """
 
-    schema = {"three_d_secure_action_result_token_id": str}
+    schema = {
+        "three_d_secure_action_result_token_id": str,
+    }
 
 
 class UniqueCouponCodeParams(Resource):
@@ -1986,7 +2051,12 @@ class UniqueCouponCodeParams(Resource):
         Sort field to list newly generated UniqueCouponCodes (should always be `created_at`)
     """
 
-    schema = {"begin_time": datetime, "limit": int, "order": str, "sort": str}
+    schema = {
+        "begin_time": datetime,
+        "limit": int,
+        "order": str,
+        "sort": str,
+    }
 
 
 class UniqueCouponCode(Resource):
@@ -2144,12 +2214,16 @@ class Pricing(Resource):
     currency : str
         3-letter ISO 4217 currency code.
     tax_inclusive : bool
-        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+        This field is deprecated. Please do not use it.
     unit_amount : float
         Unit price
     """
 
-    schema = {"currency": str, "tax_inclusive": bool, "unit_amount": float}
+    schema = {
+        "currency": str,
+        "tax_inclusive": bool,
+        "unit_amount": float,
+    }
 
 
 class MeasuredUnit(Resource):
@@ -2196,7 +2270,9 @@ class BinaryFile(Resource):
     data : str
     """
 
-    schema = {"data": str}
+    schema = {
+        "data": str,
+    }
 
 
 class Plan(Resource):
@@ -2304,7 +2380,7 @@ class PlanPricing(Resource):
     setup_fee : float
         Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.
     tax_inclusive : bool
-        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+        This field is deprecated. Please do not use it.
     unit_amount : float
         Unit price
     """
@@ -2443,7 +2519,7 @@ class AddOnPricing(Resource):
     currency : str
         3-letter ISO 4217 currency code.
     tax_inclusive : bool
-        Determines whether or not tax is included in the unit amount. The Tax Inclusive Pricing feature (separate from the Mixed Tax Pricing feature) must be enabled to use this flag.
+        This field is deprecated. Please do not use it.
     unit_amount : float
         Allows up to 2 decimal places. Required unless `unit_amount_decimal` is provided.
     unit_amount_decimal : str
@@ -2491,7 +2567,11 @@ class TierPricing(Resource):
         If `unit_amount_decimal` is provided, `unit_amount` cannot be provided.
     """
 
-    schema = {"currency": str, "unit_amount": float, "unit_amount_decimal": str}
+    schema = {
+        "currency": str,
+        "unit_amount": float,
+        "unit_amount_decimal": str,
+    }
 
 
 class PercentageTiersByCurrency(Resource):
@@ -2504,7 +2584,10 @@ class PercentageTiersByCurrency(Resource):
         Tiers
     """
 
-    schema = {"currency": str, "tiers": ["PercentageTier"]}
+    schema = {
+        "currency": str,
+        "tiers": ["PercentageTier"],
+    }
 
 
 class PercentageTier(Resource):
@@ -2518,7 +2601,10 @@ class PercentageTier(Resource):
         This can be up to 4 decimal places represented as a string.
     """
 
-    schema = {"ending_amount": float, "usage_percentage": str}
+    schema = {
+        "ending_amount": float,
+        "usage_percentage": str,
+    }
 
 
 class ShippingMethod(Resource):
@@ -2641,7 +2727,10 @@ class ExportDates(Resource):
         Object type
     """
 
-    schema = {"dates": list, "object": str}
+    schema = {
+        "dates": list,
+        "object": str,
+    }
 
 
 class ExportFiles(Resource):
@@ -2653,7 +2742,10 @@ class ExportFiles(Resource):
         Object type
     """
 
-    schema = {"files": ["ExportFile"], "object": str}
+    schema = {
+        "files": ["ExportFile"],
+        "object": str,
+    }
 
 
 class ExportFile(Resource):
@@ -2668,7 +2760,11 @@ class ExportFile(Resource):
         Name of the export file.
     """
 
-    schema = {"href": str, "md5sum": str, "name": str}
+    schema = {
+        "href": str,
+        "md5sum": str,
+        "name": str,
+    }
 
 
 class DunningCampaign(Resource):
@@ -2766,7 +2862,10 @@ class DunningInterval(Resource):
         Email template being used.
     """
 
-    schema = {"days": int, "email_template": str}
+    schema = {
+        "days": int,
+        "email_template": str,
+    }
 
 
 class DunningCampaignsBulkUpdateResponse(Resource):
@@ -2779,7 +2878,10 @@ class DunningCampaignsBulkUpdateResponse(Resource):
         An array containing all of the `Plan` resources that have been updated.
     """
 
-    schema = {"object": str, "plans": ["Plan"]}
+    schema = {
+        "object": str,
+        "plans": ["Plan"],
+    }
 
 
 class InvoiceTemplate(Resource):


### PR DESCRIPTION
- Added `pl-PL` and `sv-SE` to the acceptable values for `preferred_locale` to allow specifying Polish or Swedish for the preferred email language on an account.
- Added `processing_prepayment_amount` to the `GET accounts/{account_id}/balance` response in the `AccountBalanceAmount` element. This is the total amount for the prepayment credit invoices in a `processing` state on the account.
- The `tax_inclusive ` field has been deprecated on the `plans`, `add_ons`, `subscriptions` and `subscription_change` endpoints.
- The invoice templates feature is now generally available to merchants with a Pro or Elite plan Recurly subscription. See [our documentation](https://docs.recurly.com/docs/invoice-customization#create-and-assigning-invoice-templates) for more information about that feature.