### PR TITLE
Adding support for Performance Obligations

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -533,6 +533,22 @@ class GeneralLedgerAccount(Resource):
         'updated_at',
     )
 
+class PerformanceObligation(Resource):
+
+    """Performance Obligation for Revenue Recognition"""
+
+    member_path = 'performance_obligations/%s'
+    collection_path = 'performance_obligations'
+
+    nodename = 'performance_obligation'
+
+    attributes = (
+        'id',
+        'name',
+        'created_at',
+        'updated_at',
+    )
+
 class BillingInfo(Resource):
 
     """A set of billing information for an account."""

--- a/tests/fixtures/performance_obligations/get.xml
+++ b/tests/fixtures/performance_obligations/get.xml
@@ -1,0 +1,18 @@
+GET https://api.recurly.com/v2/performance_obligations/6 HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<performance_obligation href="https://api.recurly.com/v2/performance_obligations/6">
+    <id>6</id>
+    <name>Over Time (Daily)</name>
+    <created_at type="datetime">2023-08-15T18:29:31Z</created_at>
+    <updated_at type="datetime">2023-08-15T18:29:31Z</updated_at>
+</performance_obligation>

--- a/tests/fixtures/performance_obligations/list.xml
+++ b/tests/fixtures/performance_obligations/list.xml
@@ -1,0 +1,50 @@
+GET https://api.recurly.com/v2/performance_obligations HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+X-Records: 1
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<performance_obligations type="array">
+    <performance_obligation href="https://api.recurly.com/v2/performance_obligations/6">
+        <id>6</id>
+        <name>Over Time (Daily)</name>
+        <created_at type="datetime">2023-08-15T18:29:31Z</created_at>
+        <updated_at type="datetime">2023-08-15T18:29:31Z</updated_at>
+    </performance_obligation>
+    <performance_obligation href="https://api.recurly.com/v2/performance_obligations/5">
+        <id>5</id>
+        <name>Over Time (Partial Monthly)</name>
+        <created_at type="datetime">2023-08-15T18:29:31Z</created_at>
+        <updated_at type="datetime">2023-08-15T18:29:31Z</updated_at>
+    </performance_obligation>
+    <performance_obligation href="https://api.recurly.com/v2/performance_obligations/4">
+        <id>4</id>
+        <name>Point in Time</name>
+        <created_at type="datetime">2023-08-15T18:29:31Z</created_at>
+        <updated_at type="datetime">2023-08-15T18:29:31Z</updated_at>
+    </performance_obligation>
+    <performance_obligation href="https://api.recurly.com/v2/performance_obligations/3">
+        <id>3</id>
+        <name>Manually Recognize</name>
+        <created_at type="datetime">2023-08-15T18:29:31Z</created_at>
+        <updated_at type="datetime">2023-08-15T18:29:31Z</updated_at>
+    </performance_obligation>
+    <performance_obligation href="https://api.recurly.com/v2/performance_obligations/2">
+        <id>2</id>
+        <name>Manual Journal</name>
+        <created_at type="datetime">2023-08-15T18:29:31Z</created_at>
+        <updated_at type="datetime">2023-08-15T18:29:31Z</updated_at>
+    </performance_obligation>
+    <performance_obligation href="https://api.recurly.com/v2/performance_obligations/1">
+        <id>1</id>
+        <name>Material Right</name>
+        <created_at type="datetime">2023-08-15T18:29:31Z</created_at>
+        <updated_at type="datetime">2023-08-15T18:29:31Z</updated_at>
+    </performance_obligation>
+</performance_obligations>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -9,7 +9,7 @@ import recurly
 from recurly import Account, AddOn, Address, Adjustment, BillingInfo, Coupon, Item, Plan, Redemption, Subscription, \
     SubscriptionAddOn, Transaction, MeasuredUnit, Usage, GiftCard, Delivery, ShippingAddress, AccountAcquisition, \
     Purchase, Invoice, InvoiceCollection, CreditPayment, CustomField, ExportDate, ExportDateFile, DunningCampaign, \
-    DunningCycle, GeneralLedgerAccount, InvoiceTemplate, PlanRampInterval, SubRampInterval, ExternalSubscription, ExternalProduct, \
+    DunningCycle, GeneralLedgerAccount, InvoiceTemplate, PerformanceObligation, PlanRampInterval, SubRampInterval, ExternalSubscription, ExternalProduct, \
     ExternalProductReference, ExternalPaymentPhase, CustomFieldDefinition, ExternalInvoice, ExternalCharge, ExternalAccount, \
     GatewayAttributes, BusinessEntity
 from recurly import Money, NotFoundError, ValidationError, BadRequestError, PageError
@@ -3439,6 +3439,19 @@ class TestResources(RecurlyTest):
 
         self.assertEquals(general_ledger_account.code, 'code2')
         self.assertEquals(general_ledger_account.description, 'Updated Description')
+
+    def test_list_performance_obligations(self):
+        with self.mock_request('performance_obligations/list.xml'):
+            performance_obligations = PerformanceObligation.all()
+
+        self.assertEqual(len(performance_obligations), 6)
+
+    def test_get_performance_obligation(self):
+        with self.mock_request('performance_obligations/get.xml'):
+            performance_obligation = PerformanceObligation.get(6)
+
+        self.assertEqual(performance_obligation.id, '6')
+        self.assertEqual(performance_obligation.name, 'Over Time (Daily)')
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION
This change creates the `PerformanceObligation` entity for the V2 client, the primary entity concerning the new (and upcoming) RevRec API features.