### PR TITLE
Generated Latest Changes for v2021-02-25 (used_tax_service on Invoice)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -19032,6 +19032,13 @@ components:
           description: The outstanding balance remaining on this invoice.
         tax_info:
           "$ref": "#/components/schemas/TaxInfo"
+        used_tax_service:
+          type: boolean
+          title: Used Tax Service?
+          description: Will be `true` when the invoice had a successful response from
+            the tax service and `false` when the invoice was not sent to tax service
+            due to a lack of address or enabled jurisdiction or was processed without
+            tax due to a non-blocking error returned from the tax service.
         vat_number:
           type: string
           title: VAT number
@@ -24043,7 +24050,9 @@ components:
       - es-MX
       - es-US
       - fi-FI
+      - fr-BE
       - fr-CA
+      - fr-CH
       - fr-FR
       - hi-IN
       - it-IT

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -1391,6 +1391,8 @@ class Invoice(Resource):
         Invoices are either charge, credit, or legacy invoices.
     updated_at : datetime
         Last updated at
+    used_tax_service : bool
+        Will be `true` when the invoice had a successful response from the tax service and `false` when the invoice was not sent to tax service due to a lack of address or enabled jurisdiction or was processed without tax due to a non-blocking error returned from the tax service.
     uuid : str
         Invoice UUID
     vat_number : str
@@ -1437,6 +1439,7 @@ class Invoice(Resource):
         "transactions": ["Transaction"],
         "type": str,
         "updated_at": datetime,
+        "used_tax_service": bool,
         "uuid": str,
         "vat_number": str,
         "vat_reverse_charge_notes": str,


### PR DESCRIPTION
`Invoice` response format has changed:
- Added `used_tax_service`. Field is present if taxes are enabled. Value is `true` or `false` based on a successful response from the tax service.