### PR TITLE
fix: Updating CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Python ${{ matrix.python }} tests
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - name: Setup python

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setuptools.setup(
     url="https://github.com/recurly/recurly-client-python",
     packages=setuptools.find_packages(),
     classifiers=[],
-    tests_require=["coverage"],
+    extras_require={"test": ["coverage"]},
 )


### PR DESCRIPTION
Removing python 3.7 and adding 3.12 and 3.13 to the CI matrix