### PR TITLE
Generated Latest Changes for v2021-02-25

### DIFF
--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -200,14 +200,12 @@ x-tagGroups:
   - usage
   - automated_exports
   - gift_cards
-- name: App Management
+- name: Invoices and Payments
   tags:
-  - external_subscriptions
-  - external_invoices
-  - external_products
-  - external_accounts
-  - external_product_references
-  - external_payment_phases
+  - invoice
+  - line_item
+  - credit_payment
+  - transaction
 - name: Products and Promotions
   tags:
   - item
@@ -218,12 +216,6 @@ x-tagGroups:
   - coupon_redemption
   - unique_coupon_code
   - price_segment
-- name: Invoices and Payments
-  tags:
-  - invoice
-  - line_item
-  - credit_payment
-  - transaction
 - name: Configuration
   tags:
   - site
@@ -233,6 +225,14 @@ x-tagGroups:
   - business_entities
   - general_ledger_account
   - performance_obligations
+- name: App Management
+  tags:
+  - external_subscriptions
+  - external_invoices
+  - external_products
+  - external_accounts
+  - external_product_references
+  - external_payment_phases
 tags:
 - name: site
   x-displayName: Site
@@ -9245,7 +9245,6 @@ paths:
       description: Apply credit payment to the outstanding balance on an existing
         charge invoice from an account’s available balance from existing credit invoices.
       parameters:
-      - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/invoice_id"
       responses:
         '200':
@@ -18621,7 +18620,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     AddressWithName:
       allOf:
       - "$ref": "#/components/schemas/Address"
@@ -19642,12 +19641,14 @@ components:
           title: Temporal amount
           description: If `duration` is "temporal" than `temporal_amount` is an integer
             which is multiplied by `temporal_unit` to define the duration that the
-            coupon will be applied to invoices for.
+            coupon will be applied to invoices for. When `temporal_unit` is "billing_period",
+            this is the number of complete billing cycles.
         temporal_unit:
           title: Temporal unit
           description: If `duration` is "temporal" than `temporal_unit` is multiplied
             by `temporal_amount` to define the duration that the coupon will be applied
-            to invoices for.
+            to invoices for. Use "billing_period" to apply the coupon for a fixed
+            number of billing cycles. Requires `redemption_resource=subscription`.
           "$ref": "#/components/schemas/TemporalUnitEnum"
         free_trial_unit:
           title: Free trial unit
@@ -19833,12 +19834,14 @@ components:
             title: Temporal amount
             description: If `duration` is "temporal" than `temporal_amount` is an
               integer which is multiplied by `temporal_unit` to define the duration
-              that the coupon will be applied to invoices for.
+              that the coupon will be applied to invoices for. When `temporal_unit`
+              is "billing_period", this is the number of complete billing cycles.
           temporal_unit:
             title: Temporal unit
             description: If `duration` is "temporal" than `temporal_unit` is multiplied
               by `temporal_amount` to define the duration that the coupon will be
-              applied to invoices for.
+              applied to invoices for. Use "billing_period" to apply the coupon for
+              a fixed number of billing cycles. Requires `redemption_resource=subscription`.
             "$ref": "#/components/schemas/TemporalUnitEnum"
           coupon_type:
             title: Coupon type
@@ -20195,6 +20198,19 @@ components:
           description: Any values that resemble a credit card number or security code
             (CVV/CVC) will be rejected.
           maxLength: 255
+        source_record_type:
+          type: string
+          title: Source record type
+          description: The type of record this custom field was automatically copied
+            from. Only present when the field was copied from another record.
+          readOnly: true
+          "$ref": "#/components/schemas/SourceRecordTypeEnum"
+        source_record_id:
+          type: string
+          title: Source record ID
+          description: The UUID of the record this custom field was automatically
+            copied from. Only present when the field was copied from another record.
+          readOnly: true
       required:
       - name
       - value
@@ -20204,6 +20220,15 @@ components:
       description: The custom fields will only be altered when they are included in
         a request. Sending an empty array will not remove any existing values. To
         remove a field send the name with a null or empty value.
+      items:
+        "$ref": "#/components/schemas/CustomField"
+    InvoiceCustomFields:
+      type: array
+      title: Custom fields
+      description: A list of custom fields that were on the account at the time of
+        invoice creation and were marked to be displayed on invoices. Read-only; cannot
+        be set directly on the invoice.
+      readOnly: true
       items:
         "$ref": "#/components/schemas/CustomField"
     CustomFieldDefinition:
@@ -21084,6 +21109,8 @@ components:
           title: Business Entity ID
           description: Unique ID to identify the business entity assigned to the invoice.
             Available when the `Multiple Business Entities` feature is enabled.
+        custom_fields:
+          "$ref": "#/components/schemas/InvoiceCustomFields"
     InvoiceCreate:
       type: object
       properties:
@@ -22735,7 +22762,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         created_at:
           type: string
           title: Created at
@@ -22823,7 +22850,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
         country:
           type: string
           maxLength: 50
@@ -23154,7 +23181,7 @@ components:
           type: string
           maxLength: 20
           description: Code that represents a geographic entity (location or object).
