### PR TITLE
V2 add support for Apply Credit Balance to existing invoice feature

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -115,6 +115,7 @@ class AccountBalance(Resource):
     attributes = (
         'balance_in_cents',
         'processing_prepayment_balance_in_cents',
+        'available_credit_balance_in_cents',
         'past_due',
     )
 
@@ -1139,6 +1140,16 @@ class Invoice(Resource):
         elem = ElementTree.fromstring(response_xml)
         invoice_collection = InvoiceCollection.from_element(elem)
         return invoice_collection
+
+    def apply_credit_balance(self):
+        url = urljoin(self._url, '/apply_credit_balance')
+        response = self.http_request(url, 'PUT')
+        if response.status not in (200, 201):
+            self.raise_http_error(response)
+        response_xml = response.read()
+        elem = ElementTree.fromstring(response_xml)
+        invoice = Invoice.from_element(elem)
+        return invoice
 
     def _create_refund_invoice(self, element):
         url = urljoin(self._url, '/refund')

--- a/tests/fixtures/account-balance/exists.xml
+++ b/tests/fixtures/account-balance/exists.xml
@@ -20,4 +20,8 @@ Content-Type: application/xml; charset=utf-8
         <USD type="integer">-3000</USD>
         <EUR type="integer">0</EUR>
     </processing_prepayment_balance_in_cents>
+    <available_credit_balance_in_cents>
+        <USD type="integer">-3000</USD>
+        <EUR type="integer">0</EUR>
+    </available_credit_balance_in_cents>
 </account_balance>

--- a/tests/fixtures/invoice/apply-credit-balance.xml
+++ b/tests/fixtures/invoice/apply-credit-balance.xml
@@ -1,8 +1,9 @@
-GET https://api.recurly.com/v2/invoices/6019 HTTP/1.1
+PUT https://api.recurly.com/v2/invoices/6019/apply_credit_balance HTTP/1.1
 X-Api-Version: {api-version}
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
 User-Agent: {user-agent}
+Content-Length: 0
 
 
 HTTP/1.1 200 OK
@@ -22,48 +23,25 @@ Location: https://api.recurly.com/v2/invoices/6019
     <phone nil="nil"></phone>
   </address>
   <uuid>46036dca820357dae40c94420ab52632</uuid>
-  <state>pending</state>
+  <state>paid</state>
   <invoice_number_prefix></invoice_number_prefix>
   <invoice_number type="integer">6019</invoice_number>
   <vat_number nil="nil"></vat_number>
   <tax_in_cents type="integer">0</tax_in_cents>
-  <tax_details type="array">
-    <tax_detail>
-      <tax_type>GST</tax_type>
-      <tax_region>CA</tax_region>
-      <tax_rate type="float">0.05</tax_rate>
-      <tax_in_cents type="integer">20</tax_in_cents>
-    </tax_detail>
-  </tax_details>
   <total_in_cents type="integer">5000</total_in_cents>
   <currency>USD</currency>
   <created_at type="datetime">2018-07-13T17:13:57Z</created_at>
   <updated_at type="datetime">2018-07-13T17:13:57Z</updated_at>
-  <attempt_next_collection_at type="datetime">2018-07-14T17:13:57Z</attempt_next_collection_at>
-  <closed_at nil="nil"></closed_at>
+  <attempt_next_collection_at nil="nil"></attempt_next_collection_at>
+  <closed_at nil="nil">2019-07-13T17:13:57Z</closed_at>
   <customer_notes>notes</customer_notes>
   <recovery_reason nil="nil"></recovery_reason>
-  <subtotal_before_discount_in_cents type="integer">5000</subtotal_before_discount_in_cents>
-  <subtotal_in_cents type="integer">5000</subtotal_in_cents>
-  <discount_in_cents type="integer">0</discount_in_cents>
-  <due_on type="datetime">2018-07-14T17:13:57Z</due_on>
-  <balance_in_cents type="integer">5000</balance_in_cents>
-  <type>charge</type>
-  <origin>purchase</origin>
-  <credit_invoices href="https://api.recurly.com/v2/invoices/6019/credit_invoices"/>
-  <refundable_total_in_cents type="integer">5000</refundable_total_in_cents>
-  <credit_payments type="array">
-  </credit_payments>
   <net_terms type="integer">0</net_terms>
   <collection_method>manual</collection_method>
