### PR TITLE
Adding support for General Ledger Accounts

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -515,6 +515,24 @@ class GatewayAttributes(Resource):
         'account_reference',
     )
 
+class GeneralLedgerAccount(Resource):
+
+    """General Ledger Account for Revenue Recognition"""
+
+    member_path = 'general_ledger_accounts/%s'
+    collection_path = 'general_ledger_accounts'
+
+    nodename = 'general_ledger_account'
+
+    attributes = (
+        'id',
+        'account_type',
+        'code',
+        'description',
+        'created_at',
+        'updated_at',
+    )
+
 class BillingInfo(Resource):
 
     """A set of billing information for an account."""

--- a/tests/fixtures/general_ledger_accounts/created.xml
+++ b/tests/fixtures/general_ledger_accounts/created.xml
@@ -1,0 +1,28 @@
+POST https://api.recurly.com/v2/general_ledger_accounts HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<general_ledger_account>
+  <account_type>liability</account_type>
+  <code>code2</code>
+  <description>Liability Description</description>
+</general_ledger_account>
+
+
+HTTP/1.1 201 Created
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/general_ledger_accounts/u9hmrpzksuy8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<general_ledger_account href="https://api.recurly.com/v2/general_ledger_accounts/u9hmrpzksuy8">
+    <id>u9hmrpzksuy8</id>
+    <code>code2</code>
+    <account_type>liability</account_type>
+    <description>Liability Description</description>
+    <created_at type="datetime">2024-01-18T23:20:01Z</created_at>
+    <updated_at type="datetime">2024-01-18T23:20:01Z</updated_at>
+</general_ledger_account>

--- a/tests/fixtures/general_ledger_accounts/get.xml
+++ b/tests/fixtures/general_ledger_accounts/get.xml
@@ -1,0 +1,20 @@
+GET https://api.recurly.com/v2/general_ledger_accounts/u90r5deeaxix HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<general_ledger_account href="https://api.recurly.com/v2/general_ledger_accounts/u90r5deeaxix">
+    <id>u90r5deeaxix</id>
+    <code>code1</code>
+    <account_type>revenue</account_type>
+    <description>Some Description</description>
+    <created_at type="datetime">2024-01-16T14:34:16Z</created_at>
+    <updated_at type="datetime">2024-01-16T14:34:16Z</updated_at>
+</general_ledger_account>

--- a/tests/fixtures/general_ledger_accounts/list.xml
+++ b/tests/fixtures/general_ledger_accounts/list.xml
@@ -1,0 +1,30 @@
+GET https://api.recurly.com/v2/general_ledger_accounts HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<general_ledger_accounts type="array">
+    <general_ledger_account href="https://api.recurly.com/v2/general_ledger_accounts/u90r5deeaxix">
+        <id>u90r5deeaxix</id>
+        <code>code1</code>
+        <account_type>revenue</account_type>
+        <description>Some Description</description>
+        <created_at type="datetime">2024-01-16T14:34:16Z</created_at>
+        <updated_at type="datetime">2024-01-16T14:34:16Z</updated_at>
+    </general_ledger_account>
+    <general_ledger_account href="https://api.recurly.com/v2/general_ledger_accounts/u9hmrpzksuy8">
+        <id>u9hmrpzksuy8</id>
+        <code>code2</code>
+        <account_type>liability</account_type>
+        <description>Liability Description</description>
+        <created_at type="datetime">2024-01-18T23:20:01Z</created_at>
+        <updated_at type="datetime">2024-01-18T23:20:01Z</updated_at>
+    </general_ledger_account>
+</general_ledger_accounts>

--- a/tests/fixtures/general_ledger_accounts/list_filtered.xml
+++ b/tests/fixtures/general_ledger_accounts/list_filtered.xml
@@ -1,0 +1,22 @@
+GET https://api.recurly.com/v2/general_ledger_accounts?account_type=revenue HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<general_ledger_accounts type="array">
+    <general_ledger_account href="https://api.recurly.com/v2/general_ledger_accounts/u90r5deeaxix">
+        <id>u90r5deeaxix</id>
+        <code>code1</code>
+        <account_type>revenue</account_type>
+        <description>Some Description</description>
+        <created_at type="datetime">2024-01-16T14:34:16Z</created_at>
+        <updated_at type="datetime">2024-01-16T14:34:16Z</updated_at>
+    </general_ledger_account>
+</general_ledger_accounts>

