### PR TITLE
Add `preferred_time_zone` to Account

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,20 @@
 name: CI
 on: [push]
-concurrency: 
+concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     name: Python ${{ matrix.python }} tests
     strategy:
       matrix:
-        python: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python: [2.7, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest]
+        include:
+          # Python 3.6 is not included in ubuntu latest (currently 22)
+          - python: 3.6
+            os: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup python

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -191,6 +191,7 @@ class Account(Resource):
         'has_paused_subscription',
         'has_past_due_invoice',
         'preferred_locale',
+        'preferred_time_zone',
         'custom_fields',
         'transaction_type',
         'dunning_campaign_id',

--- a/tests/fixtures/account/child-accounts.xml
+++ b/tests/fixtures/account/child-accounts.xml
@@ -30,6 +30,7 @@ Content-Type: application/xml; charset=utf-8
     <company_name nil="nil"></company_name>
     <vat_number nil="nil"></vat_number>
     <preferred_locale nil="nil"></preferred_locale>
+    <preferred_time_zone nil="nil"></preferred_time_zone>
     <address>
       <address1 nil="nil"></address1>
       <address2 nil="nil"></address2>

--- a/tests/fixtures/account/created-with-parent.xml
+++ b/tests/fixtures/account/created-with-parent.xml
@@ -44,4 +44,5 @@ Location: https://api.recurly.com/v2/accounts/testmock
   </address>
   <accept_language nil="nil"></accept_language>
   <preferred_locale>en-US</preferred_locale>
+  <preferred_time_zone nil="nil"></preferred_time_zone>
 </account>

--- a/tests/fixtures/account/created.xml
+++ b/tests/fixtures/account/created.xml
@@ -9,6 +9,7 @@ Content-Type: application/xml; charset=utf-8
 <account>
   <account_code>testmock</account_code>
   <preferred_locale>en-US</preferred_locale>
+  <preferred_time_zone>America/Los_Angeles</preferred_time_zone>
   <vat_number>444444-UK</vat_number>
 </account>
 
@@ -43,4 +44,5 @@ Location: https://api.recurly.com/v2/accounts/testmock
   <accept_language nil="nil"></accept_language>
   <vat_location_enabled type="boolean">true</vat_location_enabled>
   <preferred_locale>en-US</preferred_locale>
+  <preferred_time_zone>America/Los_Angeles</preferred_time_zone>
 </account>

--- a/tests/fixtures/billing-info/account-becs-created.xml
+++ b/tests/fixtures/billing-info/account-becs-created.xml
@@ -47,6 +47,7 @@ Location: https://api.recurly.com/v2/accounts/binfo-mock-5
   <company_name nil="nil"></company_name>
   <vat_number nil="nil"></vat_number>
   <preferred_locale nil="nil"></preferred_locale>
+  <preferred_time_zone nil="nil"></preferred_time_zone>
   <address>
     <address1 nil="nil"></address1>
     <address2 nil="nil"></address2>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -303,6 +303,7 @@ class TestResources(RecurlyTest):
         account = Account(account_code=account_code)
         account.vat_number = '444444-UK'
         account.preferred_locale = 'en-US'
+        account.preferred_time_zone = 'America/Los_Angeles'
         with self.mock_request('account/created.xml'):
             account.save()
         self.assertEqual(account._url, urljoin(recurly.base_uri(), 'accounts/%s' % account_code))
@@ -1286,7 +1287,7 @@ class TestResources(RecurlyTest):
                 'https://api.recurly.com/v2/subscriptions/rhind9aehvrt',
                 'https://api.recurly.com/v2/external_subscriptions/rlhjggnogtc5'
             ])
-            
+
     def test_invoice_templates(self):
         with self.mock_request('invoice_templates/list.xml'):
             template = InvoiceTemplate.all()[0]
@@ -2795,7 +2796,7 @@ class TestResources(RecurlyTest):
 
         with self.mock_request('external-subscription/list.xml'):
             external_subscriptions = ExternalSubscription.all(per_page = 200)
-            
+
         self.assertEqual(len(external_subscriptions), 2)
 
         self.assertEqual(external_subscriptions[0].external_resource.external_object_reference, 'teste')
@@ -2824,7 +2825,7 @@ class TestResources(RecurlyTest):
 
         with self.mock_request('external-subscription/get.xml'):
             external_subscription = ExternalSubscription.get('ru2208s6hmf0')
-            
+
         self.assertEqual(external_subscription.external_resource.external_object_reference, 'teste')
         self.assertEqual(external_subscription.external_product_reference, None)
         self.assertEqual(external_subscription.last_purchased, None)
@@ -2899,7 +2900,7 @@ class TestResources(RecurlyTest):
 
         with self.mock_request('external-product/get.xml'):
             external_product = ExternalProduct.get('ru1u1gms4msk')
-            
+
         self.assertEqual(external_product.plan.plan_code, '5_abril')
         self.assertEqual(external_product.plan.name, '5 de abril')
         self.assertEqual(external_product.name, 'product_name_teste')


### PR DESCRIPTION
Adds `Account#preferred_time_zone` as a string attribute for API version 2.29 which is used to determine the time zone of emails sent on behalf of the merchant to the customer.

Also fix the Python 3.6 build by running it on Ubuntu 20 as Ubuntu 22 does not bundle in Python 3.6