### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21302,7 +21302,9 @@ components:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
         unit_amount:
-          type: integer
+          type: number
+          format: float
+          title: Unit price
           description: Represents the price for the ramp interval.
     TaxInfo:
       type: object

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -2060,14 +2060,14 @@ class SubscriptionRampIntervalResponse(Resource):
         Represents how many billing cycles are left in a ramp interval.
     starting_billing_cycle : int
         Represents the billing cycle where a ramp interval starts.
-    unit_amount : int
+    unit_amount : float
         Represents the price for the ramp interval.
     """
 
     schema = {
         "remaining_billing_cycles": int,
         "starting_billing_cycle": int,
-        "unit_amount": int,
+        "unit_amount": float,
     }
 
 


### PR DESCRIPTION
Fixed incorrect type in OpenAPI spec for SubscriptionRampIntervalResponse, `unit_amount` is now `float`