### PR TITLE
Generated Latest Changes for v2019-10-10 (gateway_attributes on PaymentMethod)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16645,6 +16645,17 @@ components:
           title: An identifier for a specific payment gateway. Must be used in conjunction
             with `gateway_token`.
           maxLength: 12
+        gateway_attributes:
+          type: object
+          description: Additional attributes to send to the gateway.
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created. Must be used in conjunction with
+                gateway_token and gateway_code.
+              maxLength: 264
         amazon_billing_agreement_id:
           type: string
           title: Amazon billing agreement ID
@@ -21470,6 +21481,7 @@ components:
           - force_collect
           - refunded_externally
           - chargeback
+          - external_recovery
         currency:
           type: string
           title: Currency
@@ -22185,6 +22197,7 @@ components:
         object:
           type: string
           enum:
+          - bacs
           - credit_card
           - paypal
           - amazon
@@ -22255,6 +22268,16 @@ components:
           type: string
           description: An identifier for a specific payment gateway.
           maxLength: 13
+        gateway_attributes:
+          type: object
+          description: Gateway specific attributes associated with this PaymentMethod
+          x-class-name: GatewayAttributes
+          properties:
+            account_reference:
+              type: string
+              description: Used by Adyen gateways. The Shopper Reference value used
+                when the external token was created.
+              maxLength: 264
         billing_agreement_id:
           type: string
           description: Billing Agreement identifier. Only present for Amazon or Paypal

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -345,6 +345,8 @@ class PaymentMethod(Resource):
         Expiration year.
     first_six : str
         Credit card number's first six digits.
+    gateway_attributes : GatewayAttributes
+        Gateway specific attributes associated with this PaymentMethod
     gateway_code : str
         An identifier for a specific payment gateway.
     gateway_token : str
@@ -370,6 +372,7 @@ class PaymentMethod(Resource):
         "exp_month": int,
         "exp_year": int,
         "first_six": str,
+        "gateway_attributes": "GatewayAttributes",
         "gateway_code": str,
         "gateway_token": str,
         "last_four": str,
@@ -378,6 +381,19 @@ class PaymentMethod(Resource):
         "object": str,
         "routing_number": str,
         "routing_number_bank": str,
+    }
+
+
+class GatewayAttributes(Resource):
+    """
+    Attributes
+    ----------
+    account_reference : str
+        Used by Adyen gateways. The Shopper Reference value used when the external token was created.
+    """
+
+    schema = {
+        "account_reference": str,
     }
 
 


### PR DESCRIPTION
Add new property to `BillingInfoCreate` and `PaymentMethod`

- Added `gateway_attributes` property
- `gateway_attributes` allows an `account_reference` value to be be submitted. This field must be passed in with a `gateway_code` and `gateway_token`
- `gateway_attributes` is returned in response if present
