### PR TITLE
Adding RevRec Support for Shipping Methods

### DIFF
--- a/recurly/__init__.py
+++ b/recurly/__init__.py
@@ -1483,6 +1483,9 @@ class ShippingMethod(Resource):
       'name',
       'accounting_code',
       'tax_code',
+      'liability_gl_account_id',
+      'revenue_gl_account_id',
+      'performance_obligation_id',
       'created_at',
       'updated_at',
     )

--- a/tests/fixtures/shipping-method/get.xml
+++ b/tests/fixtures/shipping-method/get.xml
@@ -1,0 +1,22 @@
+GET https://api.recurly.com/v2/shipping_methods/shipping2 HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<shipping_method href="https://api.recurly.com/v2/shipping_methods/shipping3">
+    <code>shipping2</code>
+    <name>shipping 2</name>
+    <accounting_code>ship</accounting_code>
+    <tax_code>FR</tax_code>
+    <liability_gl_account_id>t5ejtge1xw0x</liability_gl_account_id>
+    <revenue_gl_account_id>t5ejtgf1vxh1</revenue_gl_account_id>
+    <performance_obligation_id>6</performance_obligation_id>
+    <created_at type="datetime">2023-07-06T16:57:18Z</created_at>
+    <updated_at type="datetime">2023-07-06T16:57:18Z</updated_at>
+</shipping_method>

--- a/tests/fixtures/shipping-method/list.xml
+++ b/tests/fixtures/shipping-method/list.xml
@@ -1,0 +1,35 @@
+GET https://api.recurly.com/v2/shipping_methods HTTP/1.1
+X-Api-Version: {api-version}
+Accept: application/xml
+Authorization: Basic YXBpa2V5Og==
+User-Agent: {user-agent}
+
+
+HTTP/1.1 200 OK
+Content-Type: application/xml; charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<shipping_methods type="array">
+    <shipping_method href="https://api.recurly.com/v2/shipping_methods/shipping2">
+        <code>shipping2</code>
+        <name>shipping 2</name>
+        <accounting_code>ship</accounting_code>
+        <tax_code>FR</tax_code>
+        <liability_gl_account_id>t5ejtge1xw0x</liability_gl_account_id>
+        <revenue_gl_account_id>t5ejtgf1vxh1</revenue_gl_account_id>
+        <performance_obligation_id>6</performance_obligation_id>
+        <created_at type="datetime">2023-07-06T16:57:18Z</created_at>
+        <updated_at type="datetime">2023-07-06T16:57:18Z</updated_at>
+    </shipping_method>
+    <shipping_method href="https://api.recurly.com/v2/shipping_methods/shipping">
+        <code>shipping</code>
+        <name>shipping</name>
+        <accounting_code></accounting_code>
+        <tax_code></tax_code>
+        <liability_gl_account_id nil="nil"></liability_gl_account_id>
+        <revenue_gl_account_id nil="nil"></revenue_gl_account_id>
+        <performance_obligation_id>4</performance_obligation_id>
+        <created_at type="datetime">2023-07-05T22:47:07Z</created_at>
+        <updated_at type="datetime">2023-07-06T18:15:41Z</updated_at>
+    </shipping_method>
+</shipping_methods>

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -7,7 +7,7 @@ from six.moves.urllib.parse import urljoin
 
 import recurly
 from recurly import Account, AddOn, Address, Adjustment, BillingInfo, Coupon, Item, Plan, Redemption, Subscription, \
-    SubscriptionAddOn, Transaction, MeasuredUnit, Usage, GiftCard, Delivery, ShippingAddress, AccountAcquisition, \
+    SubscriptionAddOn, Transaction, MeasuredUnit, Usage, GiftCard, Delivery, ShippingAddress, ShippingMethod, AccountAcquisition, \
     Purchase, Invoice, InvoiceCollection, CreditPayment, CustomField, ExportDate, ExportDateFile, DunningCampaign, \
     DunningCycle, GeneralLedgerAccount, InvoiceTemplate, PerformanceObligation, PlanRampInterval, SubRampInterval, ExternalSubscription, ExternalProduct, \
     ExternalProductReference, ExternalPaymentPhase, CustomFieldDefinition, ExternalInvoice, ExternalCharge, ExternalAccount, \
@@ -3515,6 +3515,26 @@ class TestResources(RecurlyTest):
 
         self.assertEqual(performance_obligation.id, '6')
         self.assertEqual(performance_obligation.name, 'Over Time (Daily)')
+
+    def test_get_shipping_method(self):
+        with self.mock_request('shipping-method/get.xml'):
+            shipping_method = ShippingMethod.get('shipping2')
+
+        self.assertEqual(shipping_method.code, 'shipping2')
+        self.assertEqual(shipping_method.name, 'shipping 2')
+        self.assertEqual(shipping_method.accounting_code, 'ship')
+        self.assertEqual(shipping_method.tax_code, 'FR')
+        self.assertEqual(shipping_method.liability_gl_account_id, 't5ejtge1xw0x')
+        self.assertEqual(shipping_method.revenue_gl_account_id, 't5ejtgf1vxh1')
+        self.assertEqual(shipping_method.performance_obligation_id, '6')
+
+    def test_list_shipping_methods(self):
+        with self.mock_request('shipping-method/list.xml'):
+            shipping_methods = ShippingMethod.all()
+
+        self.assertEqual(len(shipping_methods), 2)
+        self.assertIsInstance(shipping_methods[0], ShippingMethod)
+        self.assertIsInstance(shipping_methods[1], ShippingMethod)
 
 if __name__ == '__main__':
     import unittest


### PR DESCRIPTION
This change adds RevRec support in Shipping Methods for the V2 client, the primary entity concerning the new (and upcoming) RevRec API features.