### PR TITLE
Adds support for subscription with ramps

### DIFF
--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -197,13 +197,11 @@ class Resource(object):
         """ Attributes to be serialized in a ``POST`` or ``PUT`` request.
         Returns all attributes unless a blacklist is specified
         """
-
         if hasattr(self, 'blacklist_attributes'):
             return [attr for attr in self.attributes if attr not in
                     self.blacklist_attributes]
         else:
-            return self.attributes
-
+            return sorted(self.attributes)
 
     def __init__(self, **kwargs):
         try:
@@ -445,33 +443,10 @@ class Resource(object):
                 return value_class.from_element(elem)
 
         # Untyped complex elements should still be resource instances. Guess from the nodename.
-        if len(elem) == 1:
+        if len(elem):
             value_class = cls._subclass_for_nodename(elem.tag)
             log.debug("Converting %r tag into a %s", elem.tag, value_class.__name__)
             return value_class.from_element(elem)
-
-        # Tries to deserialize arrays of elements without type 'array' definition or resource
-        if len(elem) > 1:
-            first_tag = elem[0].tag
-            last_tag = elem[-1].tag
-            # Check if the element have and array of items 
-            # <items>
-            #   <item>...</item>
-            #   <item>...</item>
-            #   <item>...</item>
-            # </items>
-            if(first_tag == last_tag):
-                return [cls._subclass_for_nodename(sub_elem.tag).from_element(sub_elem) for sub_elem in elem]
-            # De-serialize one resource
-            # <resource>
-            #   <name>name</name>
-            #   <description>description</name>
-            #   <other_attribute>other text</other_description>
-            # </resource>
-            else:
-                value_class = cls._subclass_for_nodename(elem.tag)
-                log.debug("Converting %r tag into a %s", elem.tag, value_class.__name__)
-                return value_class.from_element(elem)
 
         value = elem.text or ''
         return value.strip()

--- a/tests/fixtures/account-acquisition/updated.xml
+++ b/tests/fixtures/account-acquisition/updated.xml
@@ -7,11 +7,11 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <account_acquisition>
+  <campaign>hubspot123456</campaign>
+  <channel>social_media</channel>
   <cost_in_cents type="integer">200</cost_in_cents>
   <currency>EUR</currency>
-  <channel>social_media</channel>
   <subchannel>Facebook Post</subchannel>
-  <campaign>hubspot123456</campaign>
 </account_acquisition>
 
 

--- a/tests/fixtures/account/created-with-account-acquisition.xml
+++ b/tests/fixtures/account/created-with-account-acquisition.xml
@@ -7,14 +7,14 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <account>
-  <account_code>testmock</account_code>
   <account_acquisition>
+    <campaign>mailchimp67a904de95.0914d8f4b4</campaign>
+    <channel>blog</channel>
     <cost_in_cents type="integer">199</cost_in_cents>
     <currency>USD</currency>
-    <channel>blog</channel>
     <subchannel>Whitepaper Blog Post</subchannel>
-    <campaign>mailchimp67a904de95.0914d8f4b4</campaign>
   </account_acquisition>
+  <account_code>testmock</account_code>
 </account>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/account/created-with-address.xml
+++ b/tests/fixtures/account/created-with-address.xml
@@ -11,10 +11,10 @@ Content-Type: application/xml; charset=utf-8
   <address>
     <address1>123 Main St</address1>
     <city>San Francisco</city>
-    <state>CA</state>
-    <zip>94105</zip>
     <country>US</country>
     <phone>8015559876</phone>
+    <state>CA</state>
+    <zip>94105</zip>
   </address>
 </account>
 

--- a/tests/fixtures/account/created.xml
+++ b/tests/fixtures/account/created.xml
@@ -8,8 +8,8 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <account>
   <account_code>testmock</account_code>
-  <vat_number>444444-UK</vat_number>
   <preferred_locale>en-US</preferred_locale>
+  <vat_number>444444-UK</vat_number>
 </account>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/account/update-bad-email.xml
+++ b/tests/fixtures/account/update-bad-email.xml
@@ -7,12 +7,12 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <account>
-  <username>shmohawk58</username>
-  <email>larry.david</email>
-  <first_name>Lärry</first_name>
-  <last_name>David</last_name>
-  <company_name>Home Box Office</company_name>
   <accept_language>en-US</accept_language>
+  <company_name>Home Box Office</company_name>
+  <email>larry.david</email>
+  <first_name>Larry</first_name>
+  <last_name>David</last_name>
+  <username>shmohawk58</username>
   <account_code>testmock</account_code>
 </account>
 

--- a/tests/fixtures/account/updated.xml
+++ b/tests/fixtures/account/updated.xml
@@ -7,12 +7,12 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <account>
-  <username>shmohawk58</username>
-  <email>larry.david@example.com</email>
-  <first_name>Lärry</first_name>
-  <last_name>David</last_name>
-  <company_name>Home Box Office</company_name>
   <accept_language>en-US</accept_language>
+  <company_name>Home Box Office</company_name>
+  <email>larry.david@example.com</email>
+  <first_name>Larry</first_name>
+  <last_name>David</last_name>
+  <username>shmohawk58</username>
   <account_code>testmock</account_code>
 </account>
 

--- a/tests/fixtures/add-on/created-percentage-tiered.xml
+++ b/tests/fixtures/add-on/created-percentage-tiered.xml
@@ -8,12 +8,10 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <add_on>
   <add_on_code>addonmock</add_on_code>
-  <name>Mock Add-On</name>
+  <add_on_type>usage</add_on_type>
   <display_quantity_on_hosted_page type="boolean">true</display_quantity_on_hosted_page>
   <measured_unit_id>3473591245469944008</measured_unit_id>
-  <usage_type>percentage</usage_type>
-  <add_on_type>usage</add_on_type>
-  <tier_type>tiered</tier_type>
+  <name>Mock Add-On</name>
   <percentage_tiers>
     <percentage_tier>
       <currency>USD</currency>
@@ -32,6 +30,8 @@ Content-Type: application/xml; charset=utf-8
       </tiers>
     </percentage_tier>
   </percentage_tiers>
+  <tier_type>tiered</tier_type>
+  <usage_type>percentage</usage_type>
 </add_on>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/add-on/created.xml
+++ b/tests/fixtures/add-on/created.xml
@@ -8,13 +8,13 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <add_on>
   <add_on_code>addonmock</add_on_code>
+  <add_on_type>usage</add_on_type>
+  <measured_unit_id type="integer">123456</measured_unit_id>
   <name>Mock Add-On</name>
   <unit_amount_in_cents>
     <USD type="integer">40</USD>
   </unit_amount_in_cents>
-  <measured_unit_id type="integer">123456</measured_unit_id>
   <usage_type>price</usage_type>
-  <add_on_type>usage</add_on_type>
 </add_on>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/add-on/need-amount.xml
+++ b/tests/fixtures/add-on/need-amount.xml
@@ -8,10 +8,10 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <add_on>
   <add_on_code>addonmock</add_on_code>
-  <name>Mock Add-On</name>
-  <measured_unit_id type="integer">123456</measured_unit_id>
-  <usage_type>price</usage_type>
   <add_on_type>usage</add_on_type>
+  <measured_unit_id type="integer">123456</measured_unit_id>
+  <name>Mock Add-On</name>
+  <usage_type>price</usage_type>
 </add_on>
 
 HTTP/1.1 422

--- a/tests/fixtures/add-on/plan-created.xml
+++ b/tests/fixtures/add-on/plan-created.xml
@@ -7,14 +7,14 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <plan>
-  <plan_code>planmock</plan_code>
   <name>Mock Plan</name>
-  <unit_amount_in_cents>
-    <USD type="integer">1000</USD>
-  </unit_amount_in_cents>
+  <plan_code>planmock</plan_code>
   <setup_fee_in_cents>
     <USD type="integer">0</USD>
   </setup_fee_in_cents>
+  <unit_amount_in_cents>
+    <USD type="integer">1000</USD>
+  </unit_amount_in_cents>
 </plan>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/adjustment/charged.xml
+++ b/tests/fixtures/adjustment/charged.xml
@@ -7,9 +7,9 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <adjustment type="charge">
+  <currency>USD</currency>
   <description>test charge</description>
   <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
-  <currency>USD</currency>
 </adjustment>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/billing-info/account-bacs-created.xml
+++ b/tests/fixtures/billing-info/account-bacs-created.xml
@@ -9,14 +9,14 @@ Content-Type: application/xml; charset=utf-8
 <account>
   <account_code>binfo-mock-5</account_code>
   <billing_info>
-    <type>bacs</type>
-    <name_on_account>Account Name</name_on_account>
-    <city>London</city>
-    <zip>W1K 6AH</zip>
-    <country>GB</country>
     <account_number>12345678</account_number>
+    <city>London</city>
+    <country>GB</country>
     <currency>USD</currency>
+    <name_on_account>Account Name</name_on_account>
     <sort_code>200000</sort_code>
+    <type>bacs</type>
+    <zip>W1K 6AH</zip>
   </billing_info>
 </account>
 

--- a/tests/fixtures/billing-info/account-becs-created.xml
+++ b/tests/fixtures/billing-info/account-becs-created.xml
@@ -10,16 +10,16 @@ Content-Type: application/xml; charset=utf-8
   <account_code>binfo-mock-6</account_code>
   <email>verena@example.com</email>
   <billing_info>
