### PR TITLE
Add tests for custom fields on adjustments and support for /credit_adjustments

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -948,6 +948,20 @@ class Adjustment(Resource):
         else:
             return super(Adjustment, self).__getattr__(name)
 
+    def credit_adjustments(self):
+        """A list of credit adjustments that were issued against this adjustment"""
+        url = recurly.base_uri() + (self.member_path % self.uuid) + '/credit_adjustments'
+
+        response = self.http_request(url, 'GET')
+        if response.status not in (200, 201):
+            self.raise_http_error(response)
+        response_xml = response.read()
+
+        # This can't be defined at the class level because it is a circular reference
+        Adjustment._classes_for_nodename['adjustment'] = Adjustment
+        elem = ElementTree.fromstring(response_xml)
+        return Adjustment.value_for_element(elem)
+
 class Invoice(Resource):
 
     """A payable charge to an account for the customer's charges and

--- a/tests/fixtures/adjustment/charged-with-custom-fields.xml
+++ b/tests/fixtures/adjustment/charged-with-custom-fields.xml
@@ -1,0 +1,51 @@
+POST https://api.recurly.com/v2/accounts/chargemock/adjustments HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<adjustment type="charge">
+  <currency>USD</currency>
+  <custom_fields>
+    <custom_field>
+      <name>size</name>
+      <value>small</value>
+    </custom_field>
+    <custom_field>
+      <name>color</name>
+      <value>blue</value>
+    </custom_field>
+  </custom_fields>
+  <description>test charge</description>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+</adjustment>
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/adjustments/4ba1531325014b4f969cd13676f514d8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<adjustment>
+  <uuid>4ba1531325014b4f969cd13676f514d8</uuid>
+  <account_code>chargemock</account_code>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <currency>
+    USD</currency>
+  <start_date type="datetime">2009-11-03T23:27:46-08:00</start_date>
+  <end_date type="datetime"></end_date>
+  <description>test charge</description>
+  <custom_fields type="array">
+    <custom_field>
+      <name>size</name>
+      <value>small</value>
+    </custom_field>
+    <custom_field>
+      <name>color</name>
+      <value>blue</value>
+    </custom_field>
+  </custom_fields>
+  <created_at type="datetime">
+    2009-11-03T23:27:46-08:00</created_at>
+</adjustment>

--- a/tests/fixtures/adjustment/credit-adjustments.xml
+++ b/tests/fixtures/adjustment/credit-adjustments.xml
@@ -1,4 +1,4 @@
-GET https://api.recurly.com/v2/accounts/chargemock/adjustments HTTP/1.1
+GET https://api.recurly.com/v2/adjustments/4ba1531325014b4f969cd13676f514d8/credit_adjustments HTTP/1.1
 X-Api-Version: {api-version}
 Accept: application/xml
 Authorization: Basic YXBpa2V5Og==
@@ -11,7 +11,7 @@ X-Records: 1
 
 <adjustments type="array">
   <adjustment type="charge">
-    <uuid>4ba1531325014b4f969cd13676f514d8</uuid>
+    <uuid>4ba1531325014b4f969cd13676f514d9</uuid>
     <description>test charge</description>
     <account_code>chargemock</account_code>
     <tax_in_cents type="integer">5000</tax_in_cents>
@@ -34,7 +34,7 @@ X-Records: 1
         <tax_in_cents type="integer">2000</tax_in_cents>
       </tax_detail>
     </tax_details>
-    <start_date type="datetime">2009-11-03T23:27:46Z</start_date>
+    <start_date type="datetime"> 2009-11-03T23:27:46Z</start_date>
     <end_date nil="nil" type="datetime"></end_date>
     <created_at type="datetime">2009-11-03T23:27:46Z</created_at>
     <custom_fields type="array">

--- a/tests/fixtures/adjustment/lookup.xml
+++ b/tests/fixtures/adjustment/lookup.xml
@@ -1,0 +1,49 @@
+GET https://api.recurly.com/v2/adjustments/4ba1531325014b4f969cd13676f514d8 HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<adjustment type="charge">
+  <uuid>4ba1531325014b4f969cd13676f514d8</uuid>
+  <description>test charge</description>
+  <account_code>chargemock</account_code>
+  <tax_in_cents type="integer">5000</tax_in_cents>
+  <tax_type>usst</tax_type>
+  <tax_region>CA</tax_region>
+  <tax_rate type="float">0.0875</tax_rate>
+  <unit_amount_in_cents type="integer">1000</unit_amount_in_cents>
+  <currency>USD</currency>
+  <tax_details type="array">
+    <tax_detail>
+      <name>california</name>
+      <type>state</type>
+      <tax_rate type="float">0.065</tax_rate>
+      <tax_in_cents type="integer">3000</tax_in_cents>
+    </tax_detail>
+    <tax_detail>
+      <name>san francisco</name>
+      <type>county</type>
+      <tax_rate type="float">0.02</tax_rate>
+      <tax_in_cents type="integer">2000</tax_in_cents>
+    </tax_detail>
+  </tax_details>
+  <start_date type="datetime">2009-11-03T23:27:46Z</start_date>
+  <end_date nil="nil" type="datetime"></end_date>
+  <created_at type="datetime">2009-11-03T23:27:46Z</created_at>
+  <custom_fields type="array">
+    <custom_field>
+      <name>size</name>
+      <value>small</value>
+    </custom_field>
+    <custom_field>
+      <name>
+        color</name>
+      <value>blue</value>
+    </custom_field>
+  </custom_fields>
+</adjustment>


### PR DESCRIPTION
Add tests for custom fields on `/adjustments` endpoints. Also added support for `/adjustments/{uuid}/credit_adjustments` endpoint.