### PR TITLE
Added support for ramp-pricing purchases 

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -896,6 +896,7 @@ class Adjustment(Resource):
         'revenue_schedule_type',
         'shipping_address',
         'shipping_address_id',
+        'refundable_total_in_cents',
     )
     xml_attribute_attributes = ('type',)
     _classes_for_nodename = {'tax_detail': TaxDetail, 'shipping_address': ShippingAddress}
@@ -959,6 +960,7 @@ class Invoice(Resource):
         'billing_info',
         'billing_info_uuid',
         'dunning_campaign_id',
+        'refundable_in_cents'
     )
 
     blacklist_attributes = (
@@ -1185,7 +1187,8 @@ class Purchase(Resource):
         'gateway_code',
         'collection_method',
         'transaction_type',
-        'billing_info_uuid'
+        'billing_info_uuid',
+        'ramp_intervals',
     )
 
     def invoice(self):
@@ -1321,11 +1324,6 @@ class PlanRampInterval(Resource):
         'unit_amount_in_cents',
         'starting_billing_cycle'
     }
-    
-    def __str__(self):
-        return 'PlanRampInterval(starting_billing_cycle={},unit_amount_in_cents={})'.format(self.starting_billing_cycle, self.unit_amount_in_cents.currencies)
-
-
 class Plan(Resource):
 
     """A service level for your service to which a customer account
@@ -1399,9 +1397,6 @@ class SubRampInterval(Resource):
         'starting_billing_cycle',
         'remaining_billing_cycles'
     }
-
-    def __str__(self):
-        return 'SubRampInterval(starting_billing_cycle={},unit_amount_in_cents={}),remaining_billing_cycles={}' .format(self.starting_billing_cycle, self.unit_amount_in_cents, self.remaining_billing_cycles)
 
 class SubAddOnPercentageTier(Resource):
 
@@ -1532,7 +1527,7 @@ class Subscription(Resource):
         'custom_field': CustomField,
         'invoice_collection': InvoiceCollection,
         'plan': Plan,
-        'ramp_interval': SubRampInterval, 
+        'ramp_interval': SubRampInterval,
         'subscription_add_on': SubscriptionAddOn,
     }
 
@@ -1845,7 +1840,7 @@ class MeasuredUnit(Resource):
 
 class PercentageTier(Resource):
 
-    """Percentage tier associated to a set of tiers per currency 
+    """Percentage tier associated to a set of tiers per currency
     in an add-on."""
 
     nodename = 'tier'

--- a/recurly/resource.py
+++ b/recurly/resource.py
@@ -216,6 +216,36 @@ class Resource(object):
             if key not in ('collection_path', 'member_path', 'node_name', 'attributes'):
                 setattr(self, key, value)
 