-    <type>becs</type>
-    <name_on_account>BECS Test</name_on_account>
-    <address1>125 Paper Street</address1>
-    <city>Adelaide</city>
-    <zip>123456</zip>
-    <country>AU</country>
-    <phone>213-555-5555</phone>
     <account_number>123456</account_number>
-    <currency>AUD</currency>
+    <address1>125 Paper Street</address1>
     <bsb_code>082-082</bsb_code>
+    <city>Adelaide</city>
+    <country>AU</country>
+    <currency>AUD</currency>
+    <name_on_account>BECS Test</name_on_account>
+    <phone>213-555-5555</phone>
+    <type>becs</type>
+    <zip>123456</zip>
   </billing_info>
 </account>
 

--- a/tests/fixtures/billing-info/account-embed-created.xml
+++ b/tests/fixtures/billing-info/account-embed-created.xml
@@ -9,18 +9,18 @@ Content-Type: application/xml; charset=utf-8
 <account>
   <account_code>binfo-mock-2</account_code>
   <billing_info type="credit_card">
-    <first_name>Verena</first_name>
-    <last_name>Example</last_name>
-    <number>4111 1111 1111 1111</number>
-    <verification_value>7777</verification_value>
-    <year>2015</year>
-    <month>12</month>
     <address1>123 Main St</address1>
-    <city>San José</city>
-    <state>CA</state>
-    <zip>94105</zip>
+    <city>San Jose</city>
     <country>US</country>
     <currency>USD</currency>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <month>12</month>
+    <number>4111 1111 1111 1111</number>
+    <state>CA</state>
+    <verification_value>7777</verification_value>
+    <year>2015</year>
+    <zip>94105</zip>
   </billing_info>
 </account>
 

--- a/tests/fixtures/billing-info/account-embed-token.xml
+++ b/tests/fixtures/billing-info/account-embed-token.xml
@@ -9,8 +9,8 @@ Content-Type: application/xml; charset=utf-8
 <account>
   <account_code>binfo-mock-3</account_code>
   <billing_info>
-    <token_id>abc123</token_id>
     <currency>USD</currency>
+    <token_id>abc123</token_id>
   </billing_info>
 </account>
 

--- a/tests/fixtures/billing-info/account-iban-created.xml
+++ b/tests/fixtures/billing-info/account-iban-created.xml
@@ -9,9 +9,9 @@ Content-Type: application/xml; charset=utf-8
 <account>
   <account_code>binfo-mock-4</account_code>
   <billing_info>
-    <name_on_account>Account Name</name_on_account>
     <currency>USD</currency>
     <iban>FR1420041010050500013M02606</iban>
+    <name_on_account>Account Name</name_on_account>
   </billing_info>
 </account>
 

--- a/tests/fixtures/billing-info/created-billing-infos.xml
+++ b/tests/fixtures/billing-info/created-billing-infos.xml
@@ -7,20 +7,20 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <billing_info>
-	<first_name>Humberto</first_name>
-	<last_name>DuMonde</last_name>
-	<number>4111111111111111</number>
-	<verification_value>123</verification_value>
-	<year type="integer">2049</year>
-	<month type="integer">10</month>
-	<address1>12345 Main St</address1>
-	<city>New Orleans</city>
-	<state>LA</state>
-	<zip>70114</zip>
-	<country>US</country>
-	<currency>USD</currency>
-	<primary_payment_method type="boolean">true</primary_payment_method>
-	<backup_payment_method type="boolean">false</backup_payment_method>
+  <address1>12345 Main St</address1>
+  <backup_payment_method type="boolean">false</backup_payment_method>
+  <city>New Orleans</city>
+  <country>US</country>
+  <currency>USD</currency>
+  <first_name>Humberto</first_name>
+  <last_name>DuMonde</last_name>
+  <month type="integer">10</month>
+  <number>4111111111111111</number>
+  <primary_payment_method type="boolean">true</primary_payment_method>
+  <state>LA</state>
+  <verification_value>123</verification_value>
+  <year type="integer">2049</year>
+  <zip>70114</zip>
 </billing_info>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/billing-info/created.xml
+++ b/tests/fixtures/billing-info/created.xml
@@ -7,20 +7,20 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <billing_info type="credit_card">
-  <first_name>Verena</first_name>
-  <last_name>Example</last_name>
-  <number>4111 1111 1111 1111</number>
-  <verification_value>7777</verification_value>
-  <year>2015</year>
-  <month>12</month>
   <address1>123 Main St</address1>
-  <city>San José</city>
-  <state>CA</state>
-  <zip>94105</zip>
+  <city>San Jose</city>
   <country>US</country>
   <currency>USD</currency>
-  <gateway_token>gatewaytoken123</gateway_token>
+  <first_name>Verena</first_name>
   <gateway_code>gatewaycode123</gateway_code>
+  <gateway_token>gatewaytoken123</gateway_token>
+  <last_name>Example</last_name>
+  <month>12</month>
+  <number>4111 1111 1111 1111</number>
+  <state>CA</state>
+  <verification_value>7777</verification_value>
+  <year>2015</year>
+  <zip>94105</zip>
 </billing_info>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/coupon/created.xml
+++ b/tests/fixtures/coupon/created.xml
@@ -8,12 +8,12 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <coupon>
   <coupon_code>couponmock</coupon_code>
-  <name>Nice Coupon</name>
   <discount_in_cents>
     <USD type="integer">1000</USD>
   </discount_in_cents>
-  <invoice_description>Invoice description</invoice_description>
   <hosted_description>Nice Description</hosted_description>
+  <invoice_description>Invoice description</invoice_description>
+  <name>Nice Coupon</name>
 </coupon>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/coupon/item-coupon-created.xml
+++ b/tests/fixtures/coupon/item-coupon-created.xml
@@ -7,15 +7,15 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <coupon>
-    <coupon_code>itemcouponmock</coupon_code>
-    <name>Item Coupon</name>
-    <discount_type>dollars</discount_type>
-    <discount_in_cents>
-        <USD type="integer">2000</USD>
-    </discount_in_cents>
-    <item_codes type="array">
-        <item_code>newitem</item_code>
-    </item_codes>
+  <coupon_code>itemcouponmock</coupon_code>
+  <discount_in_cents>
+    <USD type="integer">2000</USD>
+  </discount_in_cents>
+  <discount_type>dollars</discount_type>
+  <item_codes type="array">
+    <item_code>newitem</item_code>
+  </item_codes>
+  <name>Item Coupon</name>
 </coupon>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/coupon/plan-coupon-created.xml
+++ b/tests/fixtures/coupon/plan-coupon-created.xml
@@ -7,19 +7,19 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <coupon>
-    <coupon_code>plancouponmock</coupon_code>
-    <name>Plan Coupon</name>
-    <discount_in_cents>
-        <USD type="integer">1000</USD>
-    </discount_in_cents>
-    <invoice_description>Invoice description</invoice_description>
-    <applies_to_all_plans type="boolean">false</applies_to_all_plans>
-    <applies_to_non_plan_charges type="boolean">true</applies_to_non_plan_charges>
-    <redemption_resource>subscription</redemption_resource>
-    <plan_codes type="array">
-      <plan_code>basicplan</plan_code>
-    </plan_codes>
-    <max_redemptions_per_account type="integer">1</max_redemptions_per_account>
+  <applies_to_all_plans type="boolean">false</applies_to_all_plans>
+  <applies_to_non_plan_charges type="boolean">true</applies_to_non_plan_charges>
+  <coupon_code>plancouponmock</coupon_code>
+  <discount_in_cents>
+    <USD type="integer">1000</USD>
+  </discount_in_cents>
+  <invoice_description>Invoice description</invoice_description>
+  <max_redemptions_per_account type="integer">1</max_redemptions_per_account>
+  <name>Plan Coupon</name>
+  <plan_codes type="array">
+    <plan_code>basicplan</plan_code>
+  </plan_codes>
+  <redemption_resource>subscription</redemption_resource>
 </coupon>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/coupon/plan-created.xml
+++ b/tests/fixtures/coupon/plan-created.xml
@@ -7,14 +7,14 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <plan>
-  <plan_code>basicplan</plan_code>
   <name>Basic Plan</name>
-  <unit_amount_in_cents>
-    <USD type="integer">1000</USD>
-  </unit_amount_in_cents>
+  <plan_code>basicplan</plan_code>
   <setup_fee_in_cents>
     <USD type="integer">0</USD>
   </setup_fee_in_cents>
+  <unit_amount_in_cents>
+    <USD type="integer">1000</USD>
+  </unit_amount_in_cents>
 </plan>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/coupon/restored.xml
+++ b/tests/fixtures/coupon/restored.xml
@@ -7,9 +7,9 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <coupon>
-  <name>New Name Restore</name>
-  <invoice_description>New Description Restore</invoice_description>
   <hosted_description>New Description Restore</hosted_description>
+  <invoice_description>New Description Restore</invoice_description>
+  <name>New Name Restore</name>
 </coupon>
 
 HTTP/1.1 200 OK

