### PR TITLE
Adding RevRec Support for Business Entities

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -490,7 +490,9 @@ class BusinessEntity(Resource):
         'default_vat_number',
         'default_registration_number',
         'created_at',
-        'updated_at'
+        'updated_at',
+        'default_revenue_gl_account_id',
+        'default_liability_gl_account_id',
     )
 
     _classes_for_nodename = {

--- a/tests/fixtures/business_entity/get.xml
+++ b/tests/fixtures/business_entity/get.xml
@@ -40,4 +40,6 @@ Content-Type: application/xml; charset=utf-8
     <default_registration_number>ab1</default_registration_number>
     <created_at type="datetime">2023-05-13T17:28:47Z</created_at>
     <updated_at type="datetime">2023-10-13T17:28:48Z</updated_at>
+    <default_liability_gl_account_id>t5ejtge1xw0x</default_liability_gl_account_id>
+    <default_revenue_gl_account_id>t5ejtgf1vxh1</default_revenue_gl_account_id>
 </business_entity>

--- a/tests/fixtures/business_entity/list.xml
+++ b/tests/fixtures/business_entity/list.xml
@@ -39,6 +39,8 @@ Content-Type: application/xml; charset=utf-8
         <default_registration_number></default_registration_number>
         <created_at type="datetime">2023-05-25T15:56:47Z</created_at>
         <updated_at type="datetime">2023-05-25T15:56:47Z</updated_at>
+        <default_liability_gl_account_id nil="nil"></default_liability_gl_account_id>
+        <default_revenue_gl_account_id nil="nil"></default_revenue_gl_account_id>
     </business_entity>
     <business_entity href="https://pcc.recurly.dev:3000/v2/business_entities/sppvjs6eripk">
         <invoices href="https://pcc.recurly.dev:3000/v2/business_entities/sppvjs6eripk/invoices"/>
@@ -69,5 +71,7 @@ Content-Type: application/xml; charset=utf-8
         <default_registration_number></default_registration_number>
         <created_at type="datetime">2023-04-12T15:11:58Z</created_at>
         <updated_at type="datetime">2023-05-15T15:34:01Z</updated_at>
+        <default_liability_gl_account_id>t5ejtge1xw0x</default_liability_gl_account_id>
+        <default_revenue_gl_account_id>t5ejtgf1vxh1</default_revenue_gl_account_id>
     </business_entity>
 </business_entities>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -3210,6 +3210,8 @@ class TestResources(RecurlyTest):
         self.assertIsInstance(entity.invoice_display_address, Address)
         self.assertEqual(entity.created_at, datetime(2023, 5, 13, 17, 28, 47, tzinfo=entity.created_at.tzinfo))
         self.assertEqual(entity.updated_at, datetime(2023, 10, 13, 17, 28, 48, tzinfo=entity.updated_at.tzinfo))
+        self.assertEqual(entity.default_liability_gl_account_id, 't5ejtge1xw0x')
+        self.assertEqual(entity.default_revenue_gl_account_id, 't5ejtgf1vxh1')
 
     def test_list_business_entities(self):
         with self.mock_request('business_entity/list.xml'):


### PR DESCRIPTION
This change adds RevRec support in Business Entities for the V2 client, the primary entity concerning the new (and upcoming) RevRec API features.