### PR TITLE
Fixes bug with put_dunning_campaign_bulk_update

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14922,6 +14922,8 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
   "/dunning_campaigns/{dunning_campaign_id}/bulk_update":
+    parameters:
+    - "$ref": "#/components/parameters/dunning_campaign_id"
     put:
       tags:
       - dunning_campaigns
@@ -20774,7 +20776,7 @@ components:
             zero then a `method_id` or `method_code` is required.
         address_id:
           type: string
-          titpe: Shipping address ID
+          title: Shipping address ID
           description: Assign a shipping address from the account's existing shipping
             addresses. If this and address are both present, address will take precedence.
         address:

--- a/recurly/client.py
+++ b/recurly/client.py
@@ -4346,12 +4346,14 @@ class Client(BaseClient):
         path = self._interpolate_path("/dunning_campaigns/%s", dunning_campaign_id)
         return self._make_request("GET", path, None, **options)
 
-    def put_dunning_campaign_bulk_update(self, body, **options):
+    def put_dunning_campaign_bulk_update(self, dunning_campaign_id, body, **options):
         """Assign a dunning campaign to multiple plans
 
         Parameters
         ----------
 
+        dunning_campaign_id : str
+            Dunning Campaign ID, e.g. `e28zov4fw0v2`.
         body : dict
             The request body. It should follow the schema of DunningCampaignsBulkUpdate.
 
@@ -4368,7 +4370,7 @@ class Client(BaseClient):
             A list of updated plans.
         """
         path = self._interpolate_path(
-            "/dunning_campaigns/%s/bulk_update",
+            "/dunning_campaigns/%s/bulk_update", dunning_campaign_id
         )
         return self._make_request("PUT", path, body, **options)
 


### PR DESCRIPTION
The `put_dunning_campaign_bulk_update ` method was missing the `dunning_campaign_id` parameter, which is used to construct the request URL.