### PR TITLE
Generated Latest Changes for v2021-02-25 (gateway_attributes on PaymentMethod)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -17853,6 +17853,17 @@ components:
           title: An identifier for a specific payment gateway. Must be used in conjunction
             with `gateway_token`.
           maxLength: 12
+        gateway_attributes:
+          type: object
+          description: Additional attributes to send to the gateway.
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created. Must be used in conjunction with
+                gateway_token and gateway_code.
+              maxLength: 264
         amazon_billing_agreement_id:
           type: string
           title: Amazon billing agreement ID
@@ -23606,6 +23617,16 @@ components:
           type: string
           description: An identifier for a specific payment gateway.
           maxLength: 13
+        gateway_attributes:
+          type: object
+          description: Gateway specific attributes associated with this PaymentMethod
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created.
+              maxLength: 264
         billing_agreement_id:
           type: string
           description: Billing Agreement identifier. Only present for Amazon or Paypal

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -372,6 +372,8 @@ class PaymentMethod(Resource):
         Expiration year.
     first_six : str
         Credit card number's first six digits.
+    gateway_attributes : GatewayAttributes
+        Gateway specific attributes associated with this PaymentMethod
     gateway_code : str
         An identifier for a specific payment gateway.
     gateway_token : str
@@ -399,6 +401,7 @@ class PaymentMethod(Resource):
         "exp_month": int,
         "exp_year": int,
         "first_six": str,
+        "gateway_attributes": "GatewayAttributes",
         "gateway_code": str,
         "gateway_token": str,
         "last_four": str,
@@ -408,6 +411,19 @@ class PaymentMethod(Resource):
         "routing_number": str,
         "routing_number_bank": str,
         "username": str,
+    }
+
+
+class GatewayAttributes(Resource):
+    """
+    Attributes
+    ----------
+    account_reference : str
+        Used by Adyen gateways. The Shopper Reference value used when the external token was created.
+    """
+
+    schema = {
+        "account_reference": str,
     }
 
 


### PR DESCRIPTION
Add new property to `BillingInfoCreate` and `PaymentMethod` responses

- Added `gateway_attributes` property
- `gateway_attributes` allows an `account_reference` value to be be submitted. This field must be passed in with a `gateway_code` and `gateway_token`
- `gateway_attributes` is returned in response if present