### PR TITLE
Generated Latest Changes for v2021-02-25(Decimal Usage and Quantities and DunningEvent new fields)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -18141,6 +18141,14 @@ components:
           description: Unique ID to identify the dunning campaign used when dunning
             the invoice. For sites without multiple dunning campaigns enabled, this
             will always be the default dunning campaign.
+        dunning_events_sent:
+          type: integer
+          title: Dunning Event Sent
+          description: Number of times the event was sent.
+        final_dunning_event:
+          type: boolean
+          title: Final Dunning Event
+          description: Last communication attempt.
     InvoiceCreate:
       type: object
       properties:
@@ -18622,6 +18630,14 @@ components:
           description: This number will be multiplied by the unit amount to compute
             the subtotal before any discounts or taxes.
           default: 1
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         unit_amount:
           type: number
           format: float
@@ -18706,6 +18722,13 @@ components:
           title: Refunded Quantity
           description: For refund charges, the quantity being refunded. For non-refund
             charges, the total quantity refunded (possibly over multiple refunds).
+        refunded_quantity_decimal:
+          type: string
+          title: Refunded Quantity Decimal
+          description: A floating-point alternative to Refunded Quantity. For refund
+            charges, the quantity being refunded. For non-refund charges, the total
+            quantity refunded (possibly over multiple refunds). The Decimal Quantity
+            feature must be enabled to utilize this field.
         credit_applied:
           type: number
           format: float
@@ -18747,6 +18770,14 @@ components:
           type: integer
           title: Quantity
           description: Line item quantity to be refunded.
+        quantity_decimal:
+          type: string
+          title: Quantity Decimal
+          description: A floating-point alternative to Quantity. If this value is
+            present, it will be used in place of Quantity for calculations, and Quantity
+            will be the rounded integer value of this number. This field supports
+            up to 9 decimal places. The Decimal Quantity feature must be enabled to
+            utilize this field.
         prorate:
           type: boolean
           title: Prorate
@@ -21667,10 +21698,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         usage_type:
           "$ref": "#/components/schemas/UsageTypeEnum"
         tier_type:
@@ -21741,10 +21773,11 @@ components:
         amount:
           type: number
           format: float
-          description: The amount of usage. Can be positive, negative, or 0. No decimals
-            allowed, we will strip them. If the usage-based add-on is billed with
-            a percentage, your usage will be a monetary amount you will want to format
-            in cents. (e.g., $5.00 is "500").
+          description: The amount of usage. Can be positive, negative, or 0. If the
+            Decimal Quantity feature is enabled, this value will be rounded to nine
+            decimal places.  Otherwise, all digits after the decimal will be stripped.
+            If the usage-based add-on is billed with a percentage, your usage should
+            be a monetary amount formatted in cents (e.g., $5.00 is "500").
         recording_timestamp:
           type: string
           format: date-time
@@ -23058,12 +23091,16 @@ components:
       - savings
     ExternalHppTypeEnum:
       type: string
-      description: Use for Adyen HPP billing info.
+      description: Use for Adyen HPP billing info. This should only be used as part
+        of a pending purchase request, when the billing info is nested inside an account
+        object.
       enum:
       - adyen
     OnlineBankingPaymentTypeEnum:
       type: string
-      description: Use for Online Banking billing info.
+      description: Use for Online Banking billing info. This should only be used as
+        part of a pending purchase request, when the billing info is nested inside
+        an account object.
       enum:
       - ideal
       - sofort

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -1143,6 +1143,10 @@ class Invoice(Resource):
         Date invoice is due. This is the date the net terms are reached.
     dunning_campaign_id : str
         Unique ID to identify the dunning campaign used when dunning the invoice. For sites without multiple dunning campaigns enabled, this will always be the default dunning campaign.
+    dunning_events_sent : int
+        Number of times the event was sent.
+    final_dunning_event : bool
+        Last communication attempt.
     has_more_line_items : bool
         Identifies if the invoice has more line items than are returned in `line_items`. If `has_more_line_items` is `true`, then a request needs to be made to the `list_invoice_line_items` endpoint.
     id : str
@@ -1208,6 +1212,8 @@ class Invoice(Resource):
         "discount": float,
         "due_at": datetime,
         "dunning_campaign_id": str,
+        "dunning_events_sent": int,
+        "final_dunning_event": bool,
         "has_more_line_items": bool,
         "id": str,
         "line_items": ["LineItem"],
@@ -1393,10 +1399,14 @@ class LineItem(Resource):
         When a line item has been prorated, this is the rate of the proration. Proration rates were made available for line items created after March 30, 2017. For line items created prior to that date, the proration rate will be `null`, even if the line item was prorated.
     quantity : int
         This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.
+    quantity_decimal : str
+        A floating-point alternative to Quantity. If this value is present, it will be used in place of Quantity for calculations, and Quantity will be the rounded integer value of this number. This field supports up to 9 decimal places. The Decimal Quantity feature must be enabled to utilize this field.
     refund : bool
         Refund?
     refunded_quantity : int
         For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds).
+    refunded_quantity_decimal : str
+        A floating-point alternative to Refunded Quantity. For refund charges, the quantity being refunded. For non-refund charges, the total quantity refunded (possibly over multiple refunds). The Decimal Quantity feature must be enabled to utilize this field.
     revenue_schedule_type : str
         Revenue schedule type
     shipping_address : ShippingAddress
@@ -1464,8 +1474,10 @@ class LineItem(Resource):
         "product_code": str,
         "proration_rate": float,
         "quantity": int,
+        "quantity_decimal": str,
         "refund": bool,
         "refunded_quantity": int,
+        "refunded_quantity_decimal": str,
         "revenue_schedule_type": str,
         "shipping_address": "ShippingAddress",
         "start_date": datetime,
@@ -2733,7 +2745,7 @@ class Usage(Resource):
     Attributes
     ----------
     amount : float
-        The amount of usage. Can be positive, negative, or 0. No decimals allowed, we will strip them. If the usage-based add-on is billed with a percentage, your usage will be a monetary amount you will want to format in cents. (e.g., $5.00 is "500").
+        The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is "500").
     billed_at : datetime
         When the usage record was billed on an invoice.
     created_at : datetime


### PR DESCRIPTION
Adds support for the for decimal usages amount and decimal line items quantity :

- Add `quantity_decimal` and `refunded_quantity_decimal` properties to `LineItem` class
- Update `Usage` `amount` property description

Invoice request format has changed:
- Added `dunning_events_sent` and `final_dunning_event`