### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -21353,6 +21353,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing
@@ -21568,6 +21573,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing
@@ -21832,6 +21842,11 @@ components:
           title: Tax exempt?
           description: "`true` exempts tax on the plan, `false` applies tax on the
             plan."
+        vertex_transaction_type:
+          type: string
+          title: Vertex Transaction Type
+          description: Used by Vertex for tax calculations. Possible values are `sale`,
+            `rental`, `lease`.
         currencies:
           type: array
           title: Pricing

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -2984,6 +2984,8 @@ class Plan(Resource):
         Units for the plan's trial period.
     updated_at : datetime
         Last updated at
+    vertex_transaction_type : str
+        Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
     """
 
     schema = {
@@ -3018,6 +3020,7 @@ class Plan(Resource):
         "trial_requires_billing_info": bool,
         "trial_unit": str,
         "updated_at": datetime,
+        "vertex_transaction_type": str,
     }
 
 


### PR DESCRIPTION
This PR adds the ability to send a plan's `vertex_transaction_type` to vertex. 
 ```
vertex_transaction_type:
  type: string
  title: Vertex Transaction Type
  description: Used by Vertex for tax calculations. Possible values are `sale`, `rental`, `lease`.
```