### PR TITLE
ci: Remediate Node.js 20 deprecation in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 on: [push]
-concurrency: 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 jobs:
@@ -11,9 +13,9 @@ jobs:
       matrix:
         python: ['3.8', '3.9', '3.10', '3.11']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - run: ./scripts/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         python: ['3.8', '3.9', '3.10', '3.11']
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.3
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python }}
       - run: ./scripts/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: CI
 on: [push]
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,10 +10,13 @@ on:
       - master
       - qa
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: r7kamura/semgrepper@v0
         continue-on-error: true

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,9 +10,6 @@ on:
       - master
       - qa
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -17,6 +17,6 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.3
       - uses: r7kamura/semgrepper@v0
         continue-on-error: true


### PR DESCRIPTION
## Description

### Problem
GitHub Actions is deprecating Node.js 20. Actions using Node.js 20 (or older) will be forced to Node.js 24 starting June 2, 2026, and will be fully removed from runners on September 16, 2026. Two workflows in this repo referenced `actions/checkout@v3` and `actions/setup-python@v3`, both using Node.js 16.

### Fix
Upgraded all affected actions to their latest Node.js 24-native versions (runtime verified via `action.yml` before applying):

- `actions/checkout@v3` (node16) → `actions/checkout@v6.0.3` (node24)
- `actions/setup-python@v3` (node16) → `actions/setup-python@v6.2.0` (node24)

Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow level to validate Node.js 24 execution in CI. This flag will be removed before merge.

The `docker://agilepathway/pull-request-label-checker:latest` and `r7kamura/semgrepper@v0` (docker) actions are not affected by this deprecation.

### Files Changed
- `.github/workflows/ci.yml` — `checkout@v3` → `v6.0.3`, `setup-python@v3` → `v6.2.0`; added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`
- `.github/workflows/semgrep.yml` — `checkout@v3` → `v6.0.3`; added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`

## Testing
CI runs with `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` active — all Python matrix tests (3.8, 3.9, 3.10, 3.11), CodeQL, and Semgrep passed.