-  <po_number nil="nil"></po_number>
-  <terms_and_conditions>t and c</terms_and_conditions>
   <line_items type="array">
     <adjustment href="https://api.recurly.com/v2/adjustments/46036dc9823500f96f43ef44769df449" type="charge">
       <account href="https://api.recurly.com/v2/accounts/aa463d59-a618-4b71-b1f4-0410f835fe74"/>
       <invoice href="https://api.recurly.com/v2/invoices/6019"/>
-      <credit_adjustments href="https://api.recurly.com/v2/adjustments/46036dc9823500f96f43ef44769df449/credit_adjustments"/>
-      <refundable_total_in_cents type="integer">5000</refundable_total_in_cents>
       <uuid>46036dc9823500f96f43ef44769df449</uuid>
       <state>invoiced</state>
       <description>Charge for extra bandwidth</description>
@@ -76,7 +54,6 @@ Location: https://api.recurly.com/v2/invoices/6019
       <tax_in_cents type="integer">0</tax_in_cents>
       <total_in_cents type="integer">5000</total_in_cents>
       <currency>USD</currency>
-      <proration_rate nil="nil"></proration_rate>
       <taxable type="boolean">false</taxable>
       <tax_exempt type="boolean">false</tax_exempt>
       <tax_code nil="nil"></tax_code>
@@ -89,7 +66,5 @@ Location: https://api.recurly.com/v2/invoices/6019
   </line_items>
   <transactions type="array">
   </transactions>
-  <a name="mark_successful" href="https://api.recurly.com/v2/invoices/6019/mark_successful" method="put"/>
-  <a name="mark_failed" href="https://api.recurly.com/v2/invoices/6019/mark_failed" method="put"/>
-  <a name="apply_credit_balance" href="https://api.recurly.com/v2/invoices/6019/apply_credit_balance" method="put"/>
+  <a name="refund" href="https://api.recurly.com/v2/invoices/6019/refund" method="post"/>
 </invoice>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -336,6 +336,9 @@ class TestResources(RecurlyTest):
         processing_prepayment_balance = account_balance.processing_prepayment_balance_in_cents
         self.assertTrue(processing_prepayment_balance['USD'] == -3000)
         self.assertTrue(processing_prepayment_balance['EUR'] == 0)
+        available_credit_balance_in_cents = account_balance.available_credit_balance_in_cents
+        self.assertTrue(available_credit_balance_in_cents['USD'] == -3000)
+        self.assertTrue(available_credit_balance_in_cents['EUR'] == 0)
 
         account.username = 'shmohawk58'
         account.email = 'larry.david'
@@ -1396,6 +1399,14 @@ class TestResources(RecurlyTest):
         with self.mock_request('invoice/collect-invoice.xml'):
             collection = invoice.force_collect()
             self.assertIsInstance(collection, InvoiceCollection)
+
+    def test_apply_credit_balance(self):
+        with self.mock_request('invoice/show-invoice.xml'):
+            invoice = Invoice.get("6019")
+
+        with self.mock_request('invoice/apply-credit-balance.xml'):
+            updated_invoice = invoice.apply_credit_balance()
+            self.assertIsInstance(updated_invoice, Invoice)
 
     def test_invoice_tax_details(self):
         with self.mock_request('invoice/show-invoice.xml'):


### PR DESCRIPTION
Add new `available_credit_balance_in_cents` attribute to `AccountBalance`. The `available_credit_balance_in_cents` attribute is a similar format to the `balance_in_cents` attribute and contains the total of open balances for credit invoices in each currency. This value is useful when trying to determine if the customer's account has any available credit that can be applied to an existing collectible invoice on the account.

Add new `apply_credit_balance` method to Invoice. This action will be available for collectible charge invoices. If the account has available credit it will be applied to pay down the balance on the invoice.