--- a/tests/fixtures/coupon/subscribed.xml
+++ b/tests/fixtures/coupon/subscribed.xml
@@ -7,26 +7,26 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <plan_code>basicplan</plan_code>
-  <coupon_code>couponmock</coupon_code>
-  <currency>USD</currency>
   <account>
     <account_code>coupon-mock-2</account_code>
     <billing_info>
-      <first_name>Verena</first_name>
-      <last_name>Example</last_name>
-      <number>4111 1111 1111 1111</number>
-      <verification_value>7777</verification_value>
-      <year>2015</year>
-      <month>12</month>
       <address1>123 Main St</address1>
       <city>San Francisco</city>
-      <state>CA</state>
-      <zip>94105</zip>
       <country>US</country>
       <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month>12</month>
+      <number>4111 1111 1111 1111</number>
+      <state>CA</state>
+      <verification_value>7777</verification_value>
+      <year>2015</year>
+      <zip>94105</zip>
     </billing_info>
   </account>
+  <coupon_code>couponmock</coupon_code>
+  <currency>USD</currency>
+  <plan_code>basicplan</plan_code>
 </subscription>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/coupon/updated.xml
+++ b/tests/fixtures/coupon/updated.xml
@@ -7,9 +7,9 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <coupon>
-  <name>New Name</name>
-  <invoice_description>New Description</invoice_description>
   <hosted_description>New Description</hosted_description>
+  <invoice_description>New Description</invoice_description>
+  <name>New Name</name>
 </coupon>
 
 HTTP/1.1 200 OK

--- a/tests/fixtures/gift_cards/created.xml
+++ b/tests/fixtures/gift_cards/created.xml
@@ -7,42 +7,42 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <gift_card>
+  <billing_info>
     <currency>USD</currency>
-    <delivery>
-        <address>
-            <address1>400 Alabama St</address1>
-            <city>San Francisco</city>
-            <state>CA</state>
-            <zip>94110</zip>
-            <country>US</country>
-        </address>
-        <email_address>john@email.com</email_address>
-        <first_name>John</first_name>
-        <last_name>Smith</last_name>
-        <method>email</method>
-    </delivery>
-    <gifter_account>
-        <account_code>e0004e3c-216c-4254-8767-9be605cd0b03</account_code>
-        <email>verena@example.com</email>
-        <first_name>Verena</first_name>
-        <last_name>Example</last_name>
-        <billing_info>
-            <first_name>Verena</first_name>
-            <last_name>Example</last_name>
-            <number>4111-1111-1111-1111</number>
-            <verification_value>123</verification_value>
-            <year type="integer">2019</year>
-            <month type="integer">11</month>
-            <country>US</country>
-            <currency>USD</currency>
-        </billing_info>
-    </gifter_account>
-    <product_code>test_gift_card</product_code>
-    <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+    <token_id>1234</token_id>
+  </billing_info>
+  <currency>USD</currency>
+  <delivery>
+    <address>
+      <address1>400 Alabama St</address1>
+      <city>San Francisco</city>
+      <country>US</country>
+      <state>CA</state>
+      <zip>94110</zip>
+    </address>
+    <email_address>john@email.com</email_address>
+    <first_name>John</first_name>
+    <last_name>Smith</last_name>
+    <method>email</method>
+  </delivery>
+  <gifter_account>
+    <account_code>e0004e3c-216c-4254-8767-9be605cd0b03</account_code>
+    <email>verena@example.com</email>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
     <billing_info>
-      <token_id>1234</token_id>
+      <country>US</country>
       <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <verification_value>123</verification_value>
+      <year type="integer">2019</year>
     </billing_info>
+  </gifter_account>
+  <product_code>test_gift_card</product_code>
+  <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
 </gift_card>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/gift_cards/preview.xml
+++ b/tests/fixtures/gift_cards/preview.xml
@@ -7,38 +7,38 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <gift_card>
-    <currency>USD</currency>
-    <delivery>
-        <address>
-            <address1>400 Alabama St</address1>
-            <city>San Francisco</city>
-            <state>CA</state>
-            <zip>94110</zip>
-            <country>US</country>
-        </address>
-        <email_address>john@email.com</email_address>
-        <first_name>John</first_name>
-        <last_name>Smith</last_name>
-        <method>email</method>
-    </delivery>
-    <gifter_account>
-        <account_code>e0004e3c-216c-4254-8767-9be605cd0b03</account_code>
-        <email>verena@example.com</email>
-        <first_name>Verena</first_name>
-        <last_name>Example</last_name>
-        <billing_info>
-            <first_name>Verena</first_name>
-            <last_name>Example</last_name>
-            <number>4111-1111-1111-1111</number>
-            <verification_value>123</verification_value>
-            <year type="integer">2019</year>
-            <month type="integer">11</month>
-            <country>US</country>
-            <currency>USD</currency>
-        </billing_info>
-    </gifter_account>
-    <product_code>test_gift_card</product_code>
-    <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+  <currency>USD</currency>
+  <delivery>
+    <address>
+      <address1>400 Alabama St</address1>
+      <city>San Francisco</city>
+      <country>US</country>
+      <state>CA</state>
+      <zip>94110</zip>
+    </address>
+    <email_address>john@email.com</email_address>
+    <first_name>John</first_name>
+    <last_name>Smith</last_name>
+    <method>email</method>
+  </delivery>
+  <gifter_account>
+    <account_code>e0004e3c-216c-4254-8767-9be605cd0b03</account_code>
+    <email>verena@example.com</email>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <billing_info>
+      <country>US</country>
+      <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <verification_value>123</verification_value>
+      <year type="integer">2019</year>
+    </billing_info>
+  </gifter_account>
+  <product_code>test_gift_card</product_code>
+  <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
 </gift_card>
 
 HTTP/1.1 200 OK

--- a/tests/fixtures/invoice/charged.xml
+++ b/tests/fixtures/invoice/charged.xml
@@ -7,9 +7,9 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <adjustment type="charge">
+  <currency>USD</currency>
   <description>test charge</description>
   <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
-  <currency>USD</currency>
 </adjustment>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/invoice/offline-payment.xml
+++ b/tests/fixtures/invoice/offline-payment.xml
@@ -7,8 +7,8 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <transaction>
-  <currency>USD</currency>
   <amount_in_cents type="integer">5000</amount_in_cents>
+  <currency>USD</currency>
   <description>Collected externally</description>
   <payment_method>paypal</payment_method>
 </transaction>

--- a/tests/fixtures/invoice/update-invoice.xml
+++ b/tests/fixtures/invoice/update-invoice.xml
@@ -7,27 +7,26 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <invoice>
-   <po_number>1234</po_number>
-   <terms_and_conditions>School staff is not responsible for items left at Hogwarts School of Witchcraft and Wizardry.</terms_and_conditions>
-   <customer_notes>It's levi-O-sa, not levio-SA!</customer_notes>
-   <vat_reverse_charge_notes>can't be changed when invoice was not a reverse charge</vat_reverse_charge_notes>
-   <address>
-     <first_name>Harry</first_name>
-     <last_name>Potter</last_name>
-     <name_on_account>Albus Dumbledore</name_on_account>
-     <company>Hogwarts</company>
-     <address1>4 Privet Drive</address1>
-     <address2>Little Whinging</address2>
-     <city>Surrey</city>
-     <state>England</state>
-     <zip>YO8 9FX</zip>
-     <country>Great Britain</country>
-     <phone>781-452-4077</phone>
-   </address>
-   <net_terms type="integer">1</net_terms>
-   <gateway_code>A new gateway code</gateway_code>
+  <po_number>1234</po_number>
+  <terms_and_conditions>School staff is not responsible for items left at Hogwarts School of Witchcraft and Wizardry.</terms_and_conditions>
+  <customer_notes>Its levi-O-sa, not levio-SA!</customer_notes>
+  <vat_reverse_charge_notes>cant be changed when invoice was not a reverse charge</vat_reverse_charge_notes>
+  <address>
+    <address1>4 Privet Drive</address1>
+    <address2>Little Whinging</address2>
+    <city>Surrey</city>
+    <company>Hogwarts</company>
+    <country>Great Britain</country>
+    <first_name>Harry</first_name>
+    <last_name>Potter</last_name>
+    <name_on_account>Albus Dumbledore</name_on_account>
+    <phone>781-452-4077</phone>
+    <state>England</state>
+    <zip>YO8 9FX</zip>
+  </address>
+  <net_terms type="integer">1</net_terms>
+  <gateway_code>A new gateway code</gateway_code>
 </invoice>
-
 
 HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8

--- a/tests/fixtures/item/created.xml
+++ b/tests/fixtures/item/created.xml
@@ -7,9 +7,9 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <item>
+  <description>An item of the mocked variety</description>
   <item_code>itemmock</item_code>
   <name>Mock Item</name>
-  <description>An item of the mocked variety</description>
 </item>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/plan/created-with-ramps.xml
+++ b/tests/fixtures/plan/created-with-ramps.xml
@@ -7,32 +7,31 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <plan>
-  <plan_code>planmock</plan_code>
   <name>Mock Plan</name>
+  <plan_code>planmock</plan_code>
+  <pricing_model>ramp</pricing_model>
+  <ramp_intervals>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
+      <unit_amount_in_cents>
+        <USD type="integer">2000</USD>
+      </unit_amount_in_cents>
+    </ramp_interval>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
+      <unit_amount_in_cents>
+        <USD type="integer">3000</USD>
+      </unit_amount_in_cents>
+    </ramp_interval>
+  </ramp_intervals>
   <setup_fee_in_cents>
     <USD type="integer">200</USD>
   </setup_fee_in_cents>
   <total_billing_cycles type="integer">10</total_billing_cycles>
