### PR TITLE
Added support for ramp-pricing plans

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -1649,6 +1649,20 @@ class Transaction(Resource):
 Transaction._classes_for_nodename['transaction'] = Transaction
 
 
+class PlanRampInterval(Resource):
+    """A plan ramp
+       representing a price point and the billing_cycle to begin that price point
+    """
+
+    nodename = 'ramp_interval'
+    collection_path = 'ramp_intervals'
+
+    attributes = {
+        'starting_billing_cycle',
+        'unit_amount_in_cents'
+    }
+
+
 class Plan(Resource):
 
     """A service level for your service to which a customer account
@@ -1690,8 +1704,12 @@ class Plan(Resource):
         'auto_renew',
         'allow_any_item_on_subscriptions',
         'dunning_campaign_id',
+        'pricing_model',
+        'ramp_intervals',
     )
 
+    _classes_for_nodename = {'ramp_interval': PlanRampInterval }
+#
     def get_add_on(self, add_on_code):
         """Return the `AddOn` for this plan with the given add-on code."""
         url = urljoin(self._url, '/add_ons/%s' % (add_on_code,))

--- a/tests/fixtures/plan/created_with_ramps.xml
+++ b/tests/fixtures/plan/created_with_ramps.xml
@@ -1,0 +1,75 @@
+POST https://api.recurly.com/v2/plans HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<plan>
+  <plan_code>planmock</plan_code>
+  <name>Mock Plan</name>
+  <setup_fee_in_cents>
+    <USD type="integer">200</USD>
+  </setup_fee_in_cents>
+  <total_billing_cycles type="integer">10</total_billing_cycles>
+  <pricing_model>ramp</pricing_model>
+  <ramp_intervals>
+    <ramp_interval>
+      <unit_amount_in_cents>
+        <USD type="integer">2000</USD>
+      </unit_amount_in_cents>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
+    </ramp_interval>
+    <ramp_interval>
+      <unit_amount_in_cents>
+        <USD type="integer">3000</USD>
+      </unit_amount_in_cents>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
+    </ramp_interval>
+  </ramp_intervals>
+</plan>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/plans/planmock
+
+<?xml version="1.0" encoding="UTF-8"?>
+<plan href="https://api.recurly.com/v2/plans/planmock">
+  <add_ons href="https://api.recurly.com/v2/plans/planmock/add_ons"/>
+  <plan_code>planmock</plan_code>
+  <name>Mock Plan</name>
+  <description nil="nil"></description>
+  <success_url nil="nil"></success_url>
+  <cancel_url nil="nil"></cancel_url>
+  <display_donation_amounts type="boolean">false</display_donation_amounts>
+  <display_quantity type="boolean">false</display_quantity>
+  <display_phone_number type="boolean">false</display_phone_number>
+  <bypass_hosted_confirmation type="boolean">false</bypass_hosted_confirmation>
+  <unit_name>unit</unit_name>
+  <payment_page_tos_link nil="nil"></payment_page_tos_link>
+  <plan_interval_length type="integer">1</plan_interval_length>
+  <plan_interval_unit>months</plan_interval_unit>
+  <trial_interval_length type="integer">0</trial_interval_length>
+  <trial_interval_unit>days</trial_interval_unit>
+  <total_billing_cycles type="integer">10</total_billing_cycles>
+  <created_at type="datetime">2011-10-03T22:23:12Z</created_at>
+  <pricing_model>ramp</pricing_model>
+  <setup_fee_in_cents>
+    <USD type="integer">200</USD>
+  </setup_fee_in_cents>
+  <ramp_intervals>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
+      <unit_amount_in_cents>
+        <USD type="integer">2000</USD>
+      </unit_amount_in_cents>
+    </ramp_interval>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
+      <unit_amount_in_cents>
+        <USD type="integer">3000</USD>
+      </unit_amount_in_cents>
+    </ramp_interval>
+  </ramp_intervals>
+</plan>

--- a/tests/fixtures/plan/exists_with_ramps.xml
+++ b/tests/fixtures/plan/exists_with_ramps.xml
@@ -1,0 +1,52 @@
+GET https://api.recurly.com/v2/plans/planmock HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<plan href="https://api.recurly.com/v2/plans/planmock">
+  <add_ons href="https://api.recurly.com/v2/plans/planmock/add_ons"/>
+  <plan_code>planmock</plan_code>
+  <name>Mock Plan</name>
+  <description nil="nil"></description>
+  <success_url nil="nil"></success_url>
+  <cancel_url nil="nil"></cancel_url>
+  <display_donation_amounts type="boolean">false</display_donation_amounts>
+  <display_quantity type="boolean">false</display_quantity>
+  <display_phone_number type="boolean">false</display_phone_number>
+  <bypass_hosted_confirmation type="boolean">false</bypass_hosted_confirmation>
+  <unit_name>unit</unit_name>
+  <payment_page_tos_link nil="nil"></payment_page_tos_link>
+  <plan_interval_length type="integer">1</plan_interval_length>
+  <plan_interval_unit>months</plan_interval_unit>
+  <trial_interval_length type="integer">0</trial_interval_length>
+  <trial_interval_unit>days</trial_interval_unit>
+  <total_billing_cycles type="integer">10</total_billing_cycles>
+  <created_at type="datetime">2011-10-03T22:23:12Z</created_at>
+  <trial_requires_billing_info type="boolean">false</trial_requires_billing_info>
+  <unit_amount_in_cents>
+  </unit_amount_in_cents>
+  <pricing_model>ramp</pricing_model>
+  <setup_fee_in_cents>
+    <USD type="integer">200</USD>
+  </setup_fee_in_cents>
+  <ramp_intervals>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
+      <unit_amount_in_cents>
+        <USD type="integer">2000</USD>
+      </unit_amount_in_cents>
+    </ramp_interval>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
+      <unit_amount_in_cents>
+        <USD type="integer">3000</USD>
+      </unit_amount_in_cents>
+    </ramp_interval>
+  </ramp_intervals>
+</plan>

--- a/tests/fixtures/plan/updated_with_ramps.xml
+++ b/tests/fixtures/plan/updated_with_ramps.xml
@@ -1,0 +1,66 @@
+PUT https://api.recurly.com/v2/plans/planmock HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<plan>
+  <ramp_intervals>
+    <ramp_interval>
+      <unit_amount_in_cents>
+        <USD type="integer">3000</USD>
+      </unit_amount_in_cents>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
+    </ramp_interval>
+    <ramp_interval>
+      <unit_amount_in_cents>
+        <USD type="integer">4000</USD>
+      </unit_amount_in_cents>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
+    </ramp_interval>
+  </ramp_intervals>
+</plan>
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<plan href="https://api.recurly.com/v2/plans/planmock">
+  <add_ons href="https://api.recurly.com/v2/plans/planmock/add_ons"/>
+  <plan_code>planmock</plan_code>
+  <name>Mock Plan</name>
+  <description nil="nil"></description>
+  <success_url nil="nil"></success_url>
+  <cancel_url nil="nil"></cancel_url>
+  <display_donation_amounts type="boolean">false</display_donation_amounts>
+  <display_quantity type="boolean">false</display_quantity>
+  <display_phone_number type="boolean">false</display_phone_number>
+  <bypass_hosted_confirmation type="boolean">false</bypass_hosted_confirmation>
+  <unit_name>unit</unit_name>
+  <payment_page_tos_link nil="nil"></payment_page_tos_link>
+  <plan_interval_length type="integer">2</plan_interval_length>
+  <plan_interval_unit>months</plan_interval_unit>
+  <trial_interval_length type="integer">0</trial_interval_length>
+  <trial_interval_unit>days</trial_interval_unit>
+  <setup_fee_accounting_code>Setup Fee AC</setup_fee_accounting_code>
+  <created_at type="datetime">2011-10-03T22:23:12Z</created_at>
+  <setup_fee_in_cents>
+    <USD type="integer">200</USD>
+  </setup_fee_in_cents>
+  <ramp_intervals>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
+      <unit_amount_in_cents>
+        <USD type="integer">3000</USD>
+      </unit_amount_in_cents>
+    </ramp_interval>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
+      <unit_amount_in_cents>
+        <USD type="integer">4000</USD>
+      </unit_amount_in_cents>
+    </ramp_interval>
+  </ramp_intervals>
+</plan>


### PR DESCRIPTION
- Adds `pricing_model` attribute to `Plan` Resource, which can be either 'fixed' (for fixed-pricing plans) or 'ramp' (for ramp-pricing plans)
- Adds `ramp_intervals` attribute to Plan Resource
- Adds `RampInterval` class, which can be used to initialize ramp_intervals for plans via the `ramp_intervals` attribute
- Adds unit tests