### PR TITLE
Generated Latest Changes for v2021-02-25 (add UUID to external subscriptions)

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -16743,8 +16743,9 @@ components:
     external_subscription_id_fetch:
       name: external_subscription_id
       in: path
-      description: External subscription ID or external_id. For ID no prefix is used
-        e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+      description: External subscription ID, external_id or uuid. For ID no prefix
+        is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g.
+        `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.
       required: true
       schema:
         type: string
@@ -25100,6 +25101,10 @@ components:
           title: External Id
           description: The id of the subscription in the external systems., I.e. Apple
             App Store or Google Play Store.
+        uuid:
+          type: string
+          title: Uuid
+          description: Universally Unique Identifier created automatically.
         last_purchased:
           type: string
           format: date-time

--- a/recurly/client.py
+++ b/recurly/client.py
@@ -2863,7 +2863,7 @@ class Client(BaseClient):
         ----------
 
         external_subscription_id : str
-            External subscription ID or external_id. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456`.
+            External subscription ID, external_id or uuid. For ID no prefix is used e.g. `e28zov4fw0v2`. For external_id use prefix `external-id-`, e.g. `external-id-123456` and for uuid use prefix `uuid-` e.g. `uuid-7293239bae62777d8c1ae044a9843633`.
 
         Keyword Arguments
         -----------------

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -1333,6 +1333,8 @@ class ExternalSubscription(Resource):
         When the external subscription trial period started in the external platform.
     updated_at : datetime
         When the external subscription was updated in Recurly.
+    uuid : str
+        Universally Unique Identifier created automatically.
     """
 
     schema = {
@@ -1357,6 +1359,7 @@ class ExternalSubscription(Resource):
         "trial_ends_at": datetime,
         "trial_started_at": datetime,
         "updated_at": datetime,
+        "uuid": str,
     }
 
 


### PR DESCRIPTION
We are giving the ability to fetch external subscriptions by uuid v3 v2021-02-25

Get `/external_subscriptions/uuid-<uuid_code>` replace <uuid_code> for specific uuid value