### PR TITLE
Add support for custom field definitions

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -156,6 +156,25 @@ class CustomField(Resource):
 
         return super(CustomField, self).to_element(root_name)
 
+class CustomFieldDefinition(Resource):
+
+    """A definition for custom fields"""
+
+    nodename = 'custom_field_definition'
+    member_path = 'custom_field_definitions/%s'
+    collection_path = 'custom_field_definitions'
+
+    attributes = (
+        'id',
+        'related_type',
+        'name',
+        'user_access',
+        'display_name',
+        'tooltip',
+        'created_at',
+        'updated_at',
+    )
+
 class Account(Resource):
 
     """A customer account."""

--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -158,7 +158,7 @@ class CustomField(Resource):
 
 class CustomFieldDefinition(Resource):
 
-    """A definition for custom fields"""
+    """Defines the name, tool tip, and kind (related_type) for a custom field"""
 
     nodename = 'custom_field_definition'
     member_path = 'custom_field_definitions/%s'

--- a/tests/fixtures/custom_field_definitions/list.xml
+++ b/tests/fixtures/custom_field_definitions/list.xml
@@ -1,0 +1,47 @@
+GET https://api.recurly.com/v2/custom_field_definitions HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 3
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<custom_field_definitions type="array">
+  <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3722298505492673710">
+    <id>3722298505492673710</id>
+    <related_type>plan</related_type>
+    <name>package</name>
+    <user_access>writable</user_access>
+    <display_name>Package</display_name>
+    <tooltip>Value can be 'Basic' or 'Premium'</tooltip>
+    <created_at type="datetime">2023-01-23T19:02:40Z</created_at>
+    <updated_at type="datetime">2023-01-23T19:02:47Z</updated_at>
+    <deleted_at nil="nil"></deleted_at>
+  </custom_field_definition>
+  <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3717783227799104920">
+    <id>3717783227799104920</id>
+    <related_type>charge</related_type>
+    <name>size</name>
+    <user_access>api_only</user_access>
+    <display_name></display_name>
+    <tooltip></tooltip>
+    <created_at type="datetime">2023-01-17T13:31:37Z</created_at>
+    <updated_at type="datetime">2023-01-17T13:31:37Z</updated_at>
+    <deleted_at nil="nil"></deleted_at>
+  </custom_field_definition>
+  <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3704733972259271618">
+    <id>3704733972259271618</id>
+    <related_type>charge</related_type>
+    <name>color</name>
+    <user_access>api_only</user_access>
+    <display_name></display_name>
+    <tooltip></tooltip>
+    <created_at type="datetime">2022-12-30T13:25:04Z</created_at>
+    <updated_at type="datetime">2022-12-30T13:25:04Z</updated_at>
+    <deleted_at nil="nil"></deleted_at>
+  </custom_field_definition>
+</custom_field_definitions>

--- a/tests/fixtures/custom_field_definitions/list_charge.xml
+++ b/tests/fixtures/custom_field_definitions/list_charge.xml
@@ -1,0 +1,36 @@
+GET https://api.recurly.com/v2/custom_field_definitions?related_type=charge HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 2
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<custom_field_definitions type="array">
+  <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3717783227799104920">
+    <id>3717783227799104920</id>
+    <related_type>charge</related_type>
+    <name>size</name>
+    <user_access>api_only</user_access>
+    <display_name></display_name>
+    <tooltip></tooltip>
+    <created_at type="datetime">2023-01-17T13:31:37Z</created_at>
+    <updated_at type="datetime">2023-01-17T13:31:37Z</updated_at>
+    <deleted_at nil="nil"></deleted_at>
+  </custom_field_definition>
+  <custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3704733972259271618">
+    <id>3704733972259271618</id>
+    <related_type>charge</related_type>
+    <name>size</name>
+    <user_access>api_only</user_access>
+    <display_name></display_name>
+    <tooltip></tooltip>
+    <created_at type="datetime">2022-12-30T13:25:04Z</created_at>
+    <updated_at type="datetime">2022-12-30T13:25:04Z</updated_at>
+    <deleted_at nil="nil"></deleted_at>
+  </custom_field_definition>
+</custom_field_definitions>