-  <pricing_model>ramp</pricing_model>
-  <ramp_intervals>
-    <ramp_interval>
-      <unit_amount_in_cents>
-        <USD type="integer">2000</USD>
-      </unit_amount_in_cents>
-      <starting_billing_cycle type="integer">1</starting_billing_cycle>
-    </ramp_interval>
-    <ramp_interval>
-      <unit_amount_in_cents>
-        <USD type="integer">3000</USD>
-      </unit_amount_in_cents>
-      <starting_billing_cycle type="integer">2</starting_billing_cycle>
-    </ramp_interval>
-  </ramp_intervals>
 </plan>
 
 HTTP/1.1 201 Created
 Content-Type: application/xml; charset=utf-8
-Location: https://api.recurly.com/v2/plans/planmock
 
 <?xml version="1.0" encoding="UTF-8"?>
 <plan href="https://api.recurly.com/v2/plans/planmock">
@@ -58,7 +57,7 @@ Location: https://api.recurly.com/v2/plans/planmock
   <setup_fee_in_cents>
     <USD type="integer">200</USD>
   </setup_fee_in_cents>
-  <ramp_intervals>
+  <ramp_intervals type="array">
     <ramp_interval>
       <starting_billing_cycle type="integer">1</starting_billing_cycle>
       <unit_amount_in_cents>

--- a/tests/fixtures/plan/created.xml
+++ b/tests/fixtures/plan/created.xml
@@ -7,15 +7,15 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <plan>
-  <plan_code>planmock</plan_code>
   <name>Mock Plan</name>
-  <unit_amount_in_cents>
-    <USD type="integer">1000</USD>
-  </unit_amount_in_cents>
+  <plan_code>planmock</plan_code>
   <setup_fee_in_cents>
     <USD type="integer">0</USD>
   </setup_fee_in_cents>
   <total_billing_cycles type="integer">10</total_billing_cycles>
+  <unit_amount_in_cents>
+    <USD type="integer">1000</USD>
+  </unit_amount_in_cents>
 </plan>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/plan/exists_with_ramps.xml
+++ b/tests/fixtures/plan/exists_with_ramps.xml
@@ -35,7 +35,7 @@ Content-Type: application/xml; charset=utf-8
   <setup_fee_in_cents>
     <USD type="integer">200</USD>
   </setup_fee_in_cents>
-  <ramp_intervals>
+  <ramp_intervals type="array">
     <ramp_interval>
       <starting_billing_cycle type="integer">1</starting_billing_cycle>
       <unit_amount_in_cents>

--- a/tests/fixtures/plan/updated.xml
+++ b/tests/fixtures/plan/updated.xml
@@ -10,12 +10,12 @@ Content-Type: application/xml; charset=utf-8
   <plan_interval_length type="integer">2</plan_interval_length>
   <plan_interval_unit>months</plan_interval_unit>
   <setup_fee_accounting_code>Setup Fee AC</setup_fee_accounting_code>
-  <unit_amount_in_cents>
-    <USD type="integer">2000</USD>
-  </unit_amount_in_cents>
   <setup_fee_in_cents>
     <USD type="integer">200</USD>
   </setup_fee_in_cents>
+  <unit_amount_in_cents>
+    <USD type="integer">2000</USD>
+  </unit_amount_in_cents>
 </plan>
 
 HTTP/1.1 200 OK

--- a/tests/fixtures/plan/updated_with_ramps.xml
+++ b/tests/fixtures/plan/updated_with_ramps.xml
@@ -9,16 +9,16 @@ Content-Type: application/xml; charset=utf-8
 <plan>
   <ramp_intervals>
     <ramp_interval>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
       <unit_amount_in_cents>
         <USD type="integer">3000</USD>
       </unit_amount_in_cents>
-      <starting_billing_cycle type="integer">1</starting_billing_cycle>
     </ramp_interval>
     <ramp_interval>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
       <unit_amount_in_cents>
         <USD type="integer">4000</USD>
       </unit_amount_in_cents>
-      <starting_billing_cycle type="integer">2</starting_billing_cycle>
     </ramp_interval>
   </ramp_intervals>
 </plan>
@@ -49,7 +49,7 @@ Content-Type: application/xml; charset=utf-8
   <setup_fee_in_cents>
     <USD type="integer">200</USD>
   </setup_fee_in_cents>
-  <ramp_intervals>
+  <ramp_intervals type="array">
     <ramp_interval>
       <starting_billing_cycle type="integer">1</starting_billing_cycle>
       <unit_amount_in_cents>

--- a/tests/fixtures/purchase/authorized.xml
+++ b/tests/fixtures/purchase/authorized.xml
@@ -11,19 +11,19 @@ Content-Type: application/xml; charset=utf-8
     <account_code>testmock</account_code>
     <email>benjamin.dumonde@example.com</email>
     <billing_info>
-      <first_name>Verena</first_name>
-      <last_name>Example</last_name>
-      <number>4111-1111-1111-1111</number>
-      <verification_value>123</verification_value>
-      <year type="integer">2020</year>
-      <month type="integer">11</month>
       <address1>123 Main St</address1>
       <city>New Orleans</city>
-      <state>LA</state>
-      <zip>70114</zip>
       <country>US</country>
       <currency>USD</currency>
       <external_hpp_type>adyen</external_hpp_type>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
     </billing_info>
   </account>
   <adjustments>
@@ -38,12 +38,9 @@ Content-Type: application/xml; charset=utf-8
       <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
     </adjustment>
   </adjustments>
+  <collection_method>manual</collection_method>
   <currency>USD</currency>
-  <subscriptions>
-    <subscription>
-      <plan_code>gold</plan_code>
-    </subscription>
-  </subscriptions>
+  <gateway_code>aBcD1234</gateway_code>
   <shipping_address>
     <address1>456 Pillow Fort Drive</address1>
     <city>New Orleans</city>
@@ -54,8 +51,11 @@ Content-Type: application/xml; charset=utf-8
     <state>LA</state>
     <zip>70114</zip>
   </shipping_address>
-  <gateway_code>aBcD1234</gateway_code>
-  <collection_method>manual</collection_method>
+  <subscriptions>
+    <subscription>
+      <plan_code>gold</plan_code>
+    </subscription>
+  </subscriptions>
 </purchase>
 
 HTTP/1.1 200 OK

--- a/tests/fixtures/purchase/invoiced-billing-info-uuid.xml
+++ b/tests/fixtures/purchase/invoiced-billing-info-uuid.xml
@@ -7,28 +7,28 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <purchase>
-	<account>
-		<account_code>testmock</account_code>
-	</account>
-	<currency>USD</currency>
-	<subscriptions>
-		<subscription>
-			<plan_code>gold</plan_code>
-		</subscription>
-	</subscriptions>
-	<shipping_address>
-		<address1>456 Pillow Fort Drive</address1>
-		<city>New Orleans</city>
-		<country>US</country>
-		<first_name>Verena</first_name>
-		<last_name>Example</last_name>
-		<nickname>Work</nickname>
-		<state>LA</state>
-		<zip>70114</zip>
-	</shipping_address>
-	<gateway_code>aBcD1234</gateway_code>
-	<collection_method>manual</collection_method>
-	<billing_info_uuid>uniqueUuid</billing_info_uuid>
+  <account>
+    <account_code>testmock</account_code>
+  </account>
+  <billing_info_uuid>uniqueUuid</billing_info_uuid>
+  <collection_method>manual</collection_method>
+  <currency>USD</currency>
+  <gateway_code>aBcD1234</gateway_code>
+  <shipping_address>
+    <address1>456 Pillow Fort Drive</address1>
+    <city>New Orleans</city>
+    <country>US</country>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <nickname>Work</nickname>
+    <state>LA</state>
+    <zip>70114</zip>
+  </shipping_address>
+  <subscriptions>
+    <subscription>
+      <plan_code>gold</plan_code>
+    </subscription>
+  </subscriptions>
 </purchase>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/purchase/invoiced.xml
+++ b/tests/fixtures/purchase/invoiced.xml
@@ -10,18 +10,18 @@ Content-Type: application/xml; charset=utf-8
   <account>
     <account_code>testmock</account_code>
     <billing_info>
-      <first_name>Verena</first_name>
-      <last_name>Example</last_name>
-      <number>4111-1111-1111-1111</number>
-      <verification_value>123</verification_value>
-      <year type="integer">2020</year>
-      <month type="integer">11</month>
       <address1>123 Main St</address1>
       <city>New Orleans</city>
-      <state>LA</state>
-      <zip>70114</zip>
       <country>US</country>
       <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
     </billing_info>
   </account>
   <adjustments>
@@ -36,12 +36,9 @@ Content-Type: application/xml; charset=utf-8
       <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
     </adjustment>
   </adjustments>
+  <collection_method>manual</collection_method>
   <currency>USD</currency>
-  <subscriptions>
-    <subscription>
-      <plan_code>gold</plan_code>
-    </subscription>
-  </subscriptions>
+  <gateway_code>aBcD1234</gateway_code>
   <shipping_address>
     <address1>456 Pillow Fort Drive</address1>
     <city>New Orleans</city>
