### PR TITLE
Generated Latest Changes for v2019-10-10(Decimal Usage and Quantities)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -14463,6 +14463,8 @@ paths:
                 "$ref": "#/components/schemas/Error"
       x-code-samples: []
   "/dunning_campaigns/{dunning_campaign_id}/bulk_update":
+    parameters:
+    - "$ref": "#/components/parameters/dunning_campaign_id"
     put:
       tags:
       - dunning_campaigns
@@ -18423,6 +18425,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18503,6 +18513,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18544,6 +18561,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -19335,7 +19360,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents the first billing cycle of a ramp.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         currencies:
           type: array
@@ -21093,7 +21118,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
           default: 1
         unit_amount:
           type: integer
@@ -21104,7 +21129,7 @@ components:
       properties:
         starting_billing_cycle:
           type: integer
-          description: Represents how many billing cycles are included in a ramp interval.
+          description: Represents the billing cycle where a ramp interval starts.
         remaining_billing_cycles:
           type: integer
           description: Represents how many billing cycles are left in a ramp interval.
@@ -21533,10 +21558,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           type: string
           enum:
@@ -21609,10 +21635,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time

--- a/recurly/client.py
+++ b/recurly/client.py
@@ -3894,12 +3894,14 @@ class Client(BaseClient):
         path = self._interpolate_path("/dunning_campaigns/%s", dunning_campaign_id)
         return self._make_request("GET", path, None, None)
 
-    def put_dunning_campaign_bulk_update(self, body):
+    def put_dunning_campaign_bulk_update(self, dunning_campaign_id, body):
         """Assign a dunning campaign to multiple plans
 
         Parameters
         ----------
 
+        dunning_campaign_id : str
+            Dunning Campaign ID, e.g. `e28zov4fw0v2`.
         body : dict
             The request body. It should follow the schema of DunningCampaignsBulkUpdate.
 
@@ -3914,6 +3916,6 @@ class Client(BaseClient):
             A list of updated plans.
         """
         path = self._interpolate_path(
-            "/dunning_campaigns/%s/bulk_update",
+            "/dunning_campaigns/%s/bulk_update", dunning_campaign_id
         )
         return self._make_request("PUT", path, body, None)

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -1379,10 +1379,14 @@ class LineItem(Resource):
         When a line item has been prorated, this is the rate of the proration. Proration rates were made available for line items created after March 30, 2017. For line items created prior to that date, the proration rate will be `null`, even if the line item was prorated.
     quantity : int
         This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
+    quantity_decimal : str
+        A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
     refund : bool
         Refund?
     refunded_quantity : int
         For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
+    refunded_quantity_decimal : str
+        A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
     revenue_schedule_type : str
         Revenue schedule type
     shipping_address : ShippingAddress
@@ -1448,8 +1452,10 @@ class LineItem(Resource):
         "product_code": str,
         "proration_rate": float,
         "quantity": int,
+        "quantity_decimal": str,
         "refund": bool,
         "refunded_quantity": int,
+        "refunded_quantity_decimal": str,
         "revenue_schedule_type": str,
         "shipping_address": "ShippingAddress",
         "start_date": datetime,
@@ -1991,7 +1997,7 @@ class SubscriptionRampIntervalResponse(Resource):
     remaining_billing_cycles : int
         Represents how many billing cycles are left in a ramp interval.
     starting_billing_cycle : int
-        Represents how many billing cycles are included in a ramp interval.
+        Represents the billing cycle where a ramp interval starts.
     unit_amount : int
         Represents the price for the ramp interval.
     """
@@ -2330,7 +2336,7 @@ class PlanRampInterval(Resource):
     currencies : :obj:`list` of :obj:`PlanRampPricing`
         Represents the price for the ramp interval.
     starting_billing_cycle : int
-        Represents the first billing cycle of a ramp.
+        Represents the billing cycle where a ramp interval starts.
     """
 
     schema = {
@@ -2644,7 +2650,7 @@ class Usage(Resource):
     Attributes
     ----------
     amount : float
-        The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+        The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
     billed_at : datetime
         When the usage record was billed on an invoice.
     created_at : datetime


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `quantity_decimal` and `refunded_quantity_decimal` properties to `LineItem` class
- Update `Usage` `amount` property description

Fix Bulk Dunning Campaign update
- Update `put_dunning_campaign_bulk_update ` method to receive the `dunning_campaign_id `