### PR TITLE
[API][V2] ASC - External Subs: Python Client Libraries & Docs

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -219,6 +219,11 @@ class Account(Resource):
 
         return elem
 
+    def external_subscriptions(self):
+        """Return a list of external subscription on account."""
+        url = urljoin(recurly.base_uri(), self.member_path % (self.account_code) + '/external_subscriptions')
+        return Page.page_for_url(url)
+
     @classmethod
     def all_active(cls, **kwargs):
         """Return a `Page` of active customer accounts.
@@ -2007,6 +2012,67 @@ class CreditPayment(Resource):
         'voided_at',
     )
 
+class ExternalSubscription(Resource):
+
+    """ A subscription from an external resource that is not managed by the Recurly platform and instead is managed by third-party platforms like Apple Store and Google Play. """
+
+    member_path = 'external_subscriptions/%s'
+    collection_path = 'external_subscriptions'
+
+    nodename = 'external_subscription'
+
+    attributes = (
+        'account',
+        'external_reference_id',
+        'external_resource',
+        'external_product_reference',
+        'last_purchased',
+        'auto_renew',
+        'app_identifier',
+        'quantity',
+        'activated_at',
+        'expires_at',
+        'created_at',
+        'updated_at'
+    )
+
+class ExternalResource(Resource):
+
+    """ Resource that is not managed by the Recurly platform and instead is managed by third-party platforms like Apple Store and Google Play. """
+
+    nodename = 'external_resource'
+
+    attributes = (
+        'external_object_reference',
+    )
+
+class ExternalProductReference(Resource):
+
+    """ A reference of a product from an external resource that is not managed by the Recurly platform and instead is managed by third-party platforms like Apple Store and Google Play. """
+
+    nodename = 'external_product_reference'
+    collection_path = 'external_product_references'
+
+    attributes = (
+        'reference_code',
+        'external_connection_type'
+    )
+
+class ExternalProduct(Resource):
+
+    """ A product from an external resource that is not managed by the Recurly platform and instead is managed by third-party platforms like Apple Store and Google Play. """
+
+    member_path = 'external_products/%s'
+    nodename = 'external_product'
+    collection_path = 'external_products'
+
+    attributes = (
+        'plan',
+        'name',
+        'created_at',
+        'updated_at',
+        'external_product_references'
+    )
 
 class ExportDate(Resource):
     nodename = 'export_date'

--- a/tests/fixtures/account/external-subscriptions.xml
+++ b/tests/fixtures/account/external-subscriptions.xml
@@ -1,0 +1,43 @@
+GET https://api.recurly.com/v2/accounts/account_code/external_subscriptions HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<external_subscriptions type="array">
+    <external_subscription href="https://paulo.recurly.dev:3000/v2/external_subscriptions/ru8jbrg7i3c0">
+        <account href="https://paulo.recurly.dev:3000/v2/accounts/account_code"/>
+        <external_resource>
+            <external_object_reference>teste</external_object_reference>
+        </external_resource>
+        <external_product_reference nil="nil"></external_product_reference>
+        <last_purchased nil="nil"></last_purchased>
+        <auto_renew type="boolean">false</auto_renew>
+        <app_identifier nil="nil"></app_identifier>
+        <quantity type="integer">1</quantity>
+        <activated_at nil="nil"></activated_at>
+        <expires_at nil="nil"></expires_at>
+        <created_at type="datetime">2022-11-04T19:45:00Z</created_at>
+        <updated_at type="datetime">2022-11-04T19:45:00Z</updated_at>
+    </external_subscription>
+    <external_subscription href="https://paulo.recurly.dev:3000/v2/external_subscriptions/ru2208s6hmf0">
+        <account href="https://paulo.recurly.dev:3000/v2/accounts/account_code"/>
+        <external_resource>
+            <external_object_reference>teste</external_object_reference>
+        </external_resource>
+        <external_product_reference nil="nil"></external_product_reference>
+        <last_purchased nil="nil"></last_purchased>
+        <auto_renew type="boolean">false</auto_renew>
+        <app_identifier>app_identifier</app_identifier>
+        <quantity type="integer">1</quantity>
+        <activated_at nil="nil"></activated_at>
+        <expires_at nil="nil"></expires_at>
+        <created_at type="datetime">2022-11-03T21:57:14Z</created_at>
+        <updated_at type="datetime">2022-11-04T18:11:51Z</updated_at>
+    </external_subscription>
+</external_subscriptions>

--- a/tests/fixtures/external-product/get.xml
+++ b/tests/fixtures/external-product/get.xml
@@ -1,0 +1,36 @@
+GET https://api.recurly.com/v2/external_products/ru1u1gms4msk HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<external_product href="https://paulo.recurly.dev:3000/v2/external_products/ru1u1gms4msk">
+    <plan href="https://paulo.recurly.dev:3000/v2/plans/5_abril">
+        <plan_code>5_abril</plan_code>
+        <name>5 de abril</name>
+    </plan>
+    <name>product_name_teste</name>
+    <created_at type="datetime">2022-11-03T21:12:35Z</created_at>
+    <updated_at type="datetime">2022-11-03T21:12:35Z</updated_at>
+    <external_product_references type="array">
+        <external_product_reference>
+            <id>ru1u1gn5otsv</id>
+            <reference_code>code_teste_google</reference_code>
+            <external_connection_type>google_play_store</external_connection_type>
+            <created_at type="datetime">2022-11-03T21:12:35Z</created_at>
+            <updated_at type="datetime">2022-11-03T21:12:35Z</updated_at>
+        </external_product_reference>
+        <external_product_reference>
+            <id>ru1u1gn7ebod</id>
+            <reference_code>code_teste_apple</reference_code>
+            <external_connection_type>apple_app_store</external_connection_type>
+            <created_at type="datetime">2022-11-03T21:12:35Z</created_at>
+            <updated_at type="datetime">2022-11-03T21:12:35Z</updated_at>
+        </external_product_reference>
+    </external_product_references>
+</external_product>

--- a/tests/fixtures/external-product/list.xml
+++ b/tests/fixtures/external-product/list.xml
@@ -1,0 +1,63 @@
+GET https://api.recurly.com/v2/external_products?per_page=200 HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<external_products type="array">
+    <external_product href="https://paulo.recurly.dev:3000/v2/external_products/rut1apk7qopu">
+        <plan href="https://paulo.recurly.dev:3000/v2/plans/annual">
+            <plan_code>annual</plan_code>
+            <name>annual</name>
+        </plan>
+        <name>external product 2</name>
+        <created_at type="datetime">2022-11-07T16:41:22Z</created_at>
+        <updated_at type="datetime">2022-11-07T16:41:22Z</updated_at>
+        <external_product_references type="array">
+            <external_product_reference>
+                <id>rut1apkhqaai</id>
+                <reference_code>apple</reference_code>
+                <external_connection_type>apple_app_store</external_connection_type>
+                <created_at type="datetime">2022-11-07T16:41:22Z</created_at>
+                <updated_at type="datetime">2022-11-07T16:41:22Z</updated_at>
+            </external_product_reference>
+            <external_product_reference>
+                <id>rut1apkhzlad</id>
+                <reference_code>google</reference_code>
+                <external_connection_type>google_play_store</external_connection_type>
+                <created_at type="datetime">2022-11-07T16:41:22Z</created_at>
+                <updated_at type="datetime">2022-11-07T16:41:22Z</updated_at>
+            </external_product_reference>
+        </external_product_references>
+    </external_product>
+    <external_product href="https://paulo.recurly.dev:3000/v2/external_products/ru1u1gms4msk">
+        <plan href="https://paulo.recurly.dev:3000/v2/plans/5_abril">
+            <plan_code>5_abril</plan_code>
+            <name>5 de abril</name>
+        </plan>
+        <name>product_name_teste</name>
+        <created_at type="datetime">2022-11-03T21:12:35Z</created_at>
+        <updated_at type="datetime">2022-11-03T21:12:35Z</updated_at>
+        <external_product_references type="array">
+            <external_product_reference>
+                <id>ru1u1gn5otsv</id>
+                <reference_code>code_teste_google</reference_code>
+                <external_connection_type>google_play_store</external_connection_type>
+                <created_at type="datetime">2022-11-03T21:12:35Z</created_at>
+                <updated_at type="datetime">2022-11-03T21:12:35Z</updated_at>
+            </external_product_reference>
+            <external_product_reference>
+                <id>ru1u1gn7ebod</id>
+                <reference_code>code_teste_apple</reference_code>
+                <external_connection_type>apple_app_store</external_connection_type>
+                <created_at type="datetime">2022-11-03T21:12:35Z</created_at>
+                <updated_at type="datetime">2022-11-03T21:12:35Z</updated_at>
+            </external_product_reference>
+        </external_product_references>
+    </external_product>
+</external_products>

--- a/tests/fixtures/external-subscription/get.xml
+++ b/tests/fixtures/external-subscription/get.xml
@@ -1,0 +1,26 @@
+GET https://api.recurly.com/v2/external_subscriptions/ru2208s6hmf0 HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<external_subscription href="https://paulo.recurly.dev:3000/v2/external_subscriptions/ru2208s6hmf0">
+    <account href="https://paulo.recurly.dev:3000/v2/accounts/pphino"/>
+    <external_resource>
+        <external_object_reference>teste</external_object_reference>
+    </external_resource>
+    <external_product_reference nil="nil"></external_product_reference>
+    <last_purchased nil="nil"></last_purchased>
+    <auto_renew type="boolean">false</auto_renew>
+    <app_identifier>app_identifier</app_identifier>
+    <quantity type="integer">1</quantity>
+    <activated_at nil="nil"></activated_at>
+    <expires_at nil="nil"></expires_at>
+    <created_at type="datetime">2022-11-03T21:57:14Z</created_at>
+    <updated_at type="datetime">2022-11-04T18:11:51Z</updated_at>
+</external_subscription>

--- a/tests/fixtures/external-subscription/list.xml
+++ b/tests/fixtures/external-subscription/list.xml
@@ -1,0 +1,43 @@
+GET https://api.recurly.com/v2/external_subscriptions?per_page=200 HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<external_subscriptions type="array">
+    <external_subscription href="https://paulo.recurly.dev:3000/v2/external_subscriptions/ru8jbrg7i3c0">
+        <account href="https://paulo.recurly.dev:3000/v2/accounts/pphino"/>
+        <external_resource>
+            <external_object_reference>teste</external_object_reference>
+        </external_resource>
+        <external_product_reference nil="nil"></external_product_reference>
+        <last_purchased nil="nil"></last_purchased>
+        <auto_renew type="boolean">false</auto_renew>
+        <app_identifier nil="nil"></app_identifier>
+        <quantity type="integer">1</quantity>
+        <activated_at nil="nil"></activated_at>
+        <expires_at nil="nil"></expires_at>
+        <created_at type="datetime">2022-11-04T19:45:00Z</created_at>
+        <updated_at type="datetime">2022-11-04T19:45:00Z</updated_at>
+    </external_subscription>
+    <external_subscription href="https://paulo.recurly.dev:3000/v2/external_subscriptions/ru2208s6hmf0">
+        <account href="https://paulo.recurly.dev:3000/v2/accounts/pphino"/>
+        <external_resource>
+            <external_object_reference>teste</external_object_reference>
+        </external_resource>
+        <external_product_reference nil="nil"></external_product_reference>
+        <last_purchased nil="nil"></last_purchased>
+        <auto_renew type="boolean">false</auto_renew>
+        <app_identifier>app_identifier</app_identifier>
+        <quantity type="integer">1</quantity>
+        <activated_at nil="nil"></activated_at>
+        <expires_at nil="nil"></expires_at>
+        <created_at type="datetime">2022-11-03T21:57:14Z</created_at>
+        <updated_at type="datetime">2022-11-04T18:11:51Z</updated_at>
+    </external_subscription>
+</external_subscriptions>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -9,7 +9,7 @@ import recurly
 from recurly import Account, AddOn, Address, Adjustment, BillingInfo, Coupon, Item, Plan, Redemption, Subscription, \
     SubscriptionAddOn, Transaction, MeasuredUnit, Usage, GiftCard, Delivery, ShippingAddress, AccountAcquisition, \
     Purchase, Invoice, InvoiceCollection, CreditPayment, CustomField, ExportDate, ExportDateFile, DunningCampaign, \
-    DunningCycle, InvoiceTemplate, PlanRampInterval, SubRampInterval
+    DunningCycle, InvoiceTemplate, PlanRampInterval, SubRampInterval, ExternalSubscription, ExternalResource, ExternalProduct, ExternalProductReference
 from recurly import Money, NotFoundError, ValidationError, BadRequestError, PageError
 from recurly import recurly_logging as logging
 from recurlytests import RecurlyTest
@@ -2749,6 +2749,169 @@ class TestResources(RecurlyTest):
             export_date_file_download_information.expires_at.strftime("%Y-%m-%d %H:%M:%S"), "2019-05-09 14:00:00"
         )
         self.assertEqual(export_date_file_download_information.download_url, "https://api.recurly.com/download")
+
+    def test_external_subscriptions_on_account(self):
+        account = Account(account_code = 'account_code')
+
+        with self.mock_request('account/external-subscriptions.xml'):
+            external_subscriptions = account.external_subscriptions()
+
+        self.assertEqual(len(external_subscriptions), 2)
+
+        self.assertEqual(external_subscriptions[0].external_resource.external_object_reference, 'teste')
+        self.assertEqual(external_subscriptions[0].external_product_reference, None)
+        self.assertEqual(external_subscriptions[0].last_purchased, None)
+        self.assertEqual(external_subscriptions[0].auto_renew, False)
+        self.assertEqual(external_subscriptions[0].app_identifier, None)
+        self.assertEqual(external_subscriptions[0].quantity, 1)
+        self.assertEqual(external_subscriptions[0].activated_at, None)
+        self.assertEqual(external_subscriptions[0].expires_at, None)
+        self.assertEqual(external_subscriptions[0].created_at, datetime(2022, 11, 4, 19, 45, tzinfo=external_subscriptions[0].created_at.tzinfo))
+        self.assertEqual(external_subscriptions[0].updated_at, datetime(2022, 11, 4, 19, 45, tzinfo=external_subscriptions[0].updated_at.tzinfo))
+
+        self.assertEqual(external_subscriptions[1].external_resource.external_object_reference, 'teste')
+        self.assertEqual(external_subscriptions[1].external_product_reference, None)
+        self.assertEqual(external_subscriptions[1].last_purchased, None)
+        self.assertEqual(external_subscriptions[1].auto_renew, False)
+        self.assertEqual(external_subscriptions[1].app_identifier, 'app_identifier')
+        self.assertEqual(external_subscriptions[1].quantity, 1)
+        self.assertEqual(external_subscriptions[1].activated_at, None)
+        self.assertEqual(external_subscriptions[1].expires_at, None)
+        self.assertEqual(external_subscriptions[1].created_at, datetime(2022, 11, 3, 21, 57, 14, tzinfo=external_subscriptions[1].created_at.tzinfo))
+        self.assertEqual(external_subscriptions[1].updated_at, datetime(2022, 11, 4, 18, 11, 51, tzinfo=external_subscriptions[1].updated_at.tzinfo))
+
+    def test_list_external_subscriptions(self):
+
+        with self.mock_request('external-subscription/list.xml'):
+            external_subscriptions = ExternalSubscription.all(per_page = 200)
+            
+        self.assertEqual(len(external_subscriptions), 2)
+
+        self.assertEqual(external_subscriptions[0].external_resource.external_object_reference, 'teste')
+        self.assertEqual(external_subscriptions[0].external_product_reference, None)
+        self.assertEqual(external_subscriptions[0].last_purchased, None)
+        self.assertEqual(external_subscriptions[0].auto_renew, False)
+        self.assertEqual(external_subscriptions[0].app_identifier, None)
+        self.assertEqual(external_subscriptions[0].quantity, 1)
+        self.assertEqual(external_subscriptions[0].activated_at, None)
+        self.assertEqual(external_subscriptions[0].expires_at, None)
+        self.assertEqual(external_subscriptions[0].created_at, datetime(2022, 11, 4, 19, 45, tzinfo=external_subscriptions[0].created_at.tzinfo))
+        self.assertEqual(external_subscriptions[0].updated_at, datetime(2022, 11, 4, 19, 45, tzinfo=external_subscriptions[0].created_at.tzinfo))
+
+        self.assertEqual(external_subscriptions[1].external_resource.external_object_reference, 'teste')
+        self.assertEqual(external_subscriptions[1].external_product_reference, None)
+        self.assertEqual(external_subscriptions[1].last_purchased, None)
+        self.assertEqual(external_subscriptions[1].auto_renew, False)
+        self.assertEqual(external_subscriptions[1].app_identifier, 'app_identifier')
+        self.assertEqual(external_subscriptions[1].quantity, 1)
+        self.assertEqual(external_subscriptions[1].activated_at, None)
+        self.assertEqual(external_subscriptions[1].expires_at, None)
+        self.assertEqual(external_subscriptions[1].created_at, datetime(2022, 11, 3, 21, 57, 14, tzinfo=external_subscriptions[1].created_at.tzinfo))
+        self.assertEqual(external_subscriptions[1].updated_at, datetime(2022, 11, 4, 18, 11, 51, tzinfo=external_subscriptions[1].updated_at.tzinfo))
+
+    def test_get_external_subscription(self):
+
+        with self.mock_request('external-subscription/get.xml'):
+            external_subscription = ExternalSubscription.get('ru2208s6hmf0')
+            
+        self.assertEqual(external_subscription.external_resource.external_object_reference, 'teste')
+        self.assertEqual(external_subscription.external_product_reference, None)
+        self.assertEqual(external_subscription.last_purchased, None)
+        self.assertEqual(external_subscription.auto_renew, False)
+        self.assertEqual(external_subscription.app_identifier, 'app_identifier')
+        self.assertEqual(external_subscription.quantity, 1)
+        self.assertEqual(external_subscription.activated_at, None)
+        self.assertEqual(external_subscription.expires_at, None)
+        self.assertEqual(external_subscription.created_at, datetime(2022, 11, 3, 21, 57, 14, tzinfo=external_subscription.created_at.tzinfo))
+        self.assertEqual(external_subscription.updated_at, datetime(2022, 11, 4, 18, 11, 51, tzinfo=external_subscription.updated_at.tzinfo))
+
+    def test_list_external_products(self):
+
+        with self.mock_request('external-product/list.xml'):
+            external_products = ExternalProduct.all(per_page = 200)
+
+        self.assertEqual(len(external_products), 2)
+
+        first_external_product = external_products[0]
+
+        self.assertEqual(first_external_product.plan.plan_code, 'annual')
+        self.assertEqual(first_external_product.plan.name, 'annual')
+        self.assertEqual(first_external_product.name, 'external product 2')
+        self.assertEqual(first_external_product.created_at, datetime(2022, 11, 7, 16, 41, 22, tzinfo=first_external_product.created_at.tzinfo))
+        self.assertEqual(first_external_product.updated_at, datetime(2022, 11, 7, 16, 41, 22, tzinfo=first_external_product.updated_at.tzinfo))
+
+        self.assertEqual(len(first_external_product.external_product_references), 2)
+
+        first_external_product_reference = first_external_product.external_product_references[0]
+
+        self.assertEqual(first_external_product_reference.id, 'rut1apkhqaai')
+        self.assertEqual(first_external_product_reference.reference_code, 'apple')
+        self.assertEqual(first_external_product_reference.external_connection_type, 'apple_app_store')
+        self.assertEqual(first_external_product_reference.created_at, datetime(2022, 11, 7, 16, 41, 22, tzinfo=first_external_product_reference.created_at.tzinfo))
+        self.assertEqual(first_external_product_reference.updated_at, datetime(2022, 11, 7, 16, 41, 22, tzinfo=first_external_product_reference.updated_at.tzinfo))
+
+        second_external_product_reference = first_external_product.external_product_references[1]
+
+        self.assertEqual(second_external_product_reference.id, 'rut1apkhzlad')
+        self.assertEqual(second_external_product_reference.reference_code, 'google')
+        self.assertEqual(second_external_product_reference.external_connection_type, 'google_play_store')
+        self.assertEqual(second_external_product_reference.created_at, datetime(2022, 11, 7, 16, 41, 22, tzinfo=second_external_product_reference.created_at.tzinfo))
+        self.assertEqual(second_external_product_reference.updated_at, datetime(2022, 11, 7, 16, 41, 22, tzinfo=second_external_product_reference.updated_at.tzinfo))
+
+        second_external_product = external_products[1]
+
+        self.assertEqual(second_external_product.plan.plan_code, '5_abril')
+        self.assertEqual(second_external_product.plan.name, '5 de abril')
+        self.assertEqual(second_external_product.name, 'product_name_teste')
+        self.assertEqual(second_external_product.created_at, datetime(2022, 11, 3, 21, 12, 35, tzinfo=second_external_product.created_at.tzinfo))
+        self.assertEqual(second_external_product.updated_at, datetime(2022, 11, 3, 21, 12, 35, tzinfo=second_external_product.updated_at.tzinfo))
+
+        self.assertEqual(len(second_external_product.external_product_references), 2)
+
+        third_external_product_reference = second_external_product.external_product_references[0]
+
+        self.assertEqual(third_external_product_reference.id, 'ru1u1gn5otsv')
+        self.assertEqual(third_external_product_reference.reference_code, 'code_teste_google')
+        self.assertEqual(third_external_product_reference.external_connection_type, 'google_play_store')
+        self.assertEqual(third_external_product_reference.created_at, datetime(2022, 11, 3, 21, 12, 35, tzinfo=third_external_product_reference.created_at.tzinfo))
+        self.assertEqual(third_external_product_reference.updated_at, datetime(2022, 11, 3, 21, 12, 35, tzinfo=third_external_product_reference.updated_at.tzinfo))
+
+        forth_external_product_reference = second_external_product.external_product_references[1]
+
+        self.assertEqual(forth_external_product_reference.id, 'ru1u1gn7ebod')
+        self.assertEqual(forth_external_product_reference.reference_code, 'code_teste_apple')
+        self.assertEqual(forth_external_product_reference.external_connection_type, 'apple_app_store')
+        self.assertEqual(forth_external_product_reference.created_at, datetime(2022, 11, 3, 21, 12, 35, tzinfo=forth_external_product_reference.created_at.tzinfo))
+        self.assertEqual(forth_external_product_reference.updated_at, datetime(2022, 11, 3, 21, 12, 35, tzinfo=forth_external_product_reference.updated_at.tzinfo))
+
+    def test_get_external_product(self):
+
+        with self.mock_request('external-product/get.xml'):
+            external_product = ExternalProduct.get('ru1u1gms4msk')
+            
+        self.assertEqual(external_product.plan.plan_code, '5_abril')
+        self.assertEqual(external_product.plan.name, '5 de abril')
+        self.assertEqual(external_product.name, 'product_name_teste')
+        self.assertEqual(external_product.created_at, datetime(2022, 11, 3, 21, 12, 35, tzinfo=external_product.created_at.tzinfo))
+        self.assertEqual(external_product.updated_at, datetime(2022, 11, 3, 21, 12, 35, tzinfo=external_product.created_at.tzinfo))
+
+        self.assertEqual(len(external_product.external_product_references), 2)
+
+        first_external_product_reference = external_product.external_product_references[0]
+
+        self.assertEqual(first_external_product_reference.id, 'ru1u1gn5otsv')
+        self.assertEqual(first_external_product_reference.reference_code, 'code_teste_google')
+        self.assertEqual(first_external_product_reference.external_connection_type, 'google_play_store')
+        self.assertEqual(first_external_product_reference.created_at, datetime(2022, 11, 3, 21, 12, 35, tzinfo=first_external_product_reference.created_at.tzinfo))
+        self.assertEqual(first_external_product_reference.updated_at, datetime(2022, 11, 3, 21, 12, 35, tzinfo=first_external_product_reference.updated_at.tzinfo))
+
+        second_external_product_reference = external_product.external_product_references[1]
+
+        self.assertEqual(second_external_product_reference.id, 'ru1u1gn7ebod')
+        self.assertEqual(second_external_product_reference.reference_code, 'code_teste_apple')
+        self.assertEqual(second_external_product_reference.external_connection_type, 'apple_app_store')
+        self.assertEqual(second_external_product_reference.created_at, datetime(2022, 11, 3, 21, 12, 35, tzinfo=second_external_product_reference.created_at.tzinfo))
+        self.assertEqual(second_external_product_reference.updated_at, datetime(2022, 11, 3, 21, 12, 35, tzinfo=second_external_product_reference.updated_at.tzinfo))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Description:
Added support to all endpoints above:
GET /external_subscriptions
GET /external_subscriptions/:id
GET /accounts/:account_code/external_subscriptions GET /external_products
GET /external_products/:id