@@ -52,8 +49,11 @@ Content-Type: application/xml; charset=utf-8
     <state>LA</state>
     <zip>70114</zip>
   </shipping_address>
-  <gateway_code>aBcD1234</gateway_code>
-  <collection_method>manual</collection_method>
+  <subscriptions>
+    <subscription>
+      <plan_code>gold</plan_code>
+    </subscription>
+  </subscriptions>
 </purchase>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/purchase/pending-ideal.xml
+++ b/tests/fixtures/purchase/pending-ideal.xml
@@ -11,19 +11,19 @@ Content-Type: application/xml; charset=utf-8
     <account_code>testmock</account_code>
     <email>benjamin.dumonde@example.com</email>
     <billing_info>
-      <first_name>Verena</first_name>
-      <last_name>Example</last_name>
-      <number>4111-1111-1111-1111</number>
-      <verification_value>123</verification_value>
-      <year type="integer">2020</year>
-      <month type="integer">11</month>
       <address1>123 Main St</address1>
       <city>New Orleans</city>
-      <state>LA</state>
-      <zip>70114</zip>
       <country>US</country>
       <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
       <online_banking_payment_type>ideal</online_banking_payment_type>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
     </billing_info>
   </account>
   <adjustments>
@@ -38,12 +38,9 @@ Content-Type: application/xml; charset=utf-8
       <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
     </adjustment>
   </adjustments>
+  <collection_method>manual</collection_method>
   <currency>USD</currency>
-  <subscriptions>
-    <subscription>
-      <plan_code>gold</plan_code>
-    </subscription>
-  </subscriptions>
+  <gateway_code>aBcD1234</gateway_code>
   <shipping_address>
     <address1>456 Pillow Fort Drive</address1>
     <city>New Orleans</city>
@@ -54,8 +51,11 @@ Content-Type: application/xml; charset=utf-8
     <state>LA</state>
     <zip>70114</zip>
   </shipping_address>
-  <gateway_code>aBcD1234</gateway_code>
-  <collection_method>manual</collection_method>
+  <subscriptions>
+    <subscription>
+      <plan_code>gold</plan_code>
+    </subscription>
+  </subscriptions>
 </purchase>
 
 HTTP/1.1 200 OK

--- a/tests/fixtures/purchase/pending.xml
+++ b/tests/fixtures/purchase/pending.xml
@@ -11,19 +11,19 @@ Content-Type: application/xml; charset=utf-8
     <account_code>testmock</account_code>
     <email>benjamin.dumonde@example.com</email>
     <billing_info>
-      <first_name>Verena</first_name>
-      <last_name>Example</last_name>
-      <number>4111-1111-1111-1111</number>
-      <verification_value>123</verification_value>
-      <year type="integer">2020</year>
-      <month type="integer">11</month>
       <address1>123 Main St</address1>
       <city>New Orleans</city>
-      <state>LA</state>
-      <zip>70114</zip>
       <country>US</country>
       <currency>USD</currency>
       <external_hpp_type>adyen</external_hpp_type>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
     </billing_info>
   </account>
   <adjustments>
@@ -38,12 +38,9 @@ Content-Type: application/xml; charset=utf-8
       <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
     </adjustment>
   </adjustments>
+  <collection_method>manual</collection_method>
   <currency>USD</currency>
-  <subscriptions>
-    <subscription>
-      <plan_code>gold</plan_code>
-    </subscription>
-  </subscriptions>
+  <gateway_code>aBcD1234</gateway_code>
   <shipping_address>
     <address1>456 Pillow Fort Drive</address1>
     <city>New Orleans</city>
@@ -54,8 +51,11 @@ Content-Type: application/xml; charset=utf-8
     <state>LA</state>
     <zip>70114</zip>
   </shipping_address>
-  <gateway_code>aBcD1234</gateway_code>
-  <collection_method>manual</collection_method>
+  <subscriptions>
+    <subscription>
+      <plan_code>gold</plan_code>
+    </subscription>
+  </subscriptions>
 </purchase>
 
 HTTP/1.1 200 OK

--- a/tests/fixtures/purchase/previewed.xml
+++ b/tests/fixtures/purchase/previewed.xml
@@ -10,18 +10,18 @@ Content-Type: application/xml; charset=utf-8
   <account>
     <account_code>testmock</account_code>
     <billing_info>
-      <first_name>Verena</first_name>
-      <last_name>Example</last_name>
-      <number>4111-1111-1111-1111</number>
-      <verification_value>123</verification_value>
-      <year type="integer">2020</year>
-      <month type="integer">11</month>
       <address1>123 Main St</address1>
       <city>New Orleans</city>
-      <state>LA</state>
-      <zip>70114</zip>
       <country>US</country>
       <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
     </billing_info>
   </account>
   <adjustments>
@@ -36,12 +36,9 @@ Content-Type: application/xml; charset=utf-8
       <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
     </adjustment>
   </adjustments>
+  <collection_method>manual</collection_method>
   <currency>USD</currency>
-  <subscriptions>
-    <subscription>
-      <plan_code>gold</plan_code>
-    </subscription>
-  </subscriptions>
+  <gateway_code>aBcD1234</gateway_code>
   <shipping_address>
     <address1>456 Pillow Fort Drive</address1>
     <city>New Orleans</city>
@@ -52,8 +49,11 @@ Content-Type: application/xml; charset=utf-8
     <state>LA</state>
     <zip>70114</zip>
   </shipping_address>
-  <gateway_code>aBcD1234</gateway_code>
-  <collection_method>manual</collection_method>
+  <subscriptions>
+    <subscription>
+      <plan_code>gold</plan_code>
+    </subscription>
+  </subscriptions>
 </purchase>
 
 HTTP/1.1 200 OK

--- a/tests/fixtures/subscribe-add-on/item-created.xml
+++ b/tests/fixtures/subscribe-add-on/item-created.xml
@@ -7,9 +7,9 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <item>
+  <description>An item of the mocked variety</description>
   <item_code>itemmock</item_code>
   <name>Mock Item</name>
-  <description>An item of the mocked variety</description>
 </item>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/subscribe-add-on/percentage-tiered-add-on-created.xml
+++ b/tests/fixtures/subscribe-add-on/percentage-tiered-add-on-created.xml
@@ -8,12 +8,10 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <add_on>
   <add_on_code>percentage_tiered_add_on</add_on_code>
-  <name>Percentage Quantity-Based Pricing Add-On</name>
+  <add_on_type>usage</add_on_type>
   <display_quantity_on_hosted_page type="boolean">true</display_quantity_on_hosted_page>
   <measured_unit_id>3473591245469944008</measured_unit_id>
-  <usage_type>percentage</usage_type>
-  <add_on_type>usage</add_on_type>
-  <tier_type>tiered</tier_type>
+  <name>Percentage Quantity-Based Pricing Add-On</name>
   <percentage_tiers>
     <percentage_tier>
       <currency>USD</currency>
@@ -32,6 +30,8 @@ Content-Type: application/xml; charset=utf-8
       </tiers>
     </percentage_tier>
   </percentage_tiers>
+  <tier_type>tiered</tier_type>
+  <usage_type>percentage</usage_type>
 </add_on>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/subscribe-add-on/plan-created.xml
+++ b/tests/fixtures/subscribe-add-on/plan-created.xml
@@ -7,14 +7,14 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <plan>
-  <plan_code>basicplan</plan_code>
   <name>Basic Plan</name>
-  <unit_amount_in_cents>
-    <USD type="integer">1000</USD>
-  </unit_amount_in_cents>
+  <plan_code>basicplan</plan_code>
   <setup_fee_in_cents>
     <USD type="integer">0</USD>
   </setup_fee_in_cents>
+  <unit_amount_in_cents>
+    <USD type="integer">1000</USD>
+  </unit_amount_in_cents>
 </plan>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/subscribe-add-on/subscribed.xml
+++ b/tests/fixtures/subscribe-add-on/subscribed.xml
@@ -7,8 +7,25 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <plan_code>basicplan</plan_code>
+  <account>
+    <account_code>sad-on-mock</account_code>
+    <billing_info>
+      <address1>123 Main St</address1>
+      <city>San Francisco</city>
+      <country>US</country>
+      <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month>12</month>
+      <number>4111 1111 1111 1111</number>
+      <state>CA</state>
+      <verification_value>7777</verification_value>
+      <year>2015</year>
+      <zip>94105</zip>
+    </billing_info>
+  </account>
   <currency>USD</currency>
+  <plan_code>basicplan</plan_code>
   <subscription_add_ons>
     <subscription_add_on>
       <add_on_code>mock_add_on</add_on_code>
@@ -18,8 +35,8 @@ Content-Type: application/xml; charset=utf-8
     </subscription_add_on>
     <subscription_add_on>
       <add_on_code>itemmock</add_on_code>
-      <unit_amount_in_cents type="integer">200</unit_amount_in_cents>
       <add_on_source>item</add_on_source>
+      <unit_amount_in_cents type="integer">200</unit_amount_in_cents>
     </subscription_add_on>
     <subscription_add_on>
       <add_on_code>tiered_add_on</add_on_code>