--- a/tests/fixtures/general_ledger_accounts/updated.xml
+++ b/tests/fixtures/general_ledger_accounts/updated.xml
@@ -1,0 +1,27 @@
+PUT https://api.recurly.com/v2/general_ledger_accounts/u90r5deeaxix HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<general_ledger_account>
+  <code>code2</code>
+  <description>Updated Description</description>
+</general_ledger_account>
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+Location: https://api.recurly.com/v2/general_ledger_accounts/u90r5deeaxix
+
+<?xml version="1.0" encoding="UTF-8"?>
+<general_ledger_account href="https://api.recurly.com/v2/general_ledger_accounts/u90r5deeaxix">
+    <id>u90r5deeaxix</id>
+    <code>code2</code>
+    <account_type>liability</account_type>
+    <description>Updated Description</description>
+    <created_at type="datetime">2024-01-18T23:20:01Z</created_at>
+    <updated_at type="datetime">2024-01-18T23:24:47Z</updated_at>
+</general_ledger_account>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -9,7 +9,7 @@ import recurly
 from recurly import Account, AddOn, Address, Adjustment, BillingInfo, Coupon, Item, Plan, Redemption, Subscription, \
     SubscriptionAddOn, Transaction, MeasuredUnit, Usage, GiftCard, Delivery, ShippingAddress, AccountAcquisition, \
     Purchase, Invoice, InvoiceCollection, CreditPayment, CustomField, ExportDate, ExportDateFile, DunningCampaign, \
-    DunningCycle, InvoiceTemplate, PlanRampInterval, SubRampInterval, ExternalSubscription, ExternalProduct, \
+    DunningCycle, GeneralLedgerAccount, InvoiceTemplate, PlanRampInterval, SubRampInterval, ExternalSubscription, ExternalProduct, \
     ExternalProductReference, ExternalPaymentPhase, CustomFieldDefinition, ExternalInvoice, ExternalCharge, ExternalAccount, \
     GatewayAttributes, BusinessEntity
 from recurly import Money, NotFoundError, ValidationError, BadRequestError, PageError
@@ -3392,6 +3392,53 @@ class TestResources(RecurlyTest):
         )
         with self.mock_request('account/created-with-external-accounts.xml'):
             account.save()
+
+    def test_list_general_ledger_accounts(self):
+        with self.mock_request('general_ledger_accounts/list.xml'):
+            general_ledger_accounts = GeneralLedgerAccount.all()
+
+        self.assertEqual(len(general_ledger_accounts), 2)
+
+    def test_list_filtered_general_ledger_accounts(self):
+        with self.mock_request('general_ledger_accounts/list_filtered.xml'):
+            general_ledger_accounts = GeneralLedgerAccount.all(account_type='revenue')
+
+        self.assertEqual(len(general_ledger_accounts), 1)
+        self.assertEqual(general_ledger_accounts[0].account_type, 'revenue')
+
+    def test_get_general_ledger_accounts(self):
+        with self.mock_request('general_ledger_accounts/get.xml'):
+            general_ledger_account = GeneralLedgerAccount.get('u90r5deeaxix')
+
+        self.assertEqual(general_ledger_account.id, 'u90r5deeaxix')
+        self.assertEqual(general_ledger_account.code, 'code1')
+        self.assertEqual(general_ledger_account.account_type, 'revenue')
+        self.assertEqual(general_ledger_account.description, 'Some Description')
+
+    def test_create_general_ledger_account(self):
+        general_ledger_account = GeneralLedgerAccount(
+            code='code2',
+            account_type='liability',
+            description='Liability Description'
+        )
+        with self.mock_request('general_ledger_accounts/created.xml'):
+            general_ledger_account.save()
+
+        self.assertEquals(general_ledger_account.code, 'code2')
+        self.assertEquals(general_ledger_account.account_type, 'liability')
+        self.assertEquals(general_ledger_account.description, 'Liability Description')
+
+    def test_update_general_ledger_account(self):
+        with self.mock_request('general_ledger_accounts/get.xml'):
+            general_ledger_account = GeneralLedgerAccount.get('u90r5deeaxix')
+
+        with self.mock_request('general_ledger_accounts/updated.xml'):
+            general_ledger_account.code = 'code2'
+            general_ledger_account.description = 'Updated Description'
+            general_ledger_account.save()
+
+        self.assertEquals(general_ledger_account.code, 'code2')
+        self.assertEquals(general_ledger_account.description, 'Updated Description')
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION
This change creates the `GeneralLedgerAccount` entity for the V2 client, the primary entity concerning the new (and upcoming) RevRec API features.