### PR TITLE
Add decimal quantity fields to Adjustment and Usage

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -896,6 +896,9 @@ class Adjustment(Resource):
         'item_code',
         'external_sku',
         'quantity',
+        'quantity_decimal',
+        'quantity_remaining',
+        'quantity_decimal_remaining',
         'unit_amount_in_cents',
         'discount_in_cents',
         'tax_in_cents',
@@ -1093,6 +1096,10 @@ class Invoice(Resource):
                 item['adjustment'].uuid))
             adj_elem.append(Resource.element_for_value('quantity',
             item['quantity']))
+
+            if 'quantity_decimal' in item:
+                adj_elem.append(Resource.element_for_value('quantity_decimal', item['quantity_decimal']))
+
             adj_elem.append(Resource.element_for_value('prorate', item['prorate']))
             line_items_elem.append(adj_elem)
 
@@ -1830,6 +1837,7 @@ class Usage(Resource):
     attributes = (
         'measured_unit',
         'amount',
+        'amount_decimal',
         'merchant_tag',
         'recording_timestamp',
         'usage_timestamp',

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -103,7 +103,7 @@ class TestResources(RecurlyTest):
                                     quantity=2),
                 ]
             )
-        
+
         with self.mock_request('purchase/invoiced.xml'):
             collection = create_purchase().invoice()
             self.assertIsInstance(collection, InvoiceCollection)
@@ -192,7 +192,7 @@ class TestResources(RecurlyTest):
                     recurly.Subscription(plan_code = 'ramp-plan')
                 ],
             )
-        
+
         with self.mock_request('purchase-with-ramp/invoiced.xml'):
             collection = create_purchase().invoice()
             self.assertIsInstance(collection, InvoiceCollection)
@@ -221,7 +221,7 @@ class TestResources(RecurlyTest):
     def test_purchase_with_ramp_intervals(self):
         account_code = 'test%s' % self.test_id
         def create_purchase():
-            
+
             subscription = recurly.Subscription(
                 plan_code = 'ramp-plan',
                 ramp_intervals = [
@@ -269,7 +269,7 @@ class TestResources(RecurlyTest):
                     subscription
                 ],
             )
-        
+
         with self.mock_request('purchase-with-ramp-intervals/invoiced.xml'):
             collection = create_purchase().invoice()
             self.assertIsInstance(collection, InvoiceCollection)
@@ -1619,7 +1619,7 @@ class TestResources(RecurlyTest):
         plan_code = 'plan%s' % self.test_id
         with self.mock_request('plan/does-not-exist.xml'):
             self.assertRaises(NotFoundError, Plan.get, plan_code)
-        
+
         ramp_interval_1 = PlanRampInterval(
             unit_amount_in_cents=Money(USD=2000),
             starting_billing_cycle=1,


### PR DESCRIPTION
Add `quantity_decimal` and `quantity_decimal_remaining` fields to `Adjustment` class.  Also add missing `quantity_remaining` field to `Adjustment` class.  Add `amount_decimal` field to `Usage` class.