### PR TITLE
Added decline_code to TransactionError

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -1785,6 +1785,7 @@ class TransactionError(recurly.Resource):
         'customer_message',
         'error_code',
         'gateway_error_code',
+        'decline_code'
     )
 
 class TransactionFraudInfo(recurly.Resource):

--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -192,7 +192,7 @@ class TransactionError:
         if el is not None:
             return el.text
 
-     @property
+    @property
     def decline_code(self):
         """Decline code from the issuer"""
         el = self.response_doc.find('decline_code')

--- a/recurly/errors.py
+++ b/recurly/errors.py
@@ -192,6 +192,13 @@ class TransactionError:
         if el is not None:
             return el.text
 
+     @property
+    def decline_code(self):
+        """Decline code from the issuer"""
+        el = self.response_doc.find('decline_code')
+        if el is not None:
+            return el.text
+
 
 class ValidationError(ClientError):
 

--- a/tests/fixtures/transaction/declined-transaction.xml
+++ b/tests/fixtures/transaction/declined-transaction.xml
@@ -25,5 +25,6 @@ Content-Type: application/xml; charset=utf-8
     <customer_message lang="en-US">The transaction was declined due to insufficient funds in your account. Please use a different card or contact your bank.</customer_message>
     <merchant_message lang="en-US">The card has insufficient funds to cover the cost of the transaction.</merchant_message>
     <gateway_error_code>123</gateway_error_code>
+    <decline_code>insufficient_funds</decline_code>
   </transaction_error>
 </errors>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -2649,6 +2649,7 @@ class TestResources(RecurlyTest):
         self.assertEqual(transaction.customer_message, 'The transaction was declined due to insufficient funds in your account. Please use a different card or contact your bank.')
         self.assertEqual(transaction.merchant_message, 'The card has insufficient funds to cover the cost of the transaction.')
         self.assertEqual(transaction.gateway_error_code, '123')
+        self.assertEqual(transaction.decline_code, 'insufficient_funds')
 
 
     def test_transaction_with_balance(self):

--- a/tests/tests_errors.py
+++ b/tests/tests_errors.py
@@ -42,7 +42,7 @@ class RecurlyExceptionTests(RecurlyTest):
         self.assertEqual(transaction_error.customer_message, "The transaction was declined due to insufficient funds in your account. Please use a different card or contact your bank.")
         self.assertEqual(transaction_error.merchant_message, "The card has insufficient funds to cover the cost of the transaction.")
         self.assertEqual(transaction_error.gateway_error_code, "123")
-        self.assertEqual(transaction.decline_code, 'insufficient_funds')
+        self.assertEqual(transaction_error.decline_code, 'insufficient_funds')
 
     def test_transaction_error_code_property(self):
         """ Test ValidationError class 'transaction_error_code' property"""

--- a/tests/tests_errors.py
+++ b/tests/tests_errors.py
@@ -42,6 +42,7 @@ class RecurlyExceptionTests(RecurlyTest):
         self.assertEqual(transaction_error.customer_message, "The transaction was declined due to insufficient funds in your account. Please use a different card or contact your bank.")
         self.assertEqual(transaction_error.merchant_message, "The card has insufficient funds to cover the cost of the transaction.")
         self.assertEqual(transaction_error.gateway_error_code, "123")
+        self.assertEqual(transaction.decline_code, 'insufficient_funds')
 
     def test_transaction_error_code_property(self):
         """ Test ValidationError class 'transaction_error_code' property"""


### PR DESCRIPTION
This PR adds decline_code field to the TransactionError response. This will be populated when a transactions are declined from the issuer.