-            Only returned for Sling Vertex Integration
+            Only returned when Vertex or Avalara for Communications is enabled.
     Site:
       type: object
       properties:
@@ -27196,11 +27223,16 @@ components:
       - temporal
     TemporalUnitEnum:
       type: string
+      description: The temporal unit for the coupon's duration. Used with temporal_amount
+        to define how long the coupon applies. When temporal_unit is billing_period,
+        the coupon applies for temporal_amount complete billing cycles rather than
+        a fixed calendar duration. billing_period requires redemption_resource=subscription.
       enum:
       - day
       - month
       - week
       - year
+      - billing_period
     FreeTrialUnitEnum:
       type: string
       enum:
@@ -28104,3 +28136,11 @@ components:
       enum:
       - customer
       - merchant
+    SourceRecordTypeEnum:
+      type: string
+      description: The type of record a custom field was automatically copied from.
+      enum:
+      - account
+      - plan
+      - product
+      - subscription

--- a/recurly/resources.py
+++ b/recurly/resources.py
@@ -56,7 +56,7 @@ class Address(Resource):
     country : str
         Country, 2-letter ISO 3166-1 alpha-2 code.
     geo_code : str
-        Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+        Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
     phone : str
         Phone number
     postal_code : str
@@ -251,7 +251,7 @@ class ShippingAddress(Resource):
     email : str
     first_name : str
     geo_code : str
-        Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+        Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
     id : str
         Shipping Address ID
     last_name : str
@@ -508,12 +508,18 @@ class CustomField(Resource):
     ----------
     name : str
         Fields must be created in the UI before values can be assigned to them.
+    source_record_id : str
+        The UUID of the record this custom field was automatically copied from. Only present when the field was copied from another record.
+    source_record_type : str
+        The type of record this custom field was automatically copied from. Only present when the field was copied from another record.
     value : str
         Any values that resemble a credit card number or security code (CVV/CVC) will be rejected.
     """
 
     schema = {
         "name": str,
+        "source_record_id": str,
+        "source_record_type": str,
         "value": str,
     }
 
@@ -943,7 +949,7 @@ class AddressWithName(Resource):
     first_name : str
         First name
     geo_code : str
-        Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+        Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
     last_name : str
         Last name
     phone : str
@@ -1107,9 +1113,9 @@ class Coupon(Resource):
     state : str
         Indicates if the coupon is redeemable, and if it is not, why.
     temporal_amount : int
-        If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for.
+        If `duration` is "temporal" than `temporal_amount` is an integer which is multiplied by `temporal_unit` to define the duration that the coupon will be applied to invoices for. When `temporal_unit` is "billing_period", this is the number of complete billing cycles.
     temporal_unit : str
-        If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for.
+        If `duration` is "temporal" than `temporal_unit` is multiplied by `temporal_amount` to define the duration that the coupon will be applied to invoices for. Use "billing_period" to apply the coupon for a fixed number of billing cycles. Requires `redemption_resource=subscription`.
     unique_code_template : str
         On a bulk coupon, the template from which unique coupon codes are generated.
     unique_coupon_code : dict
@@ -1568,6 +1574,8 @@ class Invoice(Resource):
         Credit payments
     currency : str
         3-letter ISO 4217 currency code.
+    custom_fields : :obj:`list` of :obj:`CustomField`
+        A list of custom fields that were on the account at the time of invoice creation and were marked to be displayed on invoices. Read-only; cannot be set directly on the invoice.
     customer_notes : str
         This will default to the Customer Notes text specified on the Invoice Settings. Specify custom notes to add or override Customer Notes.
     discount : float
@@ -1667,6 +1675,7 @@ class Invoice(Resource):
         "created_at": datetime,
         "credit_payments": ["CreditPayment"],
         "currency": str,
+        "custom_fields": ["CustomField"],
         "customer_notes": str,
         "discount": float,
         "due_at": datetime,
@@ -1718,7 +1727,7 @@ class InvoiceAddress(Resource):
     first_name : str
         First name
     geo_code : str
-        Code that represents a geographic entity (location or object). Only returned for Sling Vertex Integration
+        Code that represents a geographic entity (location or object). Only returned when Vertex or Avalara for Communications is enabled.
     last_name : str
         Last name
     name_on_account : str


### PR DESCRIPTION
This PR includes the latest generated changes for the `v2021-02-25` API version.

**New fields**
- `CustomField` now exposes `source_record_id` and `source_record_type` (read-only) — populated when a custom field was automatically copied from another record.
- `Invoice` now exposes `custom_fields` (read-only) — the list of custom fields that were on the account at invoice creation time and were marked for display on invoices.

**New enum values**
- `TemporalUnit`: added `billing_period` — use with `temporal_amount` to apply a coupon for a fixed number of billing cycles (requires `redemption_resource=subscription`).
- `SourceRecordType` (new enum): `account`, `plan`, `product`, `subscription`.

**Documentation clarifications**
- `Coupon` / `CouponCreate`: clarified `temporal_amount` and `temporal_unit` descriptions to document `billing_period` behavior.
- `Address`, `AddressWithName`, `InvoiceAddress`, `ShippingAddress`: updated `geo_code` description — now reads "Only returned when Vertex or Avalara for Communications is enabled" (previously referenced Sling Vertex only).