### PR TITLE
Add used_tax_service to Invoice response

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -1037,7 +1037,8 @@ class Invoice(Resource):
         'billing_info',
         'billing_info_uuid',
         'dunning_campaign_id',
-        'refundable_in_cents'
+        'refundable_in_cents',
+        'used_tax_service'
     )
 
     blacklist_attributes = (

--- a/tests/fixtures/invoice/show-invoice.xml
+++ b/tests/fixtures/invoice/show-invoice.xml
@@ -58,6 +58,7 @@ Location: https://api.recurly.com/v2/invoices/6019
   <collection_method>manual</collection_method>
   <po_number nil="nil"></po_number>
   <terms_and_conditions>t and c</terms_and_conditions>
+  <used_tax_service type="boolean">true</used_tax_service>
   <line_items type="array">
     <adjustment href="https://api.recurly.com/v2/adjustments/46036dc9823500f96f43ef44769df449" type="charge">
       <account href="https://api.recurly.com/v2/accounts/aa463d59-a618-4b71-b1f4-0410f835fe74"/>

--- a/tests/fixtures/invoice/show-taxed.xml
+++ b/tests/fixtures/invoice/show-taxed.xml
@@ -24,5 +24,6 @@ Content-Type: application/xml; charset=utf-8
     <description>test charge</description>
     <created_at type="datetime">2009-11-03T23:27:46-08:00</created_at>
     <tax_type>usst</tax_type>
+    <used_tax_service type="boolean">true</used_tax_service>
   </invoice>
 </invoices>


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `<used_tax_service>`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.