### PR TITLE
Generated Latest Changes for v2019-10-10

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -17259,7 +17259,7 @@ components:
           title: Field value
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
-          maxLength: 100
+          maxLength: 255
       required:
       - name
       - value
@@ -18828,6 +18828,22 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          type: string
+          enum:
+          - fixed
+          - ramp
+          default: fixed
+          description: |
+            A fixed pricing model has the same price for each billing period.
+            A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+            a specified cadence of billing periods. The price change could be an increase or decrease.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         accounting_code:
           type: string
           title: Plan accounting code
@@ -19006,6 +19022,22 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        pricing_model:
+          title: Pricing Model
+          type: string
+          enum:
+          - fixed
+          - ramp
+          default: fixed
+          description: |
+            A fixed pricing model has the same price for each billing period.
+            A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+            a specified cadence of billing periods. The price change could be an increase or decrease.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           type: string
           title: Revenue schedule type
@@ -19137,6 +19169,7 @@ components:
           type: number
           format: float
           title: Unit price
+          description: This field should not be sent when the pricing model is 'ramp'.
           minimum: 0
           maximum: 1000000
         tax_inclusive:
@@ -19214,6 +19247,11 @@ components:
             renew its term at renewal. If `auto_renew` is `false`, then a subscription
             will expire at the end of its term. `auto_renew` can be overridden on
             the subscription record itself.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          items:
+            "$ref": "#/components/schemas/PlanRampInterval"
         revenue_schedule_type:
           type: string
           title: Revenue schedule type
@@ -19291,6 +19329,19 @@ components:
             a non-default dunning campaign should be assigned to this plan. For sites
             without multiple dunning campaigns enabled, the default dunning campaign
             will always be used.
+    PlanRampInterval:
+      type: object
+      title: Plan Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents the first billing cycle of a ramp.
+          default: 1
+        currencies:
+          type: array
+          description: Represents the price for the ramp interval.
+          items:
+            "$ref": "#/components/schemas/PlanRampPricing"
     AddOnPricing:
       type: object
       properties:
@@ -19311,6 +19362,24 @@ components:
           default: false
           description: This field is deprecated. Please do not use it.
           deprecated: true
+      required:
+      - currency
+      - unit_amount
+    PlanRampPricing:
+      type: object
+      properties:
+        currency:
+          type: string
+          title: Currency
+          description: 3-letter ISO 4217 currency code.
+          maxLength: 3
+        unit_amount:
+          type: number
+          format: float
+          title: Unit price
+          description: Represents the price for the Ramp Interval.
+          minimum: 0
+          maximum: 1000000
       required:
       - currency
       - unit_amount
@@ -19899,6 +19968,13 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
         paused_at:
           type: string
           format: date-time
@@ -20362,6 +20438,13 @@ components:
           readOnly: true
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfo"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The ramp intervals representing the pricing schedule for the
+            subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampIntervalResponse"
     SubscriptionChangeBillingInfo:
       type: object
       description: Accept nested attributes for three_d_secure_action_result_token_id
@@ -20501,6 +20584,12 @@ components:
           - moto
         billing_info:
           "$ref": "#/components/schemas/SubscriptionChangeBillingInfoCreate"
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
     SubscriptionChangePreview:
       type: object
       allOf:
@@ -20652,6 +20741,12 @@ components:
           default: true
           title: Auto renew
           description: Whether the subscription renews at the end of its term.
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
         revenue_schedule_type:
           type: string
           title: Revenue schedule type
@@ -20803,6 +20898,12 @@ components:
           - evenly
           - at_range_end
           - at_range_start
+        ramp_intervals:
+          type: array
+          title: Ramp Intervals
+          description: The new set of ramp intervals for the subscription.
+          items:
+            "$ref": "#/components/schemas/SubscriptionRampInterval"
       required:
       - plan_code
     SubscriptionUpdate:
@@ -20986,6 +21087,30 @@ components:
           format: float
           title: Assigns the subscription's shipping cost. If this is greater than
             zero then a `method_id` or `method_code` is required.
+    SubscriptionRampInterval:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+          default: 1
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
+    SubscriptionRampIntervalResponse:
+      type: object
+      title: Subscription Ramp Interval
+      properties:
+        starting_billing_cycle:
+          type: integer
+          description: Represents how many billing cycles are included in a ramp interval.
+        remaining_billing_cycles:
+          type: integer
+          description: Represents how many billing cycles are left in a ramp interval.
+        unit_amount:
+          type: integer
+          description: Represents the price for the ramp interval.
     TaxInfo:
       type: object
       title: Tax info

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -1599,6 +1599,8 @@ class Subscription(Resource):
         For manual invoicing, this identifies the PO number associated with the subscription.
     quantity : int
         Subscription quantity
+    ramp_intervals : :obj:`list` of :obj:`SubscriptionRampIntervalResponse`
+        The ramp intervals representing the pricing schedule for the subscription.
     remaining_billing_cycles : int
         The remaining billing cycles in the current term.
     remaining_pause_cycles : int
@@ -1661,6 +1663,7 @@ class Subscription(Resource):
         "plan": "PlanMini",
         "po_number": str,
         "quantity": int,