@@ -28,23 +45,6 @@ Content-Type: application/xml; charset=utf-8
       <add_on_code>percentage_tiered_add_on</add_on_code>
     </subscription_add_on>
   </subscription_add_ons>
-  <account>
-    <account_code>sad-on-mock</account_code>
-    <billing_info>
-      <first_name>Verena</first_name>
-      <last_name>Example</last_name>
-      <number>4111 1111 1111 1111</number>
-      <verification_value>7777</verification_value>
-      <year>2015</year>
-      <month>12</month>
-      <address1>123 Main St</address1>
-      <city>San Francisco</city>
-      <state>CA</state>
-      <zip>94105</zip>
-      <country>US</country>
-      <currency>USD</currency>
-    </billing_info>
-  </account>
 </subscription>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/subscribe-add-on/tiered-add-on-created.xml
+++ b/tests/fixtures/subscribe-add-on/tiered-add-on-created.xml
@@ -8,16 +8,20 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <add_on>
   <add_on_code>tiered_add_on</add_on_code>
-  <name>Quantity-Based Pricing Add-On</name>
   <display_quantity_on_hosted_page>true</display_quantity_on_hosted_page>
+  <name>Quantity-Based Pricing Add-On</name>
   <tier_type>tiered</tier_type>
   <tiers>
     <tier>
       <ending_quantity type="integer">2000</ending_quantity>
-      <unit_amount_in_cents><USD type="integer">1000</USD></unit_amount_in_cents>
+      <unit_amount_in_cents>
+        <USD type="integer">1000</USD>
+      </unit_amount_in_cents>
     </tier>
     <tier>
-      <unit_amount_in_cents><USD type="integer">800</USD></unit_amount_in_cents>
+      <unit_amount_in_cents>
+        <USD type="integer">800</USD>
+      </unit_amount_in_cents>
     </tier>
   </tiers>
 </add_on>

--- a/tests/fixtures/subscription/error-no-billing-info.xml
+++ b/tests/fixtures/subscription/error-no-billing-info.xml
@@ -7,13 +7,13 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <plan_code>basicplan</plan_code>
-  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
-  <currency>USD</currency>
   <bulk type="boolean">true</bulk>
-  <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
+  <currency>USD</currency>
   <customer_notes>Some Customer Notes</customer_notes>
   <imported_trial type="boolean">true</imported_trial>
+  <plan_code>basicplan</plan_code>
+  <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
 </subscription>
 
 HTTP/1.1 400 Bad Request

--- a/tests/fixtures/subscription/exist-with-ramps.xml
+++ b/tests/fixtures/subscription/exist-with-ramps.xml
@@ -1,0 +1,61 @@
+GET https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription
+    href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab">
+  <redemptions href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/redemptions" />
+  <uuid>123456789012345678901234567890ab</uuid>
+  <account href="https://api.recurly.com/v2/accounts/subscribemock"/>
+  <plan href="https://api.recurly.com/v2/plans/basicplan">
+    <plan_code>planmock</plan_code>
+    <name>Basic Plan</name>
+  </plan>
+  <state>active</state>
+  <quantity type="integer">1</quantity>
+  <currency>EUR</currency>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <activated_at type="datetime">2011-05-27T07:00:00Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <current_period_started_at type="datetime">2011-06-27T07:00:00Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2010-07-27T07:00:00Z</current_period_ends_at>
+  <trial_started_at nil="nil"></trial_started_at>
+  <trial_ends_at nil="nil"></trial_ends_at>
+  <tax_in_cents type="integer">0</tax_in_cents>
+  <tax_type>usst</tax_type>
+  <no_billing_info_reason>plan_free_trial</no_billing_info_reason>
+  <gateway_code>A gateway code</gateway_code>
+  <subscription_add_ons type="array">
+    <subscription_add_on>
+        <add_on_type>usage</add_on_type>
+        <measured_unit href="https://api.recurly.com/v2/measured_units/123456"/>
+        <usage href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/add_ons/marketing_emails/usage"/>
+        <add_on_code>marketing_emails</add_on_code>
+        <unit_amount_in_cents type="integer">5</unit_amount_in_cents>
+        <quantity type="integer">1</quantity>
+        <usage_type>price</usage_type>
+        <usage_percentage nil="nil"/>
+    </subscription_add_on>
+  </subscription_add_ons>
+  <ramp_intervals type="array">
+    <ramp_interval>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
+      <unit_amount_in_cents>2000</unit_amount_in_cents>
+      <remaining_billing_cycles>1</remaining_billing_cycles>
+    </ramp_interval>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
+      <unit_amount_in_cents>3000</unit_amount_in_cents>
+      <remaining_billing_cycles></remaining_billing_cycles>
+    </ramp_interval>
+  </ramp_intervals>
+</subscription>

--- a/tests/fixtures/subscription/plan-created.xml
+++ b/tests/fixtures/subscription/plan-created.xml
@@ -7,14 +7,14 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <plan>
-  <plan_code>basicplan</plan_code>
   <name>Basic Plan</name>
-  <unit_amount_in_cents>
-    <USD type="integer">1000</USD>
-  </unit_amount_in_cents>
+  <plan_code>basicplan</plan_code>
   <setup_fee_in_cents>
     <USD type="integer">0</USD>
   </setup_fee_in_cents>
+  <unit_amount_in_cents>
+    <USD type="integer">1000</USD>
+  </unit_amount_in_cents>
 </plan>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/subscription/subscribe-custom-fields.xml
+++ b/tests/fixtures/subscription/subscribe-custom-fields.xml
@@ -7,8 +7,6 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <plan_code>basicplan</plan_code>
-  <currency>USD</currency>
   <account>
     <account_code>subscribe-mock-2</account_code>
     <custom_fields>
@@ -18,26 +16,28 @@ Content-Type: application/xml; charset=utf-8
       </custom_field>
     </custom_fields>
     <billing_info type="credit_card">
-      <first_name>Verena</first_name>
-      <last_name>Example</last_name>
-      <number>4111 1111 1111 1111</number>
-      <verification_value>7777</verification_value>
-      <year>2015</year>
-      <month>12</month>
       <address1>123 Main St</address1>
-      <city>San José</city>
-      <state>CA</state>
-      <zip>94105</zip>
+      <city>San Jose</city>
       <country>US</country>
       <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month>12</month>
+      <number>4111 1111 1111 1111</number>
+      <state>CA</state>
+      <verification_value>7777</verification_value>
+      <year>2015</year>
+      <zip>94105</zip>
     </billing_info>
   </account>
+  <currency>USD</currency>
   <custom_fields>
     <custom_field>
       <name>my_sub_field</name>
       <value>definitely sub value</value>
     </custom_field>
   </custom_fields>
+  <plan_code>basicplan</plan_code>
 </subscription>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/subscription/subscribe-embedded-account.xml
+++ b/tests/fixtures/subscription/subscribe-embedded-account.xml
@@ -7,25 +7,25 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <plan_code>basicplan</plan_code>
-  <currency>USD</currency>
   <account>
     <account_code>subscribe-mock-2</account_code>
     <billing_info type="credit_card">
-      <first_name>Verena</first_name>
-      <last_name>Example</last_name>
-      <number>4111 1111 1111 1111</number>
-      <verification_value>7777</verification_value>
-      <year>2015</year>
-      <month>12</month>
       <address1>123 Main St</address1>
-      <city>San José</city>
-      <state>CA</state>
-      <zip>94105</zip>
+      <city>San Jose</city>
       <country>US</country>
       <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month>12</month>
+      <number>4111 1111 1111 1111</number>
+      <state>CA</state>
+      <verification_value>7777</verification_value>
+      <year>2015</year>
+      <zip>94105</zip>
     </billing_info>
   </account>
+  <currency>USD</currency>
+  <plan_code>basicplan</plan_code>
 </subscription>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/subscription/subscribe-notes.xml
+++ b/tests/fixtures/subscription/subscribe-notes.xml
@@ -7,10 +7,10 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <terms_and_conditions>Some terms and conditions</terms_and_conditions>
   <customer_notes>Some customer notes</customer_notes>
-  <vat_reverse_charge_notes>Some vat reverse charge notes</vat_reverse_charge_notes>
   <gateway_code>A new gateway code</gateway_code>
+  <terms_and_conditions>Some terms and conditions</terms_and_conditions>
+  <vat_reverse_charge_notes>Some vat reverse charge notes</vat_reverse_charge_notes>
 </subscription>
 
 HTTP/1.1 200 OK 

--- a/tests/fixtures/subscription/subscribed-manual.xml
+++ b/tests/fixtures/subscription/subscribed-manual.xml
@@ -7,10 +7,10 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <plan_code>basicplan</plan_code>
+  <collection_method>manual</collection_method>
   <currency>USD</currency>
   <net_terms type="integer">10</net_terms>
-  <collection_method>manual</collection_method>
+  <plan_code>basicplan</plan_code>
   <po_number>1000</po_number>
 </subscription>
 

--- a/tests/fixtures/subscription/subscribed-shipping-address.xml
+++ b/tests/fixtures/subscription/subscribed-shipping-address.xml
@@ -7,8 +7,8 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <plan_code>basicplan</plan_code>
   <currency>USD</currency>
+  <plan_code>basicplan</plan_code>
   <shipping_address>
     <address1>123 Main St</address1>
     <city>San Francisco</city>

