### PR TITLE
Removing python 3.7 from ci matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,8 @@ jobs:
     name: Python ${{ matrix.python }} tests
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: ['3.8', '3.9']
         os: [ubuntu-latest]
-        include:
-          # Python 3.6 is not included in ubuntu latest (currently 22)
-          - python: 3.6
-            os: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup python


### PR DESCRIPTION
Removing 3.7 from CI test matrix since GHA dropped support