+    def _beauty_print(self):
+        title = self.__class__.__name__
+
+        attrs_output = ''
+        for idx, attribute in enumerate(self.attributes):
+            is_not_last = idx != len(self.attributes) - 1
+            try:
+                attr_value = getattr(self, attribute)
+                if isinstance(attr_value, Resource):
+                    attrs_output += '{}={}'.format(attribute, attr_value._beauty_print())
+                elif type(attr_value) is list and len(attr_value) > 0:
+                    attrs_output += '{}=['.format(attribute)
+                    for val in attr_value: 
+                        attrs_output += val._beauty_print()
+                    attrs_output += ']'
+                else:
+                    attrs_output += '{}={}'.format(attribute, attr_value)
+            except:
+                attrs_output += '{}=None'.format(attribute)
+
+            if is_not_last:
+                attrs_output += ', '
+
+        output = '<\033[1m{}\033[0m({})>'.format(title, attrs_output)
+
+        return output
+
+    def __str__(self):
+        return self._beauty_print()
+
     @classmethod
     def http_request(cls, url, method='GET', body=None, headers=None):
         """Make an HTTP request with the given method to the given URL,
@@ -713,9 +743,9 @@ class Resource(object):
             except KeyError:
                 continue
             # With one exception, type is an element xml attribute, e.g. <billing info type="credit_card"> or <adjustment type="charge">
-            # For billing_info, type property takes precedence over xml attribute when type = bacs or becs, e.g. <billing info><type>bacs</type></billing_info>. 
+            # For billing_info, type property takes precedence over xml attribute when type = bacs or becs, e.g. <billing info><type>bacs</type></billing_info>.
             if attrname in self.xml_attribute_attributes and (
-              (root_name != 'billing_info' and attrname == 'type') 
+              (root_name != 'billing_info' and attrname == 'type')
               or (root_name == 'billing_info' and value not in ('bacs', 'becs'))
             ):
               elem.attrib[attrname] = six.text_type(value)

--- a/tests/fixtures/purchase-with-ramp-intervals/authorized.xml
+++ b/tests/fixtures/purchase-with-ramp-intervals/authorized.xml
@@ -1,0 +1,163 @@
+POST https://api.recurly.com/v2/purchases/authorize HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<purchase>
+  <account>
+    <account_code>testmock</account_code>
+    <email>benjamin.dumonde@example.com</email>
+    <billing_info>
+      <address1>123 Main St</address1>
+      <city>New Orleans</city>
+      <country>US</country>
+      <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
+    </billing_info>
+  </account>
+  <collection_method>automatic</collection_method>
+  <currency>USD</currency>
+  <gateway_code>aBcD1234</gateway_code>
+  <shipping_address>
+    <address1>456 Pillow Fort Drive</address1>
+    <city>New Orleans</city>
+    <country>US</country>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <nickname>Work</nickname>
+    <state>LA</state>
+    <zip>70114</zip>
+  </shipping_address>
+  <subscriptions>
+    <subscription>
+      <plan_code>ramp-plan</plan_code>
+      <ramp_intervals>
+        <ramp_interval>
+          <starting_billing_cycle type="integer">1</starting_billing_cycle>
+          <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+        </ramp_interval>
+        <ramp_interval>
+          <starting_billing_cycle type="integer">3</starting_billing_cycle>
+          <unit_amount_in_cents type="integer">3000</unit_amount_in_cents>
+        </ramp_interval>
+      </ramp_intervals>
+    </subscription>
+  </subscriptions>
+</purchase>
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/1021
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice_collection>
+    <charge_invoice href="">
+      <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+      <address>
+        <address1>123 Main St</address1>
+        <address2 nil="nil"></address2>
+        <city>New Orleans</city>
+        <state>LA</state>
+        <zip>70114</zip>
+        <country>US</country>
+        <phone nil="nil"></phone>
+      </address>
+      <uuid>40625fd700c1c2d90060744092b4a1b1</uuid>
+      <state>pending</state>
+      <invoice_number_prefix></invoice_number_prefix>
+      <invoice_number nil="nil"></invoice_number>
+      <po_number nil="nil"></po_number>
+      <vat_number nil="nil"></vat_number>
+      <subtotal_in_cents type="integer">6000</subtotal_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <total_in_cents type="integer">6000</total_in_cents>
+      <subtotal_after_discount_in_cents type="integer">6000</subtotal_after_discount_in_cents>
+      <currency>USD</currency>
+      <created_at nil="nil"></created_at>
+      <updated_at nil="nil"></updated_at>
+      <attempt_next_collection_at type="datetime">2017-10-06T21:25:55Z</attempt_next_collection_at>
+      <closed_at nil="nil"></closed_at>
+      <terms_and_conditions nil="nil"></terms_and_conditions>
+      <customer_notes nil="nil"></customer_notes>
+      <recovery_reason nil="nil"></recovery_reason>
+      <net_terms type="integer">0</net_terms>
+      <collection_method>automatic</collection_method>
+      <line_items type="array">
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6fc46181e2f15044db38c1c82</uuid>
+          <state>pending</state>
+          <description>gold</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code>gold</product_code>
+          <origin>plan</origin>
+          <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+          <quantity type="integer">1</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">1000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date type="datetime">2017-11-06T21:25:55Z</end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type>evenly</revenue_schedule_type>
+        </adjustment>
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6e6a5817b59a2174b72a92fea</uuid>
+          <state>pending</state>
+          <description>Item 1</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code nil="nil"></product_code>
+          <origin>debit</origin>
+          <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+          <quantity type="integer">1</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">1000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date nil="nil"></end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type></revenue_schedule_type>
+        </adjustment>
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6e9096c9922b52646e29f6d5e</uuid>
+          <state>pending</state>
+          <description>Item 2</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code nil="nil"></product_code>
+          <origin>debit</origin>
+          <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+          <quantity type="integer">2</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">4000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date nil="nil"></end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type></revenue_schedule_type>
+        </adjustment>
+      </line_items>
+      <transactions type="array">
+      </transactions>
+    </charge_invoice>
+</invoice_collection>

--- a/tests/fixtures/purchase-with-ramp-intervals/invoiced.xml
+++ b/tests/fixtures/purchase-with-ramp-intervals/invoiced.xml
@@ -1,0 +1,214 @@
+POST https://api.recurly.com/v2/purchases HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<purchase>
+  <account>
+    <account_code>testmock</account_code>
+    <billing_info>
+      <address1>123 Main St</address1>
+      <city>New Orleans</city>
+      <country>US</country>
+      <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
+    </billing_info>
+  </account>
+  <collection_method>automatic</collection_method>
+  <currency>USD</currency>
+  <gateway_code>aBcD1234</gateway_code>
+  <shipping_address>
+    <address1>456 Pillow Fort Drive</address1>
+    <city>New Orleans</city>
+    <country>US</country>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <nickname>Work</nickname>
+    <state>LA</state>
+    <zip>70114</zip>
+  </shipping_address>
+  <subscriptions>
+    <subscription>
+      <plan_code>ramp-plan</plan_code>
+      <ramp_intervals>
+        <ramp_interval>
+          <starting_billing_cycle type="integer">1</starting_billing_cycle>
+          <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+        </ramp_interval>
+        <ramp_interval>
+          <starting_billing_cycle type="integer">3</starting_billing_cycle>
+          <unit_amount_in_cents type="integer">3000</unit_amount_in_cents>
+        </ramp_interval>
+      </ramp_intervals>
+    </subscription>
+  </subscriptions>
+</purchase>
+
+HTTP/1.1 201 Created 
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/1021
+
+<?xml version="1.0" encoding="utf-8"?>
+<invoice_collection>
+  <charge_invoice href="https://api.recurly.com/v2/invoices/1240">
+    <account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+    <dunning_campaign_id nil="nil"/>
+    <address>
+      <name_on_account nil="nil"/>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <company/>
+      <address1>123 Main St</address1>
+      <address2 nil="nil"/>
+      <city>New Orleans</city>
+      <state>LA</state>
+      <zip>70114</zip>
+      <country>US</country>
+      <phone nil="nil"/>
+    </address>
+    <shipping_address>
+      <address1>456 Pillow Fort Drive</address1>
+      <city>New Orleans</city>
+      <country>US</country>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <nickname>Work</nickname>
+      <state>LA</state>
+      <zip>70114</zip>
+    </shipping_address>
+    <subscriptions href="https://api.recurly.com/v2/invoices/1240/subscriptions"/>
+    <uuid>63f7cd6612ef3c7befe2aa4432bd9426</uuid>
+    <state>paid</state>
+    <invoice_number_prefix/>
+    <invoice_number type="integer">1240</invoice_number>
+    <vat_number nil="nil"/>
+    <tax_in_cents type="integer">0</tax_in_cents>
+    <total_in_cents type="integer">7000</total_in_cents>
+    <currency>USD</currency>
+    <created_at type="datetime">2022-08-10T18:26:38Z</created_at>
+    <updated_at type="datetime">2022-08-10T18:26:38Z</updated_at>
+    <attempt_next_collection_at nil="nil"/>
+    <closed_at type="datetime">2022-08-10T18:26:38Z</closed_at>
+    <customer_notes nil="nil"/>
+    <recovery_reason nil="nil"/>
+    <gateway_code nil="nil"/>
+    <subtotal_before_discount_in_cents type="integer">7000</subtotal_before_discount_in_cents>
+    <subtotal_in_cents type="integer">7000</subtotal_in_cents>
+    <discount_in_cents type="integer">0</discount_in_cents>
+    <due_on type="datetime">2022-08-10T18:26:38Z</due_on>
+    <balance_in_cents type="integer">0</balance_in_cents>
+    <type>charge</type>
+    <origin>purchase</origin>
+    <credit_invoices href="https://api.recurly.com/v2/invoices/1240/credit_invoices"/>
+    <refundable_total_in_cents type="integer">7000</refundable_total_in_cents>
+    <credit_payments type="array"/>
+    <net_terms type="integer">0</net_terms>
+    <collection_method>automatic</collection_method>
+    <po_number nil="nil"/>
+    <terms_and_conditions nil="nil"/>
+    <line_items type="array">
+      <adjustment href="https://api.recurly.com/v2/adjustments/63f7cd6605de0c75fbdf8745b28f77a8" type="charge">
+        <account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+        <bill_for_account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+        <item_code nil="nil"/>
+        <external_sku nil="nil"/>
+        <invoice href="https://api.recurly.com/v2/invoices/1240"/>
+        <subscription href="https://api.recurly.com/v2/subscriptions/63f7cd659ab7ad05401eff456dab46f8"/>
+        <credit_adjustments href="https://api.recurly.com/v2/adjustments/63f7cd6605de0c75fbdf8745b28f77a8/credit_adjustments"/>
+        <refundable_total_in_cents type="integer">7000</refundable_total_in_cents>
+        <uuid>63f7cd6605de0c75fbdf8745b28f77a8</uuid>
+        <state>invoiced</state>
+        <description>Setup fee: Byzantium Draw</description>
+        <accounting_code nil="nil"/>
+        <product_code>ramp-plan</product_code>
+        <origin>setup_fee</origin>
+        <unit_amount_in_cents type="integer">7000</unit_amount_in_cents>
+        <quantity type="integer">1</quantity>
+        <discount_in_cents type="integer">0</discount_in_cents>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <total_in_cents type="integer">7000</total_in_cents>
+        <currency>USD</currency>
+        <proration_rate nil="nil"/>
+        <start_date type="datetime">2022-08-10T18:26:35Z</start_date>
+        <end_date nil="nil"/>
+        <created_at type="datetime">2022-08-10T18:26:38Z</created_at>
+        <updated_at type="datetime">2022-08-10T18:26:38Z</updated_at>
+        <revenue_schedule_type>evenly</revenue_schedule_type>
+      </adjustment>
+    </line_items>
+    <transactions type="array">
+      <transaction href="https://api.recurly.com/v2/transactions/63f7cd6639e20788c87c164842872b85" type="credit_card">
+        <account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+        <invoice href="https://api.recurly.com/v2/invoices/1240"/>
+        <subscriptions href="https://api.recurly.com/v2/transactions/63f7cd6639e20788c87c164842872b85/subscriptions"/>
+        <uuid>63f7cd6639e20788c87c164842872b85</uuid>
+        <action>purchase</action>
+        <amount_in_cents type="integer">7000</amount_in_cents>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <currency>USD</currency>
+        <status>success</status>
+        <payment_method>credit_card</payment_method>
+        <reference>5654000</reference>
+        <source>subscription</source>
+        <recurring type="boolean">false</recurring>
+        <test type="boolean">true</test>
+        <voidable type="boolean">true</voidable>
+        <refundable type="boolean">true</refundable>
+        <ip_address nil="nil"/>
+        <gateway_type>test</gateway_type>
+        <origin>api</origin>
+        <description nil="nil"/>
+        <message>Successful test transaction</message>
+        <approval_code nil="nil"/>
+        <failure_type nil="nil"/>
+        <gateway_error_codes nil="nil"/>
+        <cvv_result code="M">Match</cvv_result>
+        <avs_result code="D">Street address and postal code match.</avs_result>
+        <avs_result_street nil="nil"/>
+        <avs_result_postal nil="nil"/>
+        <created_at type="datetime">2022-08-10T18:26:35Z</created_at>
+        <collected_at type="datetime">2022-08-10T18:26:35Z</collected_at>
+        <updated_at type="datetime">2022-08-10T18:26:38Z</updated_at>
+        <backup_payment_method_used type="boolean">false</backup_payment_method_used>
+        <details>
+          <account>
+            <account_code>03f2dad7-e0d3-4856-acbb-fa7a7ce26683</account_code>
+            <first_name nil="nil"></first_name>
+            <last_name nil="nil"></last_name>
+            <company nil="nil"></company>
+            <email nil="nil"></email>
+            <billing_info type="credit_card">
+              <first_name>Verena</first_name>
+              <last_name>Example</last_name>
+              <address1>123 Main St</address1>
+              <address2 nil="nil"></address2>
+              <city>New Orleans</city>
+              <state>LA</state>
+              <zip>70114</zip>
+              <country>US</country>
+              <phone nil="nil"></phone>
+              <vat_number nil="nil"></vat_number>
+              <card_type>Visa</card_type>
+              <year type="integer">2020</year>
+              <month type="integer">11</month>
+              <first_six>411111</first_six>
+              <last_four>1111</last_four>
+            </billing_info>
+          </account>
+        </details>
+      </transaction>
+    </transactions>
+    <a name="refund" href="https://api.recurly.com/v2/invoices/1240/refund" method="post"/>
+  </charge_invoice>
+  <credit_invoices type="array"/>
+</invoice_collection>

--- a/tests/fixtures/purchase-with-ramp-intervals/pending.xml
+++ b/tests/fixtures/purchase-with-ramp-intervals/pending.xml
@@ -1,0 +1,163 @@
+POST https://api.recurly.com/v2/purchases/pending HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<purchase>
+  <account>
+    <account_code>testmock</account_code>
+    <email>benjamin.dumonde@example.com</email>
+    <billing_info>
+      <address1>123 Main St</address1>
+      <city>New Orleans</city>
+      <country>US</country>
+      <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
+    </billing_info>
+  </account>
+  <collection_method>automatic</collection_method>
+  <currency>USD</currency>
+  <gateway_code>aBcD1234</gateway_code>
+  <shipping_address>
+    <address1>456 Pillow Fort Drive</address1>
+    <city>New Orleans</city>
+    <country>US</country>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <nickname>Work</nickname>
+    <state>LA</state>
+    <zip>70114</zip>
+  </shipping_address>
+  <subscriptions>
+    <subscription>
+      <plan_code>ramp-plan</plan_code>
+      <ramp_intervals>
+        <ramp_interval>
+          <starting_billing_cycle type="integer">1</starting_billing_cycle>
+          <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+        </ramp_interval>
+        <ramp_interval>
+          <starting_billing_cycle type="integer">3</starting_billing_cycle>
+          <unit_amount_in_cents type="integer">3000</unit_amount_in_cents>
+        </ramp_interval>
+      </ramp_intervals>
+    </subscription>
+  </subscriptions>
+</purchase>
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/1021
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice_collection>
+    <charge_invoice href="">
+      <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+      <address>
+        <address1>123 Main St</address1>
+        <address2 nil="nil"></address2>
+        <city>New Orleans</city>
+        <state>LA</state>
+        <zip>70114</zip>
+        <country>US</country>
+        <phone nil="nil"></phone>
+      </address>
+      <uuid>40625fd700c1c2d90060744092b4a1b1</uuid>
+      <state>pending</state>
+      <invoice_number_prefix></invoice_number_prefix>
+      <invoice_number nil="nil"></invoice_number>
+      <po_number nil="nil"></po_number>
+      <vat_number nil="nil"></vat_number>
+      <subtotal_in_cents type="integer">6000</subtotal_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <total_in_cents type="integer">6000</total_in_cents>
+      <subtotal_after_discount_in_cents type="integer">6000</subtotal_after_discount_in_cents>
+      <currency>USD</currency>
+      <created_at nil="nil"></created_at>
+      <updated_at nil="nil"></updated_at>
+      <attempt_next_collection_at type="datetime">2017-10-06T21:25:55Z</attempt_next_collection_at>
+      <closed_at nil="nil"></closed_at>
+      <terms_and_conditions nil="nil"></terms_and_conditions>
+      <customer_notes nil="nil"></customer_notes>
+      <recovery_reason nil="nil"></recovery_reason>
+      <net_terms type="integer">0</net_terms>
+      <collection_method>automatic</collection_method>
+      <line_items type="array">
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6fc46181e2f15044db38c1c82</uuid>
+          <state>pending</state>
+          <description>gold</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code>gold</product_code>
+          <origin>plan</origin>
+          <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+          <quantity type="integer">1</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">1000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date type="datetime">2017-11-06T21:25:55Z</end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type>evenly</revenue_schedule_type>
+        </adjustment>
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6e6a5817b59a2174b72a92fea</uuid>
+          <state>pending</state>
+          <description>Item 1</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code nil="nil"></product_code>
+          <origin>debit</origin>
+          <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+          <quantity type="integer">1</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">1000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date nil="nil"></end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type></revenue_schedule_type>
+        </adjustment>
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6e9096c9922b52646e29f6d5e</uuid>
+          <state>pending</state>
+          <description>Item 2</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code nil="nil"></product_code>
+          <origin>debit</origin>
+          <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+          <quantity type="integer">2</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">4000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date nil="nil"></end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type></revenue_schedule_type>
+        </adjustment>
+      </line_items>
+      <transactions type="array">
+      </transactions>
+    </charge_invoice>
+</invoice_collection>

--- a/tests/fixtures/purchase-with-ramp-intervals/previewed.xml
+++ b/tests/fixtures/purchase-with-ramp-intervals/previewed.xml
@@ -1,0 +1,215 @@
+POST https://api.recurly.com/v2/purchases/preview HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<purchase>
+  <account>
+    <account_code>testmock</account_code>
+    <billing_info>
+      <address1>123 Main St</address1>
+      <city>New Orleans</city>
+      <country>US</country>
+      <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
+    </billing_info>
+  </account>
+  <collection_method>automatic</collection_method>
+  <currency>USD</currency>
+  <gateway_code>aBcD1234</gateway_code>
+  <shipping_address>
+    <address1>456 Pillow Fort Drive</address1>
+    <city>New Orleans</city>
+    <country>US</country>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <nickname>Work</nickname>
+    <state>LA</state>
+    <zip>70114</zip>
+  </shipping_address>
+  <subscriptions>
+    <subscription>
+      <plan_code>ramp-plan</plan_code>
+      <ramp_intervals>
+        <ramp_interval>
+          <starting_billing_cycle type="integer">1</starting_billing_cycle>
+          <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+        </ramp_interval>
+        <ramp_interval>
+          <starting_billing_cycle type="integer">3</starting_billing_cycle>
+          <unit_amount_in_cents type="integer">3000</unit_amount_in_cents>
+        </ramp_interval>
+      </ramp_intervals>
+    </subscription>
+  </subscriptions>
+</purchase>
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/1021
+
+<?xml version="1.0" encoding="utf-8"?>
+<invoice_collection>
+  <charge_invoice href="https://api.recurly.com/v2/invoices/1240">
+    <account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+    <dunning_campaign_id nil="nil"/>
+    <address>
+      <name_on_account nil="nil"/>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <company/>
+      <address1>123 Main St</address1>
+      <address2 nil="nil"/>
+      <city>New Orleans</city>
+      <state>LA</state>
+      <zip>70114</zip>
+      <country>US</country>
+      <phone nil="nil"/>
+    </address>
+    <shipping_address>
+      <address1>456 Pillow Fort Drive</address1>
+      <city>New Orleans</city>
+      <country>US</country>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <nickname>Work</nickname>
+      <state>LA</state>
+      <zip>70114</zip>
+    </shipping_address>
+    <subscriptions href="https://api.recurly.com/v2/invoices/1240/subscriptions"/>
+    <uuid>63f7cd6612ef3c7befe2aa4432bd9426</uuid>
+    <state>paid</state>
+    <invoice_number_prefix/>
+    <invoice_number type="integer">1240</invoice_number>
+    <vat_number nil="nil"/>
+    <tax_in_cents type="integer">0</tax_in_cents>
+    <total_in_cents type="integer">7000</total_in_cents>
+    <currency>USD</currency>
+    <created_at type="datetime">2022-08-10T18:26:38Z</created_at>
+    <updated_at type="datetime">2022-08-10T18:26:38Z</updated_at>
+    <attempt_next_collection_at nil="nil"/>
+    <closed_at type="datetime">2022-08-10T18:26:38Z</closed_at>
+    <customer_notes nil="nil"/>
+    <recovery_reason nil="nil"/>
+    <gateway_code nil="nil"/>
+    <subtotal_before_discount_in_cents type="integer">7000</subtotal_before_discount_in_cents>
+    <subtotal_in_cents type="integer">7000</subtotal_in_cents>
+    <discount_in_cents type="integer">0</discount_in_cents>
+    <due_on type="datetime">2022-08-10T18:26:38Z</due_on>
+    <balance_in_cents type="integer">0</balance_in_cents>
+    <type>charge</type>
+    <origin>purchase</origin>
+    <credit_invoices href="https://api.recurly.com/v2/invoices/1240/credit_invoices"/>
+    <refundable_total_in_cents type="integer">7000</refundable_total_in_cents>
+    <credit_payments type="array"/>
+    <net_terms type="integer">0</net_terms>
+    <collection_method>automatic</collection_method>
+    <po_number nil="nil"/>
+    <terms_and_conditions nil="nil"/>
+    <line_items type="array">
+      <adjustment href="https://api.recurly.com/v2/adjustments/63f7cd6605de0c75fbdf8745b28f77a8" type="charge">
+        <account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+        <bill_for_account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+        <item_code nil="nil"/>
+        <external_sku nil="nil"/>
+        <invoice href="https://api.recurly.com/v2/invoices/1240"/>
+        <subscription href="https://api.recurly.com/v2/subscriptions/63f7cd659ab7ad05401eff456dab46f8"/>
+        <credit_adjustments href="https://api.recurly.com/v2/adjustments/63f7cd6605de0c75fbdf8745b28f77a8/credit_adjustments"/>
+        <refundable_total_in_cents type="integer">7000</refundable_total_in_cents>
+        <uuid>63f7cd6605de0c75fbdf8745b28f77a8</uuid>
+        <state>invoiced</state>
+        <description>Setup fee: Byzantium Draw</description>
+        <accounting_code nil="nil"/>
+        <product_code>ramp-plan</product_code>
+        <origin>setup_fee</origin>
+        <unit_amount_in_cents type="integer">7000</unit_amount_in_cents>
+        <quantity type="integer">1</quantity>
+        <discount_in_cents type="integer">0</discount_in_cents>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <total_in_cents type="integer">7000</total_in_cents>
+        <currency>USD</currency>
+        <proration_rate nil="nil"/>
+        <start_date type="datetime">2022-08-10T18:26:35Z</start_date>
+        <end_date nil="nil"/>
+        <created_at type="datetime">2022-08-10T18:26:38Z</created_at>
+        <updated_at type="datetime">2022-08-10T18:26:38Z</updated_at>
+        <revenue_schedule_type>evenly</revenue_schedule_type>
+      </adjustment>
+    </line_items>
+    <transactions type="array">
+      <transaction href="https://api.recurly.com/v2/transactions/63f7cd6639e20788c87c164842872b85" type="credit_card">
+        <account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+        <invoice href="https://api.recurly.com/v2/invoices/1240"/>
+        <subscriptions href="https://api.recurly.com/v2/transactions/63f7cd6639e20788c87c164842872b85/subscriptions"/>
+        <uuid>63f7cd6639e20788c87c164842872b85</uuid>
+        <action>purchase</action>
+        <amount_in_cents type="integer">7000</amount_in_cents>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <currency>USD</currency>
+        <status>success</status>
+        <payment_method>credit_card</payment_method>
+        <reference>5654000</reference>
+        <source>subscription</source>
+        <recurring type="boolean">false</recurring>
+        <test type="boolean">true</test>
+        <voidable type="boolean">true</voidable>
+        <refundable type="boolean">true</refundable>
+        <ip_address nil="nil"/>
+        <gateway_type>test</gateway_type>
+        <origin>api</origin>
+        <description nil="nil"/>
+        <message>Successful test transaction</message>
+        <approval_code nil="nil"/>
+        <failure_type nil="nil"/>
+        <gateway_error_codes nil="nil"/>
+        <cvv_result code="M">Match</cvv_result>
+        <avs_result code="D">Street address and postal code match.</avs_result>
+        <avs_result_street nil="nil"/>
+        <avs_result_postal nil="nil"/>
+        <created_at type="datetime">2022-08-10T18:26:35Z</created_at>
+        <collected_at type="datetime">2022-08-10T18:26:35Z</collected_at>
+        <updated_at type="datetime">2022-08-10T18:26:38Z</updated_at>
+        <backup_payment_method_used type="boolean">false</backup_payment_method_used>
+        <details>
+          <account>
+            <account_code>03f2dad7-e0d3-4856-acbb-fa7a7ce26683</account_code>
+            <first_name nil="nil"></first_name>
+            <last_name nil="nil"></last_name>
+            <company nil="nil"></company>
+            <email nil="nil"></email>
+            <billing_info type="credit_card">
+              <first_name>Verena</first_name>
+              <last_name>Example</last_name>
+              <address1>123 Main St</address1>
+              <address2 nil="nil"></address2>
+              <city>New Orleans</city>
+              <state>LA</state>
+              <zip>70114</zip>
+              <country>US</country>
+              <phone nil="nil"></phone>
+              <vat_number nil="nil"></vat_number>
+              <card_type>Visa</card_type>
+              <year type="integer">2020</year>
+              <month type="integer">11</month>
+              <first_six>411111</first_six>
+              <last_four>1111</last_four>
+            </billing_info>
+          </account>
+        </details>
+      </transaction>
+    </transactions>
+    <a name="refund" href="https://api.recurly.com/v2/invoices/1240/refund" method="post"/>
+  </charge_invoice>
+  <credit_invoices type="array"/>
+</invoice_collection>
+

--- a/tests/fixtures/purchase-with-ramp/authorized.xml
+++ b/tests/fixtures/purchase-with-ramp/authorized.xml
@@ -1,0 +1,153 @@
+POST https://api.recurly.com/v2/purchases/authorize HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<purchase>
+  <account>
+    <account_code>testmock</account_code>
+    <email>benjamin.dumonde@example.com</email>
+    <billing_info>
+      <address1>123 Main St</address1>
+      <city>New Orleans</city>
+      <country>US</country>
+      <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
+    </billing_info>
+  </account>
+  <collection_method>automatic</collection_method>
+  <currency>USD</currency>
+  <gateway_code>aBcD1234</gateway_code>
+  <shipping_address>
+    <address1>456 Pillow Fort Drive</address1>
+    <city>New Orleans</city>
+    <country>US</country>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <nickname>Work</nickname>
+    <state>LA</state>
+    <zip>70114</zip>
+  </shipping_address>
+  <subscriptions>
+    <subscription>
+      <plan_code>ramp-plan</plan_code>
+    </subscription>
+  </subscriptions>
+</purchase>
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/1021
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice_collection>
+    <charge_invoice href="">
+      <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+      <address>
+        <address1>123 Main St</address1>
+        <address2 nil="nil"></address2>
+        <city>New Orleans</city>
+        <state>LA</state>
+        <zip>70114</zip>
+        <country>US</country>
+        <phone nil="nil"></phone>
+      </address>
+      <uuid>40625fd700c1c2d90060744092b4a1b1</uuid>
+      <state>pending</state>
+      <invoice_number_prefix></invoice_number_prefix>
+      <invoice_number nil="nil"></invoice_number>
+      <po_number nil="nil"></po_number>
+      <vat_number nil="nil"></vat_number>
+      <subtotal_in_cents type="integer">6000</subtotal_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <total_in_cents type="integer">6000</total_in_cents>
+      <subtotal_after_discount_in_cents type="integer">6000</subtotal_after_discount_in_cents>
+      <currency>USD</currency>
+      <created_at nil="nil"></created_at>
+      <updated_at nil="nil"></updated_at>
+      <attempt_next_collection_at type="datetime">2017-10-06T21:25:55Z</attempt_next_collection_at>
+      <closed_at nil="nil"></closed_at>
+      <terms_and_conditions nil="nil"></terms_and_conditions>
+      <customer_notes nil="nil"></customer_notes>
+      <recovery_reason nil="nil"></recovery_reason>
+      <net_terms type="integer">0</net_terms>
+      <collection_method>automatic</collection_method>
+      <line_items type="array">
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6fc46181e2f15044db38c1c82</uuid>
+          <state>pending</state>
+          <description>gold</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code>gold</product_code>
+          <origin>plan</origin>
+          <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+          <quantity type="integer">1</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">1000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date type="datetime">2017-11-06T21:25:55Z</end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type>evenly</revenue_schedule_type>
+        </adjustment>
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6e6a5817b59a2174b72a92fea</uuid>
+          <state>pending</state>
+          <description>Item 1</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code nil="nil"></product_code>
+          <origin>debit</origin>
+          <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+          <quantity type="integer">1</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">1000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date nil="nil"></end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type></revenue_schedule_type>
+        </adjustment>
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6e9096c9922b52646e29f6d5e</uuid>
+          <state>pending</state>
+          <description>Item 2</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code nil="nil"></product_code>
+          <origin>debit</origin>
+          <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+          <quantity type="integer">2</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">4000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date nil="nil"></end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type></revenue_schedule_type>
+        </adjustment>
+      </line_items>
+      <transactions type="array">
+      </transactions>
+    </charge_invoice>
+</invoice_collection>

--- a/tests/fixtures/purchase-with-ramp/invoiced.xml
+++ b/tests/fixtures/purchase-with-ramp/invoiced.xml
@@ -1,0 +1,205 @@
+POST https://api.recurly.com/v2/purchases HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<purchase>
+  <account>
+    <account_code>testmock</account_code>
+    <billing_info>
+      <address1>123 Main St</address1>
+      <city>New Orleans</city>
+      <country>US</country>
+      <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
+    </billing_info>
+  </account>
+  <collection_method>automatic</collection_method>
+  <currency>USD</currency>
+  <gateway_code>aBcD1234</gateway_code>
+  <shipping_address>
+    <address1>456 Pillow Fort Drive</address1>
+    <city>New Orleans</city>
+    <country>US</country>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <nickname>Work</nickname>
+    <state>LA</state>
+    <zip>70114</zip>
+  </shipping_address>
+  <subscriptions>
+    <subscription>
+      <plan_code>ramp-plan</plan_code>
+    </subscription>
+  </subscriptions>
+</purchase>
+
+
+HTTP/1.1 201 Created 
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/1021
+
+<?xml version="1.0" encoding="utf-8"?>
+<invoice_collection>
+  <charge_invoice href="https://api.recurly.com/v2/invoices/1240">
+    <account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+    <dunning_campaign_id nil="nil"/>
+    <address>
+      <name_on_account nil="nil"/>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <company/>
+      <address1>123 Main St</address1>
+      <address2 nil="nil"/>
+      <city>New Orleans</city>
+      <state>LA</state>
+      <zip>70114</zip>
+      <country>US</country>
+      <phone nil="nil"/>
+    </address>
+    <shipping_address>
+      <address1>456 Pillow Fort Drive</address1>
+      <city>New Orleans</city>
+      <country>US</country>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <nickname>Work</nickname>
+      <state>LA</state>
+      <zip>70114</zip>
+    </shipping_address>
+    <subscriptions href="https://api.recurly.com/v2/invoices/1240/subscriptions"/>
+    <uuid>63f7cd6612ef3c7befe2aa4432bd9426</uuid>
+    <state>paid</state>
+    <invoice_number_prefix/>
+    <invoice_number type="integer">1240</invoice_number>
+    <vat_number nil="nil"/>
+    <tax_in_cents type="integer">0</tax_in_cents>
+    <total_in_cents type="integer">7000</total_in_cents>
+    <currency>USD</currency>
+    <created_at type="datetime">2022-08-10T18:26:38Z</created_at>
+    <updated_at type="datetime">2022-08-10T18:26:38Z</updated_at>
+    <attempt_next_collection_at nil="nil"/>
+    <closed_at type="datetime">2022-08-10T18:26:38Z</closed_at>
+    <customer_notes nil="nil"/>
+    <recovery_reason nil="nil"/>
+    <gateway_code nil="nil"/>
+    <subtotal_before_discount_in_cents type="integer">7000</subtotal_before_discount_in_cents>
+    <subtotal_in_cents type="integer">7000</subtotal_in_cents>
+    <discount_in_cents type="integer">0</discount_in_cents>
+    <due_on type="datetime">2022-08-10T18:26:38Z</due_on>
+    <balance_in_cents type="integer">0</balance_in_cents>
+    <type>charge</type>
+    <origin>purchase</origin>
+    <credit_invoices href="https://api.recurly.com/v2/invoices/1240/credit_invoices"/>
+    <refundable_total_in_cents type="integer">7000</refundable_total_in_cents>
+    <credit_payments type="array"/>
+    <net_terms type="integer">0</net_terms>
+    <collection_method>automatic</collection_method>
+    <po_number nil="nil"/>
+    <terms_and_conditions nil="nil"/>
+    <line_items type="array">
+      <adjustment href="https://api.recurly.com/v2/adjustments/63f7cd6605de0c75fbdf8745b28f77a8" type="charge">
+        <account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+        <bill_for_account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+        <item_code nil="nil"/>
+        <external_sku nil="nil"/>
+        <invoice href="https://api.recurly.com/v2/invoices/1240"/>
+        <subscription href="https://api.recurly.com/v2/subscriptions/63f7cd659ab7ad05401eff456dab46f8"/>
+        <credit_adjustments href="https://api.recurly.com/v2/adjustments/63f7cd6605de0c75fbdf8745b28f77a8/credit_adjustments"/>
+        <refundable_total_in_cents type="integer">7000</refundable_total_in_cents>
+        <uuid>63f7cd6605de0c75fbdf8745b28f77a8</uuid>
+        <state>invoiced</state>
+        <description>Setup fee: Byzantium Draw</description>
+        <accounting_code nil="nil"/>
+        <product_code>ramp-plan</product_code>
+        <origin>setup_fee</origin>
+        <unit_amount_in_cents type="integer">7000</unit_amount_in_cents>
+        <quantity type="integer">1</quantity>
+        <discount_in_cents type="integer">0</discount_in_cents>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <total_in_cents type="integer">7000</total_in_cents>
+        <currency>USD</currency>
+        <proration_rate nil="nil"/>
+        <start_date type="datetime">2022-08-10T18:26:35Z</start_date>
+        <end_date nil="nil"/>
+        <created_at type="datetime">2022-08-10T18:26:38Z</created_at>
+        <updated_at type="datetime">2022-08-10T18:26:38Z</updated_at>
+        <revenue_schedule_type>evenly</revenue_schedule_type>
+      </adjustment>
+    </line_items>
+    <transactions type="array">
+      <transaction href="https://api.recurly.com/v2/transactions/63f7cd6639e20788c87c164842872b85" type="credit_card">
+        <account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+        <invoice href="https://api.recurly.com/v2/invoices/1240"/>
+        <subscriptions href="https://api.recurly.com/v2/transactions/63f7cd6639e20788c87c164842872b85/subscriptions"/>
+        <uuid>63f7cd6639e20788c87c164842872b85</uuid>
+        <action>purchase</action>
+        <amount_in_cents type="integer">7000</amount_in_cents>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <currency>USD</currency>
+        <status>success</status>
+        <payment_method>credit_card</payment_method>
+        <reference>5654000</reference>
+        <source>subscription</source>
+        <recurring type="boolean">false</recurring>
+        <test type="boolean">true</test>
+        <voidable type="boolean">true</voidable>
+        <refundable type="boolean">true</refundable>
+        <ip_address nil="nil"/>
+        <gateway_type>test</gateway_type>
+        <origin>api</origin>
+        <description nil="nil"/>
+        <message>Successful test transaction</message>
+        <approval_code nil="nil"/>
+        <failure_type nil="nil"/>
+        <gateway_error_codes nil="nil"/>
+        <cvv_result code="M">Match</cvv_result>
+        <avs_result code="D">Street address and postal code match.</avs_result>
+        <avs_result_street nil="nil"/>
+        <avs_result_postal nil="nil"/>
+        <created_at type="datetime">2022-08-10T18:26:35Z</created_at>
+        <collected_at type="datetime">2022-08-10T18:26:35Z</collected_at>
+        <updated_at type="datetime">2022-08-10T18:26:38Z</updated_at>
+        <backup_payment_method_used type="boolean">false</backup_payment_method_used>
+        <details>
+          <account>
+            <account_code>03f2dad7-e0d3-4856-acbb-fa7a7ce26683</account_code>
+            <first_name nil="nil"></first_name>
+            <last_name nil="nil"></last_name>
+            <company nil="nil"></company>
+            <email nil="nil"></email>
+            <billing_info type="credit_card">
+              <first_name>Verena</first_name>
+              <last_name>Example</last_name>
+              <address1>123 Main St</address1>
+              <address2 nil="nil"></address2>
+              <city>New Orleans</city>
+              <state>LA</state>
+              <zip>70114</zip>
+              <country>US</country>
+              <phone nil="nil"></phone>
+              <vat_number nil="nil"></vat_number>
+              <card_type>Visa</card_type>
+              <year type="integer">2020</year>
+              <month type="integer">11</month>
+              <first_six>411111</first_six>
+              <last_four>1111</last_four>
+            </billing_info>
+          </account>
+        </details>
+      </transaction>
+    </transactions>
+    <a name="refund" href="https://api.recurly.com/v2/invoices/1240/refund" method="post"/>
+  </charge_invoice>
+  <credit_invoices type="array"/>
+</invoice_collection>

--- a/tests/fixtures/purchase-with-ramp/pending.xml
+++ b/tests/fixtures/purchase-with-ramp/pending.xml
@@ -1,0 +1,153 @@
+POST https://api.recurly.com/v2/purchases/pending HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<purchase>
+  <account>
+    <account_code>testmock</account_code>
+    <email>benjamin.dumonde@example.com</email>
+    <billing_info>
+      <address1>123 Main St</address1>
+      <city>New Orleans</city>
+      <country>US</country>
+      <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
+    </billing_info>
+  </account>
+  <collection_method>automatic</collection_method>
+  <currency>USD</currency>
+  <gateway_code>aBcD1234</gateway_code>
+  <shipping_address>
+    <address1>456 Pillow Fort Drive</address1>
+    <city>New Orleans</city>
+    <country>US</country>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <nickname>Work</nickname>
+    <state>LA</state>
+    <zip>70114</zip>
+  </shipping_address>
+  <subscriptions>
+    <subscription>
+      <plan_code>ramp-plan</plan_code>
+    </subscription>
+  </subscriptions>
+</purchase>
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/1021
+
+<?xml version="1.0" encoding="UTF-8"?>
+<invoice_collection>
+    <charge_invoice href="">
+      <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+      <address>
+        <address1>123 Main St</address1>
+        <address2 nil="nil"></address2>
+        <city>New Orleans</city>
+        <state>LA</state>
+        <zip>70114</zip>
+        <country>US</country>
+        <phone nil="nil"></phone>
+      </address>
+      <uuid>40625fd700c1c2d90060744092b4a1b1</uuid>
+      <state>pending</state>
+      <invoice_number_prefix></invoice_number_prefix>
+      <invoice_number nil="nil"></invoice_number>
+      <po_number nil="nil"></po_number>
+      <vat_number nil="nil"></vat_number>
+      <subtotal_in_cents type="integer">6000</subtotal_in_cents>
+      <tax_in_cents type="integer">0</tax_in_cents>
+      <total_in_cents type="integer">6000</total_in_cents>
+      <subtotal_after_discount_in_cents type="integer">6000</subtotal_after_discount_in_cents>
+      <currency>USD</currency>
+      <created_at nil="nil"></created_at>
+      <updated_at nil="nil"></updated_at>
+      <attempt_next_collection_at type="datetime">2017-10-06T21:25:55Z</attempt_next_collection_at>
+      <closed_at nil="nil"></closed_at>
+      <terms_and_conditions nil="nil"></terms_and_conditions>
+      <customer_notes nil="nil"></customer_notes>
+      <recovery_reason nil="nil"></recovery_reason>
+      <net_terms type="integer">0</net_terms>
+      <collection_method>automatic</collection_method>
+      <line_items type="array">
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6fc46181e2f15044db38c1c82</uuid>
+          <state>pending</state>
+          <description>gold</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code>gold</product_code>
+          <origin>plan</origin>
+          <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+          <quantity type="integer">1</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">1000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date type="datetime">2017-11-06T21:25:55Z</end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type>evenly</revenue_schedule_type>
+        </adjustment>
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6e6a5817b59a2174b72a92fea</uuid>
+          <state>pending</state>
+          <description>Item 1</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code nil="nil"></product_code>
+          <origin>debit</origin>
+          <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+          <quantity type="integer">1</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">1000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date nil="nil"></end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type></revenue_schedule_type>
+        </adjustment>
+        <adjustment href="" type="charge">
+          <account href="https://api.recurly.com/v2/accounts/03f2dad7-e0d3-4856-acbb-fa7a7ce26683"/>
+          <uuid>40625fd6e9096c9922b52646e29f6d5e</uuid>
+          <state>pending</state>
+          <description>Item 2</description>
+          <accounting_code nil="nil"></accounting_code>
+          <product_code nil="nil"></product_code>
+          <origin>debit</origin>
+          <unit_amount_in_cents type="integer">2000</unit_amount_in_cents>
+          <quantity type="integer">2</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">0</tax_in_cents>
+          <total_in_cents type="integer">4000</total_in_cents>
+          <currency>USD</currency>
+          <taxable type="boolean">false</taxable>
+          <start_date type="datetime">2017-10-06T21:25:55Z</start_date>
+          <end_date nil="nil"></end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type></revenue_schedule_type>
+        </adjustment>
+      </line_items>
+      <transactions type="array">
+      </transactions>
+    </charge_invoice>
+</invoice_collection>

--- a/tests/fixtures/purchase-with-ramp/previewed.xml
+++ b/tests/fixtures/purchase-with-ramp/previewed.xml
@@ -1,0 +1,206 @@
+POST https://api.recurly.com/v2/purchases/preview HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<purchase>
+  <account>
+    <account_code>testmock</account_code>
+    <billing_info>
+      <address1>123 Main St</address1>
+      <city>New Orleans</city>
+      <country>US</country>
+      <currency>USD</currency>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <month type="integer">11</month>
+      <number>4111-1111-1111-1111</number>
+      <state>LA</state>
+      <verification_value>123</verification_value>
+      <year type="integer">2020</year>
+      <zip>70114</zip>
+    </billing_info>
+  </account>
+  <collection_method>automatic</collection_method>
+  <currency>USD</currency>
+  <gateway_code>aBcD1234</gateway_code>
+  <shipping_address>
+    <address1>456 Pillow Fort Drive</address1>
+    <city>New Orleans</city>
+    <country>US</country>
+    <first_name>Verena</first_name>
+    <last_name>Example</last_name>
+    <nickname>Work</nickname>
+    <state>LA</state>
+    <zip>70114</zip>
+  </shipping_address>
+  <subscriptions>
+    <subscription>
+      <plan_code>ramp-plan</plan_code>
+    </subscription>
+  </subscriptions>
+</purchase>
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/invoices/1021
+
+<?xml version="1.0" encoding="utf-8"?>
+<invoice_collection>
+  <charge_invoice href="https://api.recurly.com/v2/invoices/1240">
+    <account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+    <dunning_campaign_id nil="nil"/>
+    <address>
+      <name_on_account nil="nil"/>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <company/>
+      <address1>123 Main St</address1>
+      <address2 nil="nil"/>
+      <city>New Orleans</city>
+      <state>LA</state>
+      <zip>70114</zip>
+      <country>US</country>
+      <phone nil="nil"/>
+    </address>
+    <shipping_address>
+      <address1>456 Pillow Fort Drive</address1>
+      <city>New Orleans</city>
+      <country>US</country>
+      <first_name>Verena</first_name>
+      <last_name>Example</last_name>
+      <nickname>Work</nickname>
+      <state>LA</state>
+      <zip>70114</zip>
+    </shipping_address>
+    <subscriptions href="https://api.recurly.com/v2/invoices/1240/subscriptions"/>
+    <uuid>63f7cd6612ef3c7befe2aa4432bd9426</uuid>
+    <state>paid</state>
+    <invoice_number_prefix/>
+    <invoice_number type="integer">1240</invoice_number>
+    <vat_number nil="nil"/>
+    <tax_in_cents type="integer">0</tax_in_cents>
+    <total_in_cents type="integer">7000</total_in_cents>
+    <currency>USD</currency>
+    <created_at type="datetime">2022-08-10T18:26:38Z</created_at>
+    <updated_at type="datetime">2022-08-10T18:26:38Z</updated_at>
+    <attempt_next_collection_at nil="nil"/>
+    <closed_at type="datetime">2022-08-10T18:26:38Z</closed_at>
+    <customer_notes nil="nil"/>
+    <recovery_reason nil="nil"/>
+    <gateway_code nil="nil"/>
+    <subtotal_before_discount_in_cents type="integer">7000</subtotal_before_discount_in_cents>
+    <subtotal_in_cents type="integer">7000</subtotal_in_cents>
+    <discount_in_cents type="integer">0</discount_in_cents>
+    <due_on type="datetime">2022-08-10T18:26:38Z</due_on>
+    <balance_in_cents type="integer">0</balance_in_cents>
+    <type>charge</type>
+    <origin>purchase</origin>
+    <credit_invoices href="https://api.recurly.com/v2/invoices/1240/credit_invoices"/>
+    <refundable_total_in_cents type="integer">7000</refundable_total_in_cents>
+    <credit_payments type="array"/>
+    <net_terms type="integer">0</net_terms>
+    <collection_method>automatic</collection_method>
+    <po_number nil="nil"/>
+    <terms_and_conditions nil="nil"/>
+    <line_items type="array">
+      <adjustment href="https://api.recurly.com/v2/adjustments/63f7cd6605de0c75fbdf8745b28f77a8" type="charge">
+        <account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+        <bill_for_account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+        <item_code nil="nil"/>
+        <external_sku nil="nil"/>
+        <invoice href="https://api.recurly.com/v2/invoices/1240"/>
+        <subscription href="https://api.recurly.com/v2/subscriptions/63f7cd659ab7ad05401eff456dab46f8"/>
+        <credit_adjustments href="https://api.recurly.com/v2/adjustments/63f7cd6605de0c75fbdf8745b28f77a8/credit_adjustments"/>
+        <refundable_total_in_cents type="integer">7000</refundable_total_in_cents>
+        <uuid>63f7cd6605de0c75fbdf8745b28f77a8</uuid>
+        <state>invoiced</state>
+        <description>Setup fee: Byzantium Draw</description>
+        <accounting_code nil="nil"/>
+        <product_code>ramp-plan</product_code>
+        <origin>setup_fee</origin>
+        <unit_amount_in_cents type="integer">7000</unit_amount_in_cents>
+        <quantity type="integer">1</quantity>
+        <discount_in_cents type="integer">0</discount_in_cents>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <total_in_cents type="integer">7000</total_in_cents>
+        <currency>USD</currency>
+        <proration_rate nil="nil"/>
+        <start_date type="datetime">2022-08-10T18:26:35Z</start_date>
+        <end_date nil="nil"/>
+        <created_at type="datetime">2022-08-10T18:26:38Z</created_at>
+        <updated_at type="datetime">2022-08-10T18:26:38Z</updated_at>
+        <revenue_schedule_type>evenly</revenue_schedule_type>
+      </adjustment>
+    </line_items>
+    <transactions type="array">
+      <transaction href="https://api.recurly.com/v2/transactions/63f7cd6639e20788c87c164842872b85" type="credit_card">
+        <account href="https://api.recurly.com/v2/accounts/periwinkleamaranth4"/>
+        <invoice href="https://api.recurly.com/v2/invoices/1240"/>
+        <subscriptions href="https://api.recurly.com/v2/transactions/63f7cd6639e20788c87c164842872b85/subscriptions"/>
+        <uuid>63f7cd6639e20788c87c164842872b85</uuid>
+        <action>purchase</action>
+        <amount_in_cents type="integer">7000</amount_in_cents>
+        <tax_in_cents type="integer">0</tax_in_cents>
+        <currency>USD</currency>
+        <status>success</status>
+        <payment_method>credit_card</payment_method>
+        <reference>5654000</reference>
+        <source>subscription</source>
+        <recurring type="boolean">false</recurring>
+        <test type="boolean">true</test>
+        <voidable type="boolean">true</voidable>
+        <refundable type="boolean">true</refundable>
+        <ip_address nil="nil"/>
+        <gateway_type>test</gateway_type>
+        <origin>api</origin>
+        <description nil="nil"/>
+        <message>Successful test transaction</message>
+        <approval_code nil="nil"/>
+        <failure_type nil="nil"/>
+        <gateway_error_codes nil="nil"/>
+        <cvv_result code="M">Match</cvv_result>
+        <avs_result code="D">Street address and postal code match.</avs_result>
+        <avs_result_street nil="nil"/>
+        <avs_result_postal nil="nil"/>
+        <created_at type="datetime">2022-08-10T18:26:35Z</created_at>
+        <collected_at type="datetime">2022-08-10T18:26:35Z</collected_at>
+        <updated_at type="datetime">2022-08-10T18:26:38Z</updated_at>
+        <backup_payment_method_used type="boolean">false</backup_payment_method_used>
+        <details>
+          <account>
+            <account_code>03f2dad7-e0d3-4856-acbb-fa7a7ce26683</account_code>
+            <first_name nil="nil"></first_name>
+            <last_name nil="nil"></last_name>
+            <company nil="nil"></company>
+            <email nil="nil"></email>
+            <billing_info type="credit_card">
+              <first_name>Verena</first_name>
+              <last_name>Example</last_name>
+              <address1>123 Main St</address1>
+              <address2 nil="nil"></address2>
+              <city>New Orleans</city>
+              <state>LA</state>
+              <zip>70114</zip>
+              <country>US</country>
+              <phone nil="nil"></phone>
+              <vat_number nil="nil"></vat_number>
+              <card_type>Visa</card_type>
+              <year type="integer">2020</year>
+              <month type="integer">11</month>
+              <first_six>411111</first_six>
+              <last_four>1111</last_four>
+            </billing_info>
+          </account>
+        </details>
+      </transaction>
+    </transactions>
+    <a name="refund" href="https://api.recurly.com/v2/invoices/1240/refund" method="post"/>
+  </charge_invoice>
+  <credit_invoices type="array"/>
+</invoice_collection>
+


### PR DESCRIPTION

- Add `refundable_total_in_cents` to Adjustment and Invoice classes
- Add specs to test Purchase - create, authorize, preview and pending
- Create a pretty print for the Resource Class and remove unnecessary `__str__` in `PlanRampInterval` and `SubRampInterval`