+        "ramp_intervals": ["SubscriptionRampIntervalResponse"],
         "remaining_billing_cycles": int,
         "remaining_pause_cycles": int,
         "renewal_billing_cycles": int,
@@ -1811,6 +1814,8 @@ class SubscriptionChange(Resource):
         Just the important parts.
     quantity : int
         Subscription quantity
+    ramp_intervals : :obj:`list` of :obj:`SubscriptionRampIntervalResponse`
+        The ramp intervals representing the pricing schedule for the subscription.
     revenue_schedule_type : str
         Revenue schedule type
     setup_fee_revenue_schedule_type : str
@@ -1840,6 +1845,7 @@ class SubscriptionChange(Resource):
         "object": str,
         "plan": "PlanMini",
         "quantity": int,
+        "ramp_intervals": ["SubscriptionRampIntervalResponse"],
         "revenue_schedule_type": str,
         "setup_fee_revenue_schedule_type": str,
         "shipping": "SubscriptionShipping",
@@ -1975,6 +1981,25 @@ class SubscriptionChangeBillingInfo(Resource):
 
     schema = {
         "three_d_secure_action_result_token_id": str,
+    }
+
+
+class SubscriptionRampIntervalResponse(Resource):
+    """
+    Attributes
+    ----------
+    remaining_billing_cycles : int
+        Represents how many billing cycles are left in a ramp interval.
+    starting_billing_cycle : int
+        Represents how many billing cycles are included in a ramp interval.
+    unit_amount : int
+        Represents the price for the ramp interval.
+    """
+
+    schema = {
+        "remaining_billing_cycles": int,
+        "starting_billing_cycle": int,
+        "unit_amount": int,
     }
 
 
@@ -2234,6 +2259,12 @@ class Plan(Resource):
         This name describes your plan and will appear on the Hosted Payment Page and the subscriber's invoice.
     object : str
         Object type
+    pricing_model : str
+        A fixed pricing model has the same price for each billing period.
+        A ramp pricing model defines a set of Ramp Intervals, where a subscription changes price on
+        a specified cadence of billing periods. The price change could be an increase or decrease.
+    ramp_intervals : :obj:`list` of :obj:`PlanRampInterval`
+        Ramp Intervals
     revenue_schedule_type : str
         Revenue schedule type
     setup_fee_accounting_code : str
@@ -2276,6 +2307,8 @@ class Plan(Resource):
         "interval_unit": str,
         "name": str,
         "object": str,
+        "pricing_model": str,
+        "ramp_intervals": ["PlanRampInterval"],
         "revenue_schedule_type": str,
         "setup_fee_accounting_code": str,
         "setup_fee_revenue_schedule_type": str,
@@ -2290,6 +2323,38 @@ class Plan(Resource):
     }
 
 
+class PlanRampInterval(Resource):
+    """
+    Attributes
+    ----------
+    currencies : :obj:`list` of :obj:`PlanRampPricing`
+        Represents the price for the ramp interval.
+    starting_billing_cycle : int
+        Represents the first billing cycle of a ramp.
+    """
+
+    schema = {
+        "currencies": ["PlanRampPricing"],
+        "starting_billing_cycle": int,
+    }
+
+
+class PlanRampPricing(Resource):
+    """
+    Attributes
+    ----------
+    currency : str
+        3-letter ISO 4217 currency code.
+    unit_amount : float
+        Represents the price for the Ramp Interval.
+    """
+
+    schema = {
+        "currency": str,
+        "unit_amount": float,
+    }
+
+
 class PlanPricing(Resource):
     """
     Attributes
@@ -2301,7 +2366,7 @@ class PlanPricing(Resource):
     tax_inclusive : bool
         This field is deprecated. Please do not use it.
     unit_amount : float
-        Unit price
+        This field should not be sent when the pricing model is 'ramp'.
     """
 
     schema = {
@@ -2532,6 +2597,8 @@ class SubscriptionChangePreview(Resource):
         Just the important parts.
     quantity : int
         Subscription quantity
+    ramp_intervals : :obj:`list` of :obj:`SubscriptionRampIntervalResponse`
+        The ramp intervals representing the pricing schedule for the subscription.
     revenue_schedule_type : str
         Revenue schedule type
     setup_fee_revenue_schedule_type : str
@@ -2561,6 +2628,7 @@ class SubscriptionChangePreview(Resource):
         "object": str,
         "plan": "PlanMini",
         "quantity": int,
+        "ramp_intervals": ["SubscriptionRampIntervalResponse"],
         "revenue_schedule_type": str,
         "setup_fee_revenue_schedule_type": str,
         "shipping": "SubscriptionShipping",


### PR DESCRIPTION
- Adds `pricing_model` property to plan requests and responses (`Plan`, `PlanCreate`), which indicates if the plan is 'fixed' or 'ramp' -priced
- Adds `ramp_intervals` property (`PlanRampInterval`) to plan requests and responses (`Plan`, `PlanCreate`), which defines the pricing schedule of a ramp plan
- Adds `ramp_intervals` property (`SubscriptionRampIntervalResponse`, `SubscriptionRampInterval`) to subscription requests and responses (`Subscription`, `SubscriptionCreate`, `SubscriptionChangeCreate`, `SubscriptionChangePreview`, `SubscriptionPurchase`), which defines the pricing schedule of a ramp subscription