--- a/tests/fixtures/subscription/subscribed-with-custom-ramps.xml
+++ b/tests/fixtures/subscription/subscribed-with-custom-ramps.xml
@@ -7,37 +7,39 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <account>
-    <account_code>subscribemock</account_code>
-  </account>
-  <billing_info_uuid>iiznlrvdt8py</billing_info_uuid>
   <bulk type="boolean">true</bulk>
   <currency>USD</currency>
   <customer_notes>Some Customer Notes</customer_notes>
   <imported_trial type="boolean">true</imported_trial>
-  <plan_code>basicplan</plan_code>
+  <plan_code>planmock</plan_code>
+  <ramp_intervals>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
+      <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+    </ramp_interval>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
+      <unit_amount_in_cents type="integer">3000</unit_amount_in_cents>
+    </ramp_interval>
+  </ramp_intervals>
   <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
-  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
 </subscription>
 
 HTTP/1.1 201 Created
 Content-Type: application/xml; charset=utf-8
-Location: https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab
 
 <?xml version="1.0" encoding="UTF-8"?>
-<subscription 
+<subscription
     href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab">
   <uuid>123456789012345678901234567890ab</uuid>
   <account href="https://api.recurly.com/v2/accounts/subscribemock"/>
-  <billing_info href="https://api.recurly.com/v2/accounts/subscribemock/billing_infos/iiznlrvdt8py"/>
   <plan href="https://api.recurly.com/v2/plans/basicplan">
-    <plan_code>basicplan</plan_code>
+    <plan_code>planmock</plan_code>
     <name>Basic Plan</name>
   </plan>
   <state>active</state>
   <quantity type="integer">1</quantity>
   <currency>EUR</currency>
-  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
   <activated_at type="datetime">2011-05-27T07:00:00Z</activated_at>
   <canceled_at nil="nil"></canceled_at>
   <expires_at nil="nil"></expires_at>
@@ -52,4 +54,16 @@ Location: https://api.recurly.com/v2/subscriptions/12345678901234567890123456789
   </subscription_add_ons>
   <a name="cancel" href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/cancel" method="put"/>
   <a name="terminate" href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/terminate" method="put"/>
+  <ramp_intervals type="array">
+    <ramp_interval>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
+      <unit_amount_in_cents>2000</unit_amount_in_cents>
+      <remaining_billing_cycles>1</remaining_billing_cycles>
+    </ramp_interval>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
+      <unit_amount_in_cents>3000</unit_amount_in_cents>
+      <remaining_billing_cycles></remaining_billing_cycles>
+    </ramp_interval>
+  </ramp_intervals>
 </subscription>

--- a/tests/fixtures/subscription/subscribed-with-ramps.xml
+++ b/tests/fixtures/subscription/subscribed-with-ramps.xml
@@ -7,44 +7,29 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <account>
-    <account_code>subscribemock</account_code>
-    <billing_info type="credit_card">
-      <address1>123 Main St</address1>
-      <city>San Jose</city>
-      <country>US</country>
-      <currency>USD</currency>
-      <first_name>Verena</first_name>
-      <last_name>Example</last_name>
-      <month>12</month>
-      <number>4111 1111 1111 1111</number>
-      <state>CA</state>
-      <verification_value>7777</verification_value>
-      <year>2015</year>
-      <zip>94105</zip>
-    </billing_info>
-  </account>
+  <bulk type="boolean">true</bulk>
   <currency>USD</currency>
-  <plan_code>basicplan</plan_code>
+  <customer_notes>Some Customer Notes</customer_notes>
+  <imported_trial type="boolean">true</imported_trial>
+  <plan_code>planmock</plan_code>
+  <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
 </subscription>
 
 HTTP/1.1 201 Created
 Content-Type: application/xml; charset=utf-8
-Location: https://api.recurly.com/v2/plans/basicplan
 
 <?xml version="1.0" encoding="UTF-8"?>
-<subscription 
+<subscription
     href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab">
   <uuid>123456789012345678901234567890ab</uuid>
   <account href="https://api.recurly.com/v2/accounts/subscribemock"/>
   <plan href="https://api.recurly.com/v2/plans/basicplan">
-    <plan_code>basicplan</plan_code>
+    <plan_code>planmock</plan_code>
     <name>Basic Plan</name>
   </plan>
   <state>active</state>
   <quantity type="integer">1</quantity>
   <currency>EUR</currency>
-  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
   <activated_at type="datetime">2011-05-27T07:00:00Z</activated_at>
   <canceled_at nil="nil"></canceled_at>
   <expires_at nil="nil"></expires_at>
@@ -52,6 +37,23 @@ Location: https://api.recurly.com/v2/plans/basicplan
   <current_period_ends_at type="datetime">2010-07-27T07:00:00Z</current_period_ends_at>
   <trial_started_at nil="nil"></trial_started_at>
   <trial_ends_at nil="nil"></trial_ends_at>
+  <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
+  <customer_notes>Some Customer Notes</customer_notes>
+  <imported_trial type="boolean">true</imported_trial>
   <subscription_add_ons type="array">
   </subscription_add_ons>
+  <a name="cancel" href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/cancel" method="put"/>
+  <a name="terminate" href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/terminate" method="put"/>
+  <ramp_intervals type="array">
+    <ramp_interval>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
+      <unit_amount_in_cents>2000</unit_amount_in_cents>
+      <remaining_billing_cycles>1</remaining_billing_cycles>
+    </ramp_interval>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
+      <unit_amount_in_cents>3000</unit_amount_in_cents>
+      <remaining_billing_cycles></remaining_billing_cycles>
+    </ramp_interval>
+  </ramp_intervals>
 </subscription>

--- a/tests/fixtures/subscription/subscribed.xml
+++ b/tests/fixtures/subscription/subscribed.xml
@@ -7,13 +7,13 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <plan_code>basicplan</plan_code>
-  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
-  <currency>USD</currency>
   <bulk type="boolean">true</bulk>
-  <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
+  <currency>USD</currency>
   <customer_notes>Some Customer Notes</customer_notes>
   <imported_trial type="boolean">true</imported_trial>
+  <plan_code>basicplan</plan_code>
+  <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
 </subscription>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/subscription/update-billing-info.xml
+++ b/tests/fixtures/subscription/update-billing-info.xml
@@ -7,18 +7,18 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <billing_info type="credit_card">
-  <first_name>Verena</first_name>
-  <last_name>Example</last_name>
-  <number>4111 1111 1111 1111</number>
-  <verification_value>7777</verification_value>
-  <year>2015</year>
-  <month>12</month>
   <address1>123 Main St</address1>
-  <city>San José</city>
-  <state>CA</state>
-  <zip>94105</zip>
+  <city>San Jose</city>
   <country>US</country>
   <currency>USD</currency>
+  <first_name>Verena</first_name>
+  <last_name>Example</last_name>
+  <month>12</month>
+  <number>4111 1111 1111 1111</number>
+  <state>CA</state>
+  <verification_value>7777</verification_value>
+  <year>2015</year>
+  <zip>94105</zip>
 </billing_info>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/subscription/updated-at-renewal.xml
+++ b/tests/fixtures/subscription/updated-at-renewal.xml
@@ -7,8 +7,8 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <unit_amount_in_cents type="integer">800</unit_amount_in_cents>
   <timeframe>renewal</timeframe>
+  <unit_amount_in_cents type="integer">800</unit_amount_in_cents>
 </subscription>
 
 HTTP/1.1 200 OK

--- a/tests/fixtures/subscription/updated-with-ramps.xml
+++ b/tests/fixtures/subscription/updated-with-ramps.xml
@@ -1,4 +1,4 @@
-POST https://api.recurly.com/v2/accounts/subscribemock/subscriptions HTTP/1.1
+PUT https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab HTTP/1.1
 X-Api-Version: {api-version}
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
@@ -7,37 +7,34 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <subscription>
-  <account>
-    <account_code>subscribemock</account_code>
-  </account>
-  <billing_info_uuid>iiznlrvdt8py</billing_info_uuid>
-  <bulk type="boolean">true</bulk>
-  <currency>USD</currency>
-  <customer_notes>Some Customer Notes</customer_notes>
-  <imported_trial type="boolean">true</imported_trial>
-  <plan_code>basicplan</plan_code>
-  <terms_and_conditions>Some Terms and Conditions</terms_and_conditions>
-  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <ramp_intervals>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
+      <unit_amount_in_cents type="integer">3000</unit_amount_in_cents>
+    </ramp_interval>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
+      <unit_amount_in_cents type="integer">4000</unit_amount_in_cents>
+    </ramp_interval>
+  </ramp_intervals>
+  <timeframe>now</timeframe>
 </subscription>
 
-HTTP/1.1 201 Created
+HTTP/1.1 200 OK
 Content-Type: application/xml; charset=utf-8
-Location: https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab
 
 <?xml version="1.0" encoding="UTF-8"?>
-<subscription 
+<subscription
     href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab">
   <uuid>123456789012345678901234567890ab</uuid>
   <account href="https://api.recurly.com/v2/accounts/subscribemock"/>
-  <billing_info href="https://api.recurly.com/v2/accounts/subscribemock/billing_infos/iiznlrvdt8py"/>
   <plan href="https://api.recurly.com/v2/plans/basicplan">