--- a/tests/fixtures/custom_field_definitions/show.xml
+++ b/tests/fixtures/custom_field_definitions/show.xml
@@ -1,0 +1,23 @@
+GET https://api.recurly.com/v2/custom_field_definitions/3722298505492673710 HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 3
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<custom_field_definition href="https://api.recurly.com/v2/custom_field_definitions/3722298505492673710">
+  <id>3722298505492673710</id>
+  <related_type>plan</related_type>
+  <name>package</name>
+  <user_access>writable</user_access>
+  <display_name>Package</display_name>
+  <tooltip>Value can be 'Basic' or 'Premium'</tooltip>
+  <created_at type="datetime">2023-01-23T19:02:40Z</created_at>
+  <updated_at type="datetime">2023-01-23T19:02:47Z</updated_at>
+  <deleted_at nil="nil"></deleted_at>
+</custom_field_definition>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -9,7 +9,8 @@ import recurly
 from recurly import Account, AddOn, Address, Adjustment, BillingInfo, Coupon, Item, Plan, Redemption, Subscription, \
     SubscriptionAddOn, Transaction, MeasuredUnit, Usage, GiftCard, Delivery, ShippingAddress, AccountAcquisition, \
     Purchase, Invoice, InvoiceCollection, CreditPayment, CustomField, ExportDate, ExportDateFile, DunningCampaign, \
-    DunningCycle, InvoiceTemplate, PlanRampInterval, SubRampInterval, ExternalSubscription, ExternalResource, ExternalProduct, ExternalProductReference
+    DunningCycle, InvoiceTemplate, PlanRampInterval, SubRampInterval, ExternalSubscription, ExternalResource, \
+    ExternalProduct, ExternalProductReference, CustomFieldDefinition
 from recurly import Money, NotFoundError, ValidationError, BadRequestError, PageError
 from recurly import recurly_logging as logging
 from recurlytests import RecurlyTest
@@ -1706,6 +1707,40 @@ class TestResources(RecurlyTest):
         finally:
             with self.mock_request('item/deleted.xml'):
                 item.delete()
+
+    def test_custom_field_definition(self):
+        """Test custom field definitions list"""
+        with self.mock_request('custom_field_definitions/list.xml'):
+            definitions = CustomFieldDefinition.all()
+
+            self.assertEqual(len(definitions), 3)
+            self.assertEqual(type(definitions[0]), CustomFieldDefinition)
+
+        """Test custom field definitions list by related type"""
+        with self.mock_request('custom_field_definitions/list_charge.xml'):
+            definitions = CustomFieldDefinition.all(related_type='charge')
+
+            self.assertEqual(len(definitions), 2)
+            self.assertEqual(definitions[0].related_type, 'charge')
+            self.assertEqual(definitions[1].related_type, 'charge')
+
+        """Test custom field definitions get"""
+        with self.mock_request('custom_field_definitions/show.xml'):
+            definition_id = '3722298505492673710'
+            definition = CustomFieldDefinition.get(definition_id)
+
+            self.assertIsInstance(definition, CustomFieldDefinition)
+            self.assertEqual(definition.id, '3722298505492673710')
+            self.assertEqual(definition.related_type, 'plan')
+            self.assertEqual(definition.name, 'package')
+            self.assertEqual(definition.user_access, 'writable')
+            self.assertEqual(definition.display_name, 'Package')
+            self.assertEqual(definition.tooltip, 'Value can be \'Basic\' or \'Premium\'')
+            self.assertEqual(definition.created_at,
+                datetime(2023, 1, 23, 19, 2, 40, tzinfo=definition.created_at.tzinfo))
+            self.assertEqual(definition.updated_at,
+                datetime(2023, 1, 23, 19, 2, 47, tzinfo=definition.updated_at.tzinfo))
+            self.assertIsNone(definition.deleted_at)
 
     def test_plan(self):
         plan_code = 'plan%s' % self.test_id


### PR DESCRIPTION
Add support for custom field definitions endpoints:
* `GET /custom_field_definitions`
* `GET /custom_field_definitions/{id}`