-    <plan_code>basicplan</plan_code>
+    <plan_code>planmock</plan_code>
     <name>Basic Plan</name>
   </plan>
   <state>active</state>
   <quantity type="integer">1</quantity>
   <currency>EUR</currency>
-  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
   <activated_at type="datetime">2011-05-27T07:00:00Z</activated_at>
   <canceled_at nil="nil"></canceled_at>
   <expires_at nil="nil"></expires_at>
@@ -52,4 +49,16 @@ Location: https://api.recurly.com/v2/subscriptions/12345678901234567890123456789
   </subscription_add_ons>
   <a name="cancel" href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/cancel" method="put"/>
   <a name="terminate" href="https://api.recurly.com/v2/subscriptions/123456789012345678901234567890ab/terminate" method="put"/>
+  <ramp_intervals type="array">
+    <ramp_interval>
+      <starting_billing_cycle type="integer">1</starting_billing_cycle>
+      <unit_amount_in_cents>3000</unit_amount_in_cents>
+      <remaining_billing_cycles>1</remaining_billing_cycles>
+    </ramp_interval>
+    <ramp_interval>
+      <starting_billing_cycle type="integer">2</starting_billing_cycle>
+      <unit_amount_in_cents>4000</unit_amount_in_cents>
+      <remaining_billing_cycles></remaining_billing_cycles>
+    </ramp_interval>
+  </ramp_intervals>
 </subscription>

--- a/tests/fixtures/transaction-balance/credited.xml
+++ b/tests/fixtures/transaction-balance/credited.xml
@@ -7,9 +7,9 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <adjustment>
+  <currency>USD</currency>
   <description>transaction test credit</description>
   <unit_amount_in_cents type="integer">-2000</unit_amount_in_cents>
-  <currency>USD</currency>
 </adjustment>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/transaction-balance/set-billing-info.xml
+++ b/tests/fixtures/transaction-balance/set-billing-info.xml
@@ -7,18 +7,18 @@ Content-Type: application/xml; charset=utf-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <billing_info type="credit_card">
-  <first_name>Verena</first_name>
-  <last_name>Example</last_name>
-  <number>4111 1111 1111 1111</number>
-  <verification_value>7777</verification_value>
-  <year>2015</year>
-  <month>12</month>
   <address1>123 Main St</address1>
-  <city>San José</city>
-  <state>CA</state>
-  <zip>94105</zip>
+  <city>San Jose</city>
   <country>US</country>
   <currency>USD</currency>
+  <first_name>Verena</first_name>
+  <last_name>Example</last_name>
+  <month>12</month>
+  <number>4111 1111 1111 1111</number>
+  <state>CA</state>
+  <verification_value>7777</verification_value>
+  <year>2015</year>
+  <zip>94105</zip>
 </billing_info>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/transaction-balance/transacted-2.xml
+++ b/tests/fixtures/transaction-balance/transacted-2.xml
@@ -10,8 +10,8 @@ Content-Type: application/xml; charset=utf-8
   <account>
     <account_code>transbalancemock</account_code>
   </account>
-  <currency>USD</currency>
   <amount_in_cents type="integer">500</amount_in_cents>
+  <currency>USD</currency>
 </transaction>
 
 HTTP/1.1 204 No Content

--- a/tests/fixtures/transaction-balance/transacted-3.xml
+++ b/tests/fixtures/transaction-balance/transacted-3.xml
@@ -10,8 +10,8 @@ Content-Type: application/xml; charset=utf-8
   <account>
     <account_code>transbalancemock</account_code>
   </account>
-  <currency>USD</currency>
   <amount_in_cents type="integer">3000</amount_in_cents>
+  <currency>USD</currency>
 </transaction>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/transaction-balance/transacted.xml
+++ b/tests/fixtures/transaction-balance/transacted.xml
@@ -10,8 +10,8 @@ Content-Type: application/xml; charset=utf-8
   <account>
     <account_code>transbalancemock</account_code>
   </account>
-  <currency>USD</currency>
   <amount_in_cents type="integer">1000</amount_in_cents>
+  <currency>USD</currency>
 </transaction>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/transaction-balance/transaction-no-account.xml
+++ b/tests/fixtures/transaction-balance/transaction-no-account.xml
@@ -8,8 +8,8 @@ Content-Type: application/xml; charset=utf-8
 <?xml version="1.0" encoding="UTF-8"?>
 <transaction>
   <account />
-  <currency>USD</currency>
   <amount_in_cents type="integer">1000</amount_in_cents>
+  <currency>USD</currency>
 </transaction>
 
 HTTP/1.1 422

--- a/tests/fixtures/transaction-balance/transaction-no-billing-fails.xml
+++ b/tests/fixtures/transaction-balance/transaction-no-billing-fails.xml
@@ -10,8 +10,8 @@ Content-Type: application/xml; charset=utf-8
   <account>
     <account_code>transbalancemock</account_code>
   </account>
-  <currency>USD</currency>
   <amount_in_cents type="integer">1000</amount_in_cents>
+  <currency>USD</currency>
 </transaction>
 
 HTTP/1.1 422

--- a/tests/fixtures/transaction/created-again.xml
+++ b/tests/fixtures/transaction/created-again.xml
@@ -10,8 +10,8 @@ Content-Type: application/xml; charset=utf-8
   <account>
     <account_code>transactionmock</account_code>
   </account>
-  <currency>USD</currency>
   <amount_in_cents type="integer">1000</amount_in_cents>
+  <currency>USD</currency>
 </transaction>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/transaction/created.xml
+++ b/tests/fixtures/transaction/created.xml
@@ -10,22 +10,22 @@ Content-Type: application/xml; charset=utf-8
   <account>
     <account_code>transactionmock</account_code>
     <billing_info>
-      <first_name>Verena</first_name>
-      <last_name>Example</last_name>
-      <number>4111-1111-1111-1111</number>
-      <verification_value>7777</verification_value>
-      <year>2014</year>
-      <month>7</month>
       <address1>123 Main St</address1>
       <city>San Francisco</city>
-      <state>CA</state>
-      <zip>94105</zip>
       <country>US</country>
       <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month>7</month>
+      <number>4111-1111-1111-1111</number>
+      <state>CA</state>
+      <verification_value>7777</verification_value>
+      <year>2014</year>
+      <zip>94105</zip>
     </billing_info>
   </account>
-  <currency>USD</currency>
   <amount_in_cents type="integer">1000</amount_in_cents>
+  <currency>USD</currency>
 </transaction>
 
 HTTP/1.1 201 Created

--- a/tests/fixtures/transaction/declined-transaction.xml
+++ b/tests/fixtures/transaction/declined-transaction.xml
@@ -10,8 +10,8 @@ Content-Type: application/xml; charset=utf-8
   <account>
     <account_code>transactionmock</account_code>
   </account>
-  <currency>USD</currency>
   <amount_in_cents type="integer">1000</amount_in_cents>
+  <currency>USD</currency>
 </transaction>
 
 HTTP/1.1 422

--- a/tests/fixtures/transaction/error-client.xml
+++ b/tests/fixtures/transaction/error-client.xml
@@ -10,8 +10,8 @@ Content-Type: application/xml; charset=utf-8
   <account>
     <account_code>transactionmock</account_code>
   </account>
-  <currency>USD</currency>
   <amount_in_cents type="integer">1000</amount_in_cents>
+  <currency>USD</currency>
 </transaction>
 
 HTTP/1.1 495

--- a/tests/fixtures/transaction/error-server.xml
+++ b/tests/fixtures/transaction/error-server.xml
@@ -10,8 +10,8 @@ Content-Type: application/xml; charset=utf-8
   <account>
     <account_code>transactionmock</account_code>
   </account>
-  <currency>USD</currency>
   <amount_in_cents type="integer">1000</amount_in_cents>
+  <currency>USD</currency>
 </transaction>
 
 HTTP/1.1 530 Origin DNS Error

--- a/tests/fixtures/transaction/error-teapot.xml
+++ b/tests/fixtures/transaction/error-teapot.xml
@@ -10,8 +10,8 @@ Content-Type: application/xml; charset=utf-8
   <account>
     <account_code>transactionmock</account_code>
   </account>
-  <currency>USD</currency>
   <amount_in_cents type="integer">1000</amount_in_cents>
+  <currency>USD</currency>
 </transaction>
 
 HTTP/1.1 418 I'm a teapot

--- a/tests/recurlytests.py
+++ b/tests/recurlytests.py
@@ -106,8 +106,8 @@ class MockRequestManager(object):
     def assert_request(self):
         headers = dict(self.headers)
         if 'user-agent' in headers:
-            import recurly
             headers['user-agent'] = headers['user-agent'].replace('{user-agent}', recurly.USER_AGENT)
+
         headers['x-api-version'] = headers['x-api-version'].replace('{api-version}', recurly.API_VERSION)
         self.request_mock.assert_called_once_with(self.method, self.uri, self.body, headers)
 


### PR DESCRIPTION
- Add `ramp_intervals` attribute in `Subscription` Resource.
- Add new `SubRampInterval` representation.
- Move some models(`PlanRampInterval`, `Plan`, `SubAddOnPercentageTier`, `Tier`, `SubscriptionAddOn`) before `Subscription` to assign `_classes